### PR TITLE
[ENGSYS-1124] Add basic output manifest

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -4,12 +4,10 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"encoding/json"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/hashicorp/go-hclog"
 )
@@ -104,28 +102,4 @@ func JSONToFile(JSON []byte, outFile string) error {
 	}
 
 	return err
-}
-
-// ManifestOutput manipulates manifest output data as needed.
-func ManifestOutput(manifest *Manifest, dir string) {
-	end := time.Now()
-	manifest.End = end
-
-	duration := end.Sub(manifest.Start)
-	manifest.Duration = fmt.Sprintf("%v seconds", duration.Seconds())
-
-	return
-}
-
-// Manifest struct is used to retain high level runtime information.
-type Manifest struct {
-	Start      time.Time
-	End        time.Time
-	Duration   string
-	NumErrors  int
-	NumSeekers int
-	OS         string
-	Dryrun     bool
-	Product    string
-	Outfile    string
 }


### PR DESCRIPTION
# [ENGSYS-1124] Add basic output manifest

## Purpose

I am submitting this PR to implement a basic manifest output file which serves as a quick high level runtime and output reference. Several aspects of this manifest output file will expand and change over time such as flags / CLI args.

Additionally, this PR moves output actions to separate function ([writeOutput](https://github.com/hashicorp/host-diagnostics/blob/randyhdev/manifest-file/main.go#L126)) and the temp dir will no longer be created if [dryrun is true](https://github.com/hashicorp/host-diagnostics/blob/randyhdev/manifest-file/main.go#L47).

## Example output

`manifest.json`
``` json
{
    "start": "2021-04-14T09:48:34.511979-04:00",
    "end": "2021-04-14T09:48:34.834436-04:00",
    "duration": "0.322458609 seconds",
    "NumSeekers": 7,
    "NumErrors": 5,
    "OS": "auto",
    "Dryrun": false,
    "Product": "vault",
    "Outfile": "support.tar.gz"
}
```

## Notes / concerns

I have a few specific concerns that I would appreciate your input on below:

* I am declaring dir and results at the [beginning](https://github.com/hashicorp/host-diagnostics/blob/randyhdev/manifest-file/main.go#L30) since they are referenced before they would otherwise be assigned (e.g. [defer writeOutput](https://github.com/hashicorp/host-diagnostics/blob/randyhdev/manifest-file/main.go#L58)). There may be a better way to handle order of operations and variable assignment here.

* Related to the above, I declare variable 'err' [here](https://github.com/hashicorp/host-diagnostics/blob/randyhdev/manifest-file/main.go#L49) in the call to ioutil.TempDir since the variable dir already exists and we want to replace its value. If we don't declare dir before this and the user is doing a dryrun, we end up with errors where it is currently required.

* I am creating a manifest output key for each flag individually in main. I originally wanted to pass a set of flags to the write output or manifest functions but did not find an easy way to do it. This will change down the road anyway and probably not a big deal currently but still wanted to mention.

* I am currently [counting errors](https://github.com/hashicorp/host-diagnostics/blob/randyhdev/manifest-file/main.go#L97) and [updating the manifest output map](https://github.com/hashicorp/host-diagnostics/blob/randyhdev/manifest-file/main.go#L122) in 'RunSeekers'. This doesn't feel great, but attempting to summarize the map[string]interface{} data thereafter seemed to require quite a bit of overhead and proved to be a bit of a challenge for me.


[ENGSYS-1124]: https://hashicorp.atlassian.net/browse/ENGSYS-1124