### PR TITLE
add goclangci lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -4,7 +4,6 @@ on:
     tags:
       - v*
     branches:
-      - master
       - main
   pull_request:
 permissions:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,36 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+      - main
+  pull_request:
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: latest
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true
+
+          # Optional: if set to true then the action will use pre-installed Go.
+          # skip-go-installation: true
+
+          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
+          # skip-pkg-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
+          # skip-build-cache: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Lint and Test
+name: test
 
 on:
   push:

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -54,7 +54,7 @@ func TestCreateTempDryrun(t *testing.T) {
 
 func TestCreateTemp(t *testing.T) {
 	a := NewAgent(Config{}, hclog.Default())
-	defer a.Cleanup()
+	defer cleanupHelper(t, a)
 
 	if err := a.CreateTemp(); err != nil {
 		t.Errorf("Failed creating temp dir: %s", err)
@@ -121,7 +121,7 @@ func TestCopyIncludes(t *testing.T) {
 	a := NewAgent(cfg, hclog.Default())
 	err := a.CreateTemp()
 	assert.NoError(t, err, "Error creating tmpDir")
-	defer a.Cleanup()
+	defer cleanupHelper(t, a)
 
 	// execute what we're aiming to test
 	err = a.CopyIncludes()
@@ -337,5 +337,12 @@ func TestParseHCL(t *testing.T) {
 		res, err := ParseHCL(c.path)
 		assert.NoError(t, err)
 		assert.Equal(t, c.expect, res, c.desc)
+	}
+}
+
+func cleanupHelper (t *testing.T, a *Agent) {
+	err := a.Cleanup()
+	if err != nil {
+		t.Errorf("Failed to clean up")
 	}
 }

--- a/product/host.go
+++ b/product/host.go
@@ -77,8 +77,7 @@ func GetProcesses() (interface{}, error) {
 	processInfo := make([]string, 0)
 
 	for eachProcess := range processes {
-		var process ps.Process
-		process = processes[eachProcess]
+		process := processes[eachProcess]
 		processInfo = append(processInfo, process.Executable())
 	}
 

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -77,7 +77,10 @@ func TestSplitFilepath(t *testing.T) {
 func TestFindInInterface(t *testing.T) {
 	bts := []byte(`{"one": {"two": {"three": "cool_value"}}}`)
 	var iface interface{}
-	json.Unmarshal(bts, &iface)
+	err := json.Unmarshal(bts, &iface)
+	if err != nil {
+		t.Error("failed to unmarshal", "error", err.Error())
+	}
 
 	i, err := FindInInterface(iface, "one", "two", "three")
 	if err != nil {


### PR DESCRIPTION
I wonder if this will run any actions that are added in its own PR 🤔 


edit:

This adds the golangci-lint action, which has various opinions, config, and defaults that we can use. It gives us line by line integration for diffs, which is nicer than us spinning it ourselves! The first commit fixes every issue raised by running `golangci-lint run` locally, then the remaining PRs modify the actions to make this fit.