### PR TITLE
stat includes before we create the copy seeker for it

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -172,6 +172,13 @@ func (a *Agent) CopyIncludes() (err error) {
 			a.l.Info("Would include", "from", f)
 			continue
 		}
+
+		a.l.Debug("validating include exists", "path", f)
+		_, err := os.Stat(f)
+		if err != nil {
+			return err
+		}
+
 		a.l.Debug("getting Copier", "path", f)
 		s := seeker.NewCopier(f, dest, a.Config.IncludeFrom, a.Config.IncludeTo)
 		if _, err = s.Run(); err != nil {


### PR DESCRIPTION
Users can specify two kinds of paths: files and directories. The changes here are intended to check that provided each file or dir name exists before we make a copy seeker for it.

I still need to write some tests for edge cases to ensure we _actually_ solve it. Some of the classes of error we can run into here were already caught by the copier later in the process. Now we check on the outside and fail a bit earlier, so we don't always catch new stuff but the behavior is a bit better.

One painpoint atm is that trailing slashes cause the system to choke... e.g. `tests/` halts as not-existing even if `./tests` exists. This doesn't quite feel correct to me - trailing slashes shouldn't matter, right? There's an ordering problem to solve here, because we can't do an fs check to see what the file is... because that requires statting it which we're trying to do already. Maybe we just trim trailing slashes as a part of processing the includes input? 