### PR TITLE
Colorize screen output by log level if available

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,7 +56,8 @@ func realMain() (returnCode int) {
 func configureLogging(loggerName string) hclog.Logger {
 	// Create logger, set default and log level
 	appLogger := hclog.New(&hclog.LoggerOptions{
-		Name: loggerName,
+		Name:  loggerName,
+		Color: hclog.AutoColor,
 	})
 	hclog.SetDefault(appLogger)
 	if logStr := os.Getenv("LOG_LEVEL"); logStr != "" {


### PR DESCRIPTION
Nice quick lil pleasantry, really helps WARNs and ERRORs pop.

```go
	// AutoColor checks if the io.Writer is a tty,
	// and if so enables coloring.
	AutoColor
```

https://github.com/hashicorp/go-hclog/blob/e77830785dbe9f30d4d968c68bcb8fe934b9af6e/logger.go#L84-L86