### PR TITLE
allow custom copy seeker copiers' to be defined without a `since=`

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -466,7 +466,7 @@ func ParseHCL(path string) (Config, error) {
 	return config, nil
 }
 
-// TODO(mkcp): This is duplicative of customSeekers. This can certainly be improved.
+// TODO(mkcp): This duplicates much of customSeekers and can certainly be improved.
 func customHostSeekers(cfg *HostConfig, tmpDir string) ([]*seeker.Seeker, error) {
 	seekers := make([]*seeker.Seeker, 0)
 	// Build Commanders
@@ -486,12 +486,18 @@ func customHostSeekers(cfg *HostConfig, tmpDir string) ([]*seeker.Seeker, error)
 	// Build copiers
 	dest := tmpDir + "/host"
 	for _, c := range cfg.Copies {
-		since, err := time.ParseDuration(c.Since)
-		if err != nil {
-			return nil, err
+		var from time.Time
+
+		// Set `from` with a timestamp
+		if c.Since != "" {
+			since, err := time.ParseDuration(c.Since)
+			if err != nil {
+				return nil, err
+			}
+			// Get the timestamp which marks the start of our duration
+			from = time.Now().Add(-since)
 		}
-		// Get the timestamp which marks the start of our duration
-		from := time.Now().Add(-since)
+
 		copier := seeker.NewCopier(c.Path, dest, from, time.Time{})
 		seekers = append(seekers, copier)
 	}
@@ -499,6 +505,7 @@ func customHostSeekers(cfg *HostConfig, tmpDir string) ([]*seeker.Seeker, error)
 	return seekers, nil
 }
 
+// TODO(mkcp): Products, not the agent, should handle their own custom seekers when they're created.
 func customSeekers(cfg *ProductConfig, tmpDir string) ([]*seeker.Seeker, error) {
 	seekers := make([]*seeker.Seeker, 0)
 	// Build Commanders
@@ -531,12 +538,17 @@ func customSeekers(cfg *ProductConfig, tmpDir string) ([]*seeker.Seeker, error) 
 	// Build copiers
 	dest := tmpDir + "/" + cfg.Name
 	for _, c := range cfg.Copies {
-		since, err := time.ParseDuration(c.Since)
-		if err != nil {
-			return nil, err
+		var from time.Time
+
+		// Set `from` with a timestamp
+		if c.Since != "" {
+			since, err := time.ParseDuration(c.Since)
+			if err != nil {
+				return nil, err
+			}
+			// Get the timestamp which marks the start of our duration
+			from = time.Now().Add(-since)
 		}
-		// Get the timestamp which marks the start of our duration
-		from := time.Now().Add(-since)
 		copier := seeker.NewCopier(c.Path, dest, from, time.Time{})
 		seekers = append(seekers, copier)
 	}


### PR DESCRIPTION
Fixes [CORI-153](https://hashicorp.atlassian.net/browse/CORI-153)

Previously, a custom `copier` seeker needed a `since=` value or the run would error out. This was not intended behavior.

When running this this config in `repro-no-since.hcl`
```
host {
  copy {
    path = "/Users/kitpatella/go/src/github.com/hashicorp/hcdiag/tests/resources/file.0"
  }
}

product "consul" {
  copy {
    path = "/Users/kitpatella/go/src/github.com/hashicorp/hcdiag/tests/resources/file.0"
  }
}
```

We get this error on main:
<img width="965" alt="Screen Shot 2021-12-17 at 11 54 05 AM" src="https://user-images.githubusercontent.com/938395/146600584-159ebbb0-5deb-464a-9285-d7de05e419d5.png">

This PR's changes add a guard to check if the `since` duration is empty -- if so, do not attempt to get a timestamp. This defaults to the zero value for time, which efficiently matches every file _since_ forever ago. Neat!
<img width="1440" alt="Screen Shot 2021-12-17 at 11 52 30 AM" src="https://user-images.githubusercontent.com/938395/146600856-f4ea543f-8b31-49f3-9b2b-ad4d54676b28.png">

This bugfix is shipped without tests because the test isolation in `agent.Setup()`, `agent.customSeekers()`, and `agent.customHostSeekers()` needs improvement and is not time efficient to unit test. Better abstractions around product setup and customSeeker() creation would make testing this behavior viable.