### PR TITLE
add ISO 8601 timestamp to tarball name

### DIFF
--- a/diagnosticator_test.go
+++ b/diagnosticator_test.go
@@ -187,7 +187,7 @@ func TestWriteOutput(t *testing.T) {
 	}
 
 	testOut := "test.tar.gz"
-	d.Outfile = testOut // ordinarily would come from ParseFlags() but see bottom of this file...
+	d.outfile = testOut // ordinarily would come from ParseFlags() but see bottom of this file...
 	d.CreateTemp()
 	defer d.Cleanup()
 	defer os.Remove(testOut)
@@ -199,6 +199,8 @@ func TestWriteOutput(t *testing.T) {
 	expectFiles := []string{
 		filepath.Join(d.tmpDir, "Manifest.json"),
 		filepath.Join(d.tmpDir, "Results.json"),
+		// PLSFIX(mkcp): We need to properly test the filename to merge this. Maybe we can match it off
+		//  disk based on the prefix and if we have a file there, consider it ok and written?
 		testOut,
 	}
 	for _, f := range expectFiles {


### PR DESCRIPTION
Now, instead of storing `Outfile` as a public field, we make it private and use it via the `DestinationFileName()` method. This fn appends the current time to the output. Needs to be tested before it can be merged - this implementation breaks the existing test. 

I added a note about changing the assertion in the current test to get this mergeable.