### PR TITLE
fix race in isInRange and refactor

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -130,7 +130,7 @@ func SplitFilepath(path string) (dir string, file string) {
 	return dir, file
 }
 
-func IsInRange(fileTime, from, to time.Time) bool {
+func IsInRange(target, from, to time.Time) bool {
 	// Default true if no range provided
 	if from.IsZero() {
 		return true
@@ -139,11 +139,11 @@ func IsInRange(fileTime, from, to time.Time) bool {
 	// Check if the end of our range is zero
 	if to.IsZero() {
 		// Anything after the start time is valid
-		return fileTime.After(from)
+		return target.After(from)
 	}
 
 	// Check if the fileTime is within range
-	return fileTime.After(from) && fileTime.Before(to)
+	return target.After(from) && target.Before(to)
 }
 
 // FilterWalk accepts a source directory, filter string, and from and to Times to return a list of matching files.

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -124,13 +124,13 @@ func TestIsInRange(t *testing.T) {
 			expect: true,
 		},
 		{
-			desc:   "Zeroed `to` includes recent files",
+			desc:   "Zeroed `to` includes recent and/or actively-written-to target",
 			target: time.Now(),
 			from:   time.Date(1977, 0, 0, 0, 0, 0, 0, &time.Location{}),
 			expect: true,
 		},
 		{
-			desc:   "Zeroed `to` does not include files before `from`",
+			desc:   "Zeroed `to` does not include target before `from`",
 			target: time.Date(1800, 0, 0, 0, 0, 0, 0, &time.Location{}),
 			from:   time.Date(1977, 0, 0, 0, 0, 0, 0, &time.Location{}),
 			expect: false,


### PR DESCRIPTION
I'm pretty happy with how this fix and refactor turned out. The logic in the function felt a bit weird - if's lead into bool returns... it was messy. Usually that means you can rephrase the algebra to return the conditionals themselves... which we did!

We also go rid of a silly decision I made earlier to sub a "zero'd" `to` (the end time of the range) to time.Now(). This introduced the possibility of a race when .Now() becomes stale compared to the statted file's modtime. The fix is that the "zeroed to" path has a specific logic branch associated with it, where `to` is ignored! Everything _after_ from is valid, which is more precisely what we want and simpler than subbing values and taking on weird snapshotting behaviors.

Cool! OK, yeah, so lots of little details in a small PR.  I **love** when a PR is twice as much red as green 😁