### PR TITLE
add host and product config to manifest json

### DIFF
--- a/agent/config.go
+++ b/agent/config.go
@@ -3,8 +3,8 @@ package agent
 import "time"
 
 type Config struct {
-	Host     *HostConfig      `hcl:"host,block" json:"-"`
-	Products []*ProductConfig `hcl:"product,block" json:"-"`
+	Host     *HostConfig      `hcl:"host,block" json:"host_config"`
+	Products []*ProductConfig `hcl:"product,block" json:"products_config"`
 
 	OS          string    `json:"operating_system"`
 	Serial      bool      `json:"serial"`


### PR DESCRIPTION
Provides us more usage feedback in Manifest.json by adding hcl configuration.