### PR TITLE
Add journald seeker for consul, nomad, vault

### DIFF
--- a/product/consul.go
+++ b/product/consul.go
@@ -44,6 +44,10 @@ func ConsulSeekers(tmpDir string, from, to time.Time) []*s.Seeker {
 		logCopier := s.NewCopier(logPath, dest, from, to)
 		seekers = append([]*s.Seeker{logCopier}, seekers...)
 	}
+	// get logs from journald if available
+	if journald := s.JournaldGetter("consul", tmpDir); journald != nil {
+		seekers = append(seekers, journald)
+	}
 
 	return seekers
 }

--- a/product/nomad.go
+++ b/product/nomad.go
@@ -45,6 +45,10 @@ func NomadSeekers(tmpDir string, from, to time.Time) []*s.Seeker {
 		logCopier := s.NewCopier(logPath, dest, from, to)
 		seekers = append([]*s.Seeker{logCopier}, seekers...)
 	}
+	// get logs from journald if available
+	if journald := s.JournaldGetter("nomad", tmpDir); journald != nil {
+		seekers = append(seekers, journald)
+	}
 
 	return seekers
 }

--- a/product/vault.go
+++ b/product/vault.go
@@ -47,6 +47,10 @@ func VaultSeekers(tmpDir string, from, to time.Time) ([]*s.Seeker, error) {
 		logCopier := s.NewCopier(logPath, dest, from, to)
 		seekers = append([]*s.Seeker{logCopier}, seekers...)
 	}
+	// get logs from journald if available
+	if journald := s.JournaldGetter("vault", tmpDir); journald != nil {
+		seekers = append(seekers, journald)
+	}
 
 	return seekers, nil
 }

--- a/seeker/journald.go
+++ b/seeker/journald.go
@@ -1,0 +1,36 @@
+package seeker
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+// JournaldGetter attempts to pull logs from journald via shell command, e.g.:
+// journalctl -x -u {name} --since '3 days ago' --no-pager > {destDir}/journald-{name}.log
+func JournaldGetter(name, destDir string) *Seeker {
+	// if systemd does not exist or have a unit with the provided name, return a nil pointer
+	cmd := fmt.Sprintf("systemctl is-enabled %s", name) // TODO(gulducat): another command?
+	out, err := NewCommander(cmd, "string").Run()
+	if err != nil {
+		hclog.L().Debug("skipping journald", "name", name, "output", out, "error", err)
+		return nil
+	}
+
+	// check if user is able to read messages
+	cmd = fmt.Sprintf("journalctl -n0 -u %s 2>&1 | grep -A10 'not seeing messages from other users'", name)
+	out, err = NewSheller(cmd).Run()
+	if err == nil { // no error, our sad magic string was found
+		hclog.L().Error("journalctl -u "+name,
+			"message", "unable to read logs, is your user allowed?  try sudo?",
+			"output", out,
+		)
+		return nil
+	}
+
+	// TODO(gulducat): custom --since
+	cmd = fmt.Sprintf("journalctl -x -u %s --since '3 days ago' --no-pager > %s/journald-%s.log", name, destDir, name)
+	seeker := NewSheller(cmd)
+	seeker.Identifier = "journald"
+	return seeker
+}


### PR DESCRIPTION
A common setup is to use systemd units to run our software as linux services (indeed our own apt packages include such systemd config).  As a result, a common location for log output is journald (via program stdout/stderr).

This attempts to include logs from journald automatically, by "simply" delegating commands to the user's shell.

For example with `hcdiag -vault`:
* detect the presence of a systemd unit named {program} via `systemctl is-enabled vault`
* check whether the user is able to read from journald with a `journalctl` pre-check
  * because journalctl will happily exit `0` "success" even if the user is not actually able to read the logs
* return a Sheller seeker to run ~ `journalctl -u vault > {bundleDir}/journald-vault.log` with the other Vault seekers.

Two hard-coded limitations at present:
* The unit name can not be customized, only "consul", "nomad", or "vault" are supported.
* The timeframe of logs is also static, from "3 days ago"

I started writing tests, but since this implementation just delegates to `systemctl` and `journalctl` commands, they would need mock'd away in some manner, and I haven't quite settled on the approach there.  Happy to chat through it if including tests here is a blocker.