### PR TITLE
update tests to fix non-duration seekers

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -274,9 +274,6 @@ func TestParseHCL(t *testing.T) {
 					Commands: []CommandConfig{
 						{Run: "ps aux", Format: "string"},
 					},
-					Copies: []CopyConfig{
-						{Path: "/var/log/syslog", Since: ""},
-					},
 				},
 				Products: []*ProductConfig{
 					{
@@ -289,8 +286,7 @@ func TestParseHCL(t *testing.T) {
 							{Path: "/v1/api/metrics?format=prometheus"},
 						},
 						Copies: []CopyConfig{
-							{Path: "/some/test/log"},
-							{Path: "/another/test/log", Since: "10d"},
+							{Path: "/another/test/log", Since: "240h"},
 						},
 						Excludes: []string{"consul some-awfully-long-command"},
 						Selects: []string{

--- a/tests/resources/config/config.hcl
+++ b/tests/resources/config/config.hcl
@@ -3,9 +3,6 @@ host {
     run = "ps aux"
     format = "string"
   }
-  copy {
-    path = "/var/log/syslog"
-  }
 }
 
 product "consul" {
@@ -24,12 +21,8 @@ product "consul" {
   }
 
   copy {
-    path = "/some/test/log"
-  }
-
-  copy {
     path = "/another/test/log"
-    since = "10d"
+    since = "240h"
   }
 
   excludes = ["consul some-awfully-long-command"]


### PR DESCRIPTION
Paired with Tehut this morning, scoped out a few tiny PRs to address docs and testing bugs.

This PR (via Tehut): fixes unsupported go notation of “d” (days) instead of “h” (hours) in a test