### PR TITLE
Capture Commander-run output on error

### DIFF
--- a/seeker/commander.go
+++ b/seeker/commander.go
@@ -30,7 +30,7 @@ func (c Commander) Run() (result interface{}, err error) {
 	bts, err := exec.Command(cmd, args...).CombinedOutput()
 
 	if err != nil {
-		return nil, fmt.Errorf("exec.Command error: %s", err)
+		err = fmt.Errorf("exec.Command error: %s", err)
 	}
 
 	switch {
@@ -38,12 +38,12 @@ func (c Commander) Run() (result interface{}, err error) {
 		result = strings.TrimSuffix(string(bts), "\n")
 
 	case c.format == "json":
-		if err := json.Unmarshal(bts, &result); err != nil {
-			return nil, fmt.Errorf("json.Unmarshal error: %s", err)
+		if e := json.Unmarshal(bts, &result); e != nil {
+			err = fmt.Errorf("json.Unmarshal error: %s", e)
 		}
 
 	default:
-		return nil, errors.New("command output format must be either 'string' or 'json'")
+		err = errors.New("command output format must be either 'string' or 'json'")
 	}
 
 	return result, err

--- a/seeker/commander_test.go
+++ b/seeker/commander_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewCommander(t *testing.T) {
@@ -51,15 +53,15 @@ func TestCommanderRunJSON(t *testing.T) {
 }
 
 func TestCommanderRunError(t *testing.T) {
-	c := NewCommander("bogus-command", "string")
+	c := NewCommander("cat no-file-to-see-here", "string")
 	out, err := c.Run()
 
-	if out != nil {
-		t.Errorf("expected out to be nil, got '%s'", out)
-	}
+	// we should get the command's error output
+	assert.Contains(t, out, "No such file")
 
-	if !strings.Contains(fmt.Sprintf("%s", err), "exec.Command error") {
-		t.Errorf("got unexpected error instead of exec.Command: %s", err)
+	// and the error from os/exec.Command()
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "exec.Command error:")
 	}
 }
 


### PR DESCRIPTION
Unlike our new `Sheller`, currently `Commander` discards the command output when there is an error, resulting in vague and confusing results like:

```
[WARN]  hcdiag: result: seeker="cat nonexistent-file" result=%!s(<nil>) error="exec.Command error: exit status 1"
```

and similar in `Results.json`:

```json
"cat nonexistent-file": {
    "runner": {
        "command": "cat nonexistent-file"
    },
    "result": null,
    "error": "exec.Command error: exit status 1"
},
```

This change captures the error output, which may be useful for users and potentially also ourselves when receiving bug reports.

**After:**

```
[WARN]  hcdiag: result: seeker="cat nonexistent-file" result="cat: nonexistent-file: No such file or directory" error="exec.Command error: exit status 1"
```

and `Results.json`:

```json
"cat nonexistent-file": {
    "runner": {
        "command": "cat nonexistent-file"
    },
    "result": "cat: nonexistent-file: No such file or directory",
    "error": "exec.Command error: exit status 1"
},
```