### PR TITLE
No more ["host"]["host"]

### DIFF
--- a/products/host.go
+++ b/products/host.go
@@ -31,7 +31,7 @@ func NewHostSeeker(os string) *s.Seeker {
 		os = runtime.GOOS
 	}
 	return &s.Seeker{
-		Identifier: "host",
+		Identifier: "stats",
 		Runner: &HostSeeker{
 			OS: os,
 		},


### PR DESCRIPTION
changes `results["host"]["host"]` to `results["host"]["stats"]`

This kinda feels like cheating... but it works!