### PR TITLE
[ENGSYS-1161] Add basic multi product support

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,9 +33,10 @@ func main() {
 
 	// Parse arguments
 	osPtr := flag.String("os", "auto", "(optional) Override operating system detection")
-	consulPtr := flag.Bool("consul", false, "(optional) Run consul diagnostic commands")
-	nomadPtr := flag.Bool("nomad", false, "(optional) Run nomad diagnostic commands")
-	vaultPtr := flag.Bool("vault", false, "(optional) Run vault diagnostic commands")
+	consulPtr := flag.Bool("consul", false, "(optional) Run consul diagnostics")
+	nomadPtr := flag.Bool("nomad", false, "(optional) Run nomad diagnostics")
+	vaultPtr := flag.Bool("vault", false, "(optional) Run vault diagnostics")
+	allProductsPtr := flag.Bool("all", false, "(optional) Run all available product diagnostics")
 	dryrunPtr := flag.Bool("dryrun", false, "(optional) Performing a dry run will display all commands without executing them")
 	outfilePtr := flag.String("outfile", "support.tar.gz", "(optional) Output file name")
 	// TODO: support more than one dir or file
@@ -47,6 +48,7 @@ func main() {
 	manifest.Consul = *consulPtr
 	manifest.Nomad = *nomadPtr
 	manifest.Vault = *vaultPtr
+	manifest.AllProducts = *allProductsPtr
 	manifest.Dryrun = *dryrunPtr
 	manifest.IncludeDir = *includeDir
 	manifest.IncludeFile = *includeFile
@@ -73,7 +75,7 @@ func main() {
 
 	appLogger.Info("Gathering diagnostics")
 	// Set up Seekers
-	seekers, err := products.GetSeekers(*consulPtr, *nomadPtr, *vaultPtr, dir)
+	seekers, err := products.GetSeekers(*consulPtr, *nomadPtr, *vaultPtr, *allProductsPtr, dir)
 	if err != nil {
 		appLogger.Error("products.GetSeekers", "error", err)
 		os.Exit(1)
@@ -110,6 +112,7 @@ type Manifest struct {
 	Consul      bool
 	Nomad       bool
 	Vault       bool
+	AllProducts bool
 	IncludeDir  string
 	IncludeFile string
 	Outfile     string

--- a/products/products.go
+++ b/products/products.go
@@ -10,14 +10,14 @@ const (
 )
 
 // GetSeekers provides product Seekers for gathering info.
-func GetSeekers(consul bool, nomad bool, vault bool, tmpDir string) (seekers []*s.Seeker, err error) {
-	if consul {
+func GetSeekers(consul bool, nomad bool, vault bool, all bool, tmpDir string) (seekers []*s.Seeker, err error) {
+	if consul || all {
 		seekers = append(seekers, ConsulSeekers(tmpDir)...)
 	}
-	if nomad {
+	if nomad || all {
 		seekers = append(seekers, NomadSeekers(tmpDir)...)
 	}
-	if vault {
+	if vault || all {
 		seekers = append(seekers, VaultSeekers(tmpDir)...)
 	}
 	return seekers, err


### PR DESCRIPTION
# [ENGSYS-1161] Add basic multi product support

## Purpose

- Add boolean flags for consul, nomad, and vault to replace individual product string flag to enable execution for multiple products in a single run
- example usage: `go run . -consul -nomad`

## Notes

- We are likely to adopt a different approach in the future as we explore CLI requirements


[ENGSYS-1161]: https://hashicorp.atlassian.net/browse/ENGSYS-1161