### PR TITLE
[ENGSYS-1168] Add basic release functionality

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Unshallow
-        run: git fetch --prune --unshallow
+        with:
+          fetch-depth: 0
         
       - name: Set up Go
         uses: actions/setup-go@v2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,6 @@ builds:
   goos:
     - windows
     - linux
-    - darwin
   goarch:
     - amd64
     - arm
@@ -35,6 +34,3 @@ checksum:
 
 release:
   draft: true
-
-changelog:
-  skip: true


### PR DESCRIPTION
# [ENGSYS-1168] Add basic release functionality

## Purpose

Add basic release functionality to repo using goreleaser

## Notes

- Add `release.yml` GitHub workflow to enable goreleaser
    - Trigger on push where tag matches 'v[0-9]+.[0-9]+.[0-9]+*'

- Add `.goreleaser.yml` for configuration
    - Builds windows / linux / darwin
    - Does not currently sign or publish elsewhere
    - Creates as draft

## Considerations / next steps

- Discover and adopt common HashiCorp versioning, tagging, signing, release / publishing processes
- Determine if existing hook is appropriate, what other config is needed
- Expand os/arch to all required platforms


[ENGSYS-1168]: https://hashicorp.atlassian.net/browse/ENGSYS-1168