### PR TITLE
Add since flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ The following subsections cover product specific prerequisite items such as envi
 | `all` | DEPRECATED: Run all available product diagnostics | bool | false |
 | `since` | Collect information within this time. Takes a 'go-formatted' duration, usage examples: `72h`, `25m`, `45s`, `120h1m90s` | string | "72h" |
 | `includes` | files or directories to include (comma-separated, file-*-globbing available if 'wrapped-*-in-single-quotes') e.g. '/var/log/consul-*,/var/log/nomad-*' | string | "" |
-| `include-since` | Time range to include files, counting back from now. Takes a 'go-formatted' duration, usage examples: `72h`, `25m`, `45s`, `120h1m90s` | string | "72h" |
 | `destination` | Path to the directory the bundle should be written in | string | "." |
 | `dest` | Shorthand for -destination | string | "." |
 | `config` | Path to HCL configuration file | string | "" |

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The following subsections cover product specific prerequisite items such as envi
 | `terraform-ent` | Run Terraform Enterprise/Cloud diagnostics | bool | false |
 | `vault` | Run Vault diagnostics | bool | false |
 | `all` | DEPRECATED: Run all available product diagnostics | bool | false |
+| `since` | Collect information within this time. Takes a 'go-formatted' duration, usage examples: `72h`, `25m`, `45s`, `120h1m90s` | string | "72h" |
 | `includes` | files or directories to include (comma-separated, file-*-globbing available if 'wrapped-*-in-single-quotes') e.g. '/var/log/consul-*,/var/log/nomad-*' | string | "" |
 | `include-since` | Time range to include files, counting back from now. Takes a 'go-formatted' duration, usage examples: `72h`, `25m`, `45s`, `120h1m90s` | string | "72h" |
 | `destination` | Path to the directory the bundle should be written in | string | "." |

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The following subsections cover product specific prerequisite items such as envi
 | `vault` | Run Vault diagnostics | bool | false |
 | `all` | DEPRECATED: Run all available product diagnostics | bool | false |
 | `since` | Collect information within this time. Takes a 'go-formatted' duration, usage examples: `72h`, `25m`, `45s`, `120h1m90s` | string | "72h" |
+| `include-since` | Alias for -since, will be overridden if -since is also provided, usage examples: `72h`, `25m`, `45s`, `120h1m90s` | string | "72h" |
 | `includes` | files or directories to include (comma-separated, file-*-globbing available if 'wrapped-*-in-single-quotes') e.g. '/var/log/consul-*,/var/log/nomad-*' | string | "" |
 | `destination` | Path to the directory the bundle should be written in | string | "." |
 | `dest` | Shorthand for -destination | string | "." |

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -199,7 +199,7 @@ func (a *Agent) CopyIncludes() (err error) {
 		}
 
 		a.l.Debug("getting Copier", "path", f)
-		s := seeker.NewCopier(f, dest, a.Config.IncludeFrom, a.Config.IncludeTo)
+		s := seeker.NewCopier(f, dest, a.Config.Since, a.Config.Until)
 		if _, err = s.Run(); err != nil {
 			return err
 		}
@@ -383,8 +383,8 @@ func (a *Agent) Setup() (map[string]*product.Product, error) {
 	cfg := product.Config{
 		Logger: &a.l,
 		TmpDir: a.tmpDir,
-		From:   a.Config.IncludeFrom,
-		To:     a.Config.IncludeTo,
+		Since:  a.Config.Since,
+		Until:  a.Config.Until,
 		OS:     a.Config.OS,
 	}
 	p := make(map[string]*product.Product)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -340,7 +340,7 @@ func TestParseHCL(t *testing.T) {
 	}
 }
 
-func cleanupHelper (t *testing.T, a *Agent) {
+func cleanupHelper(t *testing.T, a *Agent) {
 	err := a.Cleanup()
 	if err != nil {
 		t.Errorf("Failed to clean up")

--- a/agent/config.go
+++ b/agent/config.go
@@ -13,9 +13,9 @@ type Config struct {
 	Nomad       bool      `json:"nomad_enabled"`
 	TFE         bool      `json:"terraform_ent_enabled"`
 	Vault       bool      `json:"vault_enabled"`
+	Since       time.Time `json:"since"`
+	Until       time.Time `json:"until"`
 	Includes    []string  `json:"includes"`
-	IncludeFrom time.Time `json:"include_from"`
-	IncludeTo   time.Time `json:"include_to"`
 	Destination string    `json:"destination"`
 }
 

--- a/agent/config.go
+++ b/agent/config.go
@@ -2,7 +2,9 @@ package agent
 
 import "time"
 
+// Config stores all user-provided inputs from the CLI and HCL
 type Config struct {
+	// HostConfig and ProductConfig are specified by HCL
 	Host     *HostConfig      `hcl:"host,block" json:"host_config"`
 	Products []*ProductConfig `hcl:"product,block" json:"products_config"`
 
@@ -52,7 +54,6 @@ type GETConfig struct {
 }
 
 type CopyConfig struct {
-	Path string `hcl:"path"`
-	// FIXME(mkcp): This should be a duration that we parse
+	Path  string `hcl:"path"`
 	Since string `hcl:"since,optional"`
 }

--- a/main.go
+++ b/main.go
@@ -15,6 +15,9 @@ import (
 
 const SemVer string = "0.1.3"
 
+// SeventyTwoHours represents the duration "72h" parsed in nanoseconds
+const SeventyTwoHours time.Duration = 259199999999999
+
 func main() {
 	os.Exit(realMain())
 }
@@ -39,7 +42,9 @@ func realMain() (returnCode int) {
 		return
 	}
 
+	// Build agent configuration from flags, HCL, and system time
 	var config agent.Config
+	// Set host and product config
 	if flags.Config != "" {
 		config, err = agent.ParseHCL(flags.Config)
 		if err != nil {
@@ -47,8 +52,16 @@ func realMain() (returnCode int) {
 		}
 		l.Debug("Config is", "config", config)
 	}
-
+	// Assign flag vals to our agent.Config
 	cfg := mergeAgentConfig(config, flags)
+	// Capture a now value and set timestamps based on the same Now value
+	now := time.Now()
+	// Get the difference between now and the provided --since Duration
+	cfg.Since = now.Add(-flags.Since)
+	// NOTE(mkcp): In the future, cfg.Until may be set by a flag.
+	cfg.Until = now
+
+	// Create agent
 	a := agent.NewAgent(cfg, l)
 
 	// Run the agent
@@ -79,20 +92,33 @@ func configureLogging(loggerName string) hclog.Logger {
 }
 
 // Flags stores our CLI inputs.
+// TODO(mkcp): Add doccomments for flag fields (and organize them)
 type Flags struct {
-	OS           string
-	Serial       bool
-	Dryrun       bool
-	Consul       bool
-	Nomad        bool
-	TFE          bool
-	Vault        bool
-	AllProducts  bool
-	Includes     []string
-	IncludeSince time.Duration
-	Destination  string
-	Config       string
-	Version      bool
+	OS     string
+	Serial bool
+	Dryrun bool
+
+	// Products
+	Consul      bool
+	Nomad       bool
+	TFE         bool
+	Vault       bool
+	AllProducts bool
+
+	// Since provides a time range for seekers to work from
+	Since time.Duration
+
+	// Includes
+	Includes []string
+
+	// Bundle write location
+	Destination string
+
+	// HCL file location
+	Config string
+
+	// Get hcdiag version
+	Version bool
 }
 
 type CSVFlag struct {
@@ -124,7 +150,7 @@ func (f *Flags) parseFlags(args []string) error {
 	flags.StringVar(&f.Destination, "destination", ".", "Path to the directory the bundle should be written in")
 	flags.StringVar(&f.Destination, "dest", ".", "Shorthand for -destination")
 	flags.StringVar(&f.Config, "config", "", "Path to HCL configuration file")
-	flags.DurationVar(&f.IncludeSince, "include-since", time.Duration(0), "Time range to include files, counting back from now. Takes a 'go-formatted' duration, usage examples: `72h`, `25m`, `45s`, `120h1m90s`")
+	flags.DurationVar(&f.Since, "since", SeventyTwoHours, "Collect information within this time. Takes a 'go-formatted' duration, usage examples: `72h`, `25m`, `45s`, `120h1m90s`")
 	flags.Var(&CSVFlag{&f.Includes}, "includes", "files or directories to include (comma-separated, file-*-globbing available if 'wrapped-*-in-single-quotes')\ne.g. '/var/log/consul-*,/var/log/nomad-*'")
 	flags.BoolVar(&f.Version, "version", false, "Print the current version of hcdiag")
 
@@ -135,15 +161,12 @@ func (f *Flags) parseFlags(args []string) error {
 	return flags.Parse(args)
 }
 
-// FIXME(mkcp): Don't love how this fits together yet
 // mergeAgentConfig merges flags into the agent.Config, prioritizing flags over HCL config.
 func mergeAgentConfig(config agent.Config, flags Flags) agent.Config {
-	// Convert our flag input to agent configuration
-	from := time.Unix(0, flags.IncludeSince.Nanoseconds())
-	to := time.Now()
 	config.OS = flags.OS
 	config.Serial = flags.Serial
 	config.Dryrun = flags.Dryrun
+
 	// DEPRECATED(mkcp): flags.AllProducts
 	config.Consul = flags.AllProducts || flags.Consul
 	// DEPRECATED(mkcp): flags.AllProducts
@@ -152,10 +175,13 @@ func mergeAgentConfig(config agent.Config, flags Flags) agent.Config {
 	config.TFE = flags.AllProducts || flags.TFE
 	// DEPRECATED(mkcp): flags.AllProducts
 	config.Vault = flags.AllProducts || flags.Vault
+
+	// Params for --includes
 	config.Includes = flags.Includes
-	config.IncludeFrom = from
-	config.IncludeTo = to
+
+	// Bundle write location
 	config.Destination = flags.Destination
+
 	return config
 }
 

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 const SemVer string = "0.1.3"
 
 // SeventyTwoHours represents the duration "72h" parsed in nanoseconds
-const SeventyTwoHours time.Duration = 259199999999999
+const SeventyTwoHours time.Duration = 259200000000000
 
 func main() {
 	os.Exit(realMain())

--- a/main.go
+++ b/main.go
@@ -54,12 +54,10 @@ func realMain() (returnCode int) {
 	}
 	// Assign flag vals to our agent.Config
 	cfg := mergeAgentConfig(config, flags)
-	// Capture a now value and set timestamps based on the same Now value
+
+	// Set config timestamps based on durations
 	now := time.Now()
-	// Get the difference between now and the provided --since Duration
-	cfg.Since = now.Add(-flags.Since)
-	// NOTE(mkcp): In the future, cfg.Until may be set by a flag.
-	cfg.Until = now
+	cfg = setTime(cfg, now, flags.Since)
 
 	// Create agent
 	a := agent.NewAgent(cfg, l)
@@ -188,4 +186,14 @@ func mergeAgentConfig(config agent.Config, flags Flags) agent.Config {
 func printVersion() {
 	slug := "hcdiag v" + SemVer
 	fmt.Println(slug)
+}
+
+func setTime(cfg agent.Config, now time.Time, since time.Duration) agent.Config {
+	// Capture a now value and set timestamps based on the same Now value
+	// Get the difference between now and the provided --since Duration
+	cfg.Since = now.Add(-since)
+	// NOTE(mkcp): In the future, cfg.Until may be set by a flag.
+	cfg.Until = now
+
+	return cfg
 }

--- a/main.go
+++ b/main.go
@@ -193,7 +193,7 @@ func setTime(cfg agent.Config, now time.Time, since time.Duration) agent.Config 
 	// Get the difference between now and the provided --since Duration
 	cfg.Since = now.Add(-since)
 	// NOTE(mkcp): In the future, cfg.Until may be set by a flag.
-	cfg.Until = now
+	cfg.Until = time.Time{}
 
 	return cfg
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,1 +1,35 @@
 package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/hcdiag/agent"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeAgentConfig(t *testing.T) {
+	testDur, err := time.ParseDuration("48h")
+	if !assert.NoError(t, err) {
+		return
+	}
+	flags := Flags{
+		OS:          "auto",
+		AllProducts: true,
+		Since:       testDur,
+	}
+
+	newCfg := mergeAgentConfig(agent.Config{}, flags)
+
+	testCfg := agent.Config{
+		OS:     "auto",
+		Consul: true,
+		Nomad:  true,
+		TFE:    true,
+		Vault:  true,
+		Since:  time.Time{},
+		Until:  time.Time{},
+	}
+
+	assert.Equal(t, newCfg, testCfg)
+}

--- a/main_test.go
+++ b/main_test.go
@@ -8,28 +8,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMergeAgentConfig(t *testing.T) {
+func TestSetTime(t *testing.T) {
+	// This test is kind of a tautology because we're replacing the impl. to build the expected struct. But it holds
+	// some value to protect against regressions.
 	testDur, err := time.ParseDuration("48h")
 	if !assert.NoError(t, err) {
 		return
 	}
-	flags := Flags{
-		OS:          "auto",
-		AllProducts: true,
-		Since:       testDur,
+	cfg := agent.Config{}
+	now := time.Now()
+	newCfg := setTime(cfg, now, testDur)
+
+	expect := agent.Config{
+		Since: now.Add(-testDur),
+		Until: now,
 	}
 
-	newCfg := mergeAgentConfig(agent.Config{}, flags)
-
-	testCfg := agent.Config{
-		OS:     "auto",
-		Consul: true,
-		Nomad:  true,
-		TFE:    true,
-		Vault:  true,
-		Since:  time.Time{},
-		Until:  time.Time{},
-	}
-
-	assert.Equal(t, newCfg, testCfg)
+	assert.Equal(t, newCfg, expect)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -21,7 +21,7 @@ func TestSetTime(t *testing.T) {
 
 	expect := agent.Config{
 		Since: now.Add(-testDur),
-		Until: now,
+		Until: time.Time{}, // This is the default zero value, but we're just being extra explicit.
 	}
 
 	assert.Equal(t, newCfg, expect)

--- a/product/consul.go
+++ b/product/consul.go
@@ -17,12 +17,12 @@ const (
 // NewConsul takes a product config and creates a Product with all of Consul's default seekers
 func NewConsul(cfg Config) *Product {
 	return &Product{
-		Seekers: ConsulSeekers(cfg.TmpDir, cfg.From, cfg.To),
+		Seekers: ConsulSeekers(cfg.TmpDir, cfg.Since, cfg.Until),
 	}
 }
 
 // ConsulSeekers seek information about Consul.
-func ConsulSeekers(tmpDir string, from, to time.Time) []*s.Seeker {
+func ConsulSeekers(tmpDir string, since, until time.Time) []*s.Seeker {
 	api := client.NewConsulAPI()
 
 	seekers := []*s.Seeker{
@@ -41,11 +41,11 @@ func ConsulSeekers(tmpDir string, from, to time.Time) []*s.Seeker {
 	// try to detect log location to copy
 	if logPath, err := client.GetConsulLogPath(api); err == nil {
 		dest := filepath.Join(tmpDir, "logs/consul")
-		logCopier := s.NewCopier(logPath, dest, from, to)
+		logCopier := s.NewCopier(logPath, dest, since, until)
 		seekers = append([]*s.Seeker{logCopier}, seekers...)
 	}
 	// get logs from journald if available
-	if journald := s.JournaldGetter("consul", tmpDir); journald != nil {
+	if journald := s.JournaldGetter("consul", tmpDir, since, until); journald != nil {
 		seekers = append(seekers, journald)
 	}
 

--- a/product/nomad.go
+++ b/product/nomad.go
@@ -18,12 +18,12 @@ const (
 // NewNomad takes a product config and creates a Product with all of Nomad's default seekers
 func NewNomad(cfg Config) *Product {
 	return &Product{
-		Seekers: NomadSeekers(cfg.TmpDir, cfg.From, cfg.To),
+		Seekers: NomadSeekers(cfg.TmpDir, cfg.Since, cfg.Until),
 	}
 }
 
 // NomadSeekers seek information about Nomad.
-func NomadSeekers(tmpDir string, from, to time.Time) []*s.Seeker {
+func NomadSeekers(tmpDir string, since, until time.Time) []*s.Seeker {
 	api := client.NewNomadAPI()
 
 	seekers := []*s.Seeker{
@@ -42,11 +42,11 @@ func NomadSeekers(tmpDir string, from, to time.Time) []*s.Seeker {
 	// try to detect log location to copy
 	if logPath, err := client.GetNomadLogPath(api); err == nil {
 		dest := filepath.Join(tmpDir, "logs", "nomad")
-		logCopier := s.NewCopier(logPath, dest, from, to)
+		logCopier := s.NewCopier(logPath, dest, since, until)
 		seekers = append([]*s.Seeker{logCopier}, seekers...)
 	}
 	// get logs from journald if available
-	if journald := s.JournaldGetter("nomad", tmpDir); journald != nil {
+	if journald := s.JournaldGetter("nomad", tmpDir, since, until); journald != nil {
 		seekers = append(seekers, journald)
 	}
 

--- a/product/products.go
+++ b/product/products.go
@@ -25,8 +25,8 @@ type Config struct {
 	Logger *hclog.Logger
 	Name   string
 	TmpDir string
-	From   time.Time
-	To     time.Time
+	Since  time.Time
+	Until  time.Time
 	OS     string
 }
 

--- a/product/tfe.go
+++ b/product/tfe.go
@@ -10,18 +10,18 @@ import (
 // NewTFE takes a product config and creates a Product containing all of TFE's seekers.
 func NewTFE(cfg Config) *Product {
 	return &Product{
-		Seekers: TFESeekers(cfg.TmpDir, cfg.From, cfg.To),
+		Seekers: TFESeekers(cfg.TmpDir, cfg.Since, cfg.Until),
 	}
 }
 
 // TFESeekers seek information about Terraform Enterprise/Cloud.
-func TFESeekers(tmpDir string, from, to time.Time) []*s.Seeker {
+func TFESeekers(tmpDir string, since, until time.Time) []*s.Seeker {
 	api := client.NewTFEAPI()
 
 	return []*s.Seeker{
 		s.NewCommander("replicatedctl support-bundle", "string"),
 
-		s.NewCopier("/var/lib/replicated/support-bundles/replicated-support*.tar.gz", tmpDir, from, to),
+		s.NewCopier("/var/lib/replicated/support-bundles/replicated-support*.tar.gz", tmpDir, since, until),
 
 		s.NewHTTPer(api, "/api/v2/admin/customization-settings"),
 		s.NewHTTPer(api, "/api/v2/admin/general-settings"),

--- a/product/vault.go
+++ b/product/vault.go
@@ -16,7 +16,7 @@ const (
 
 // NewVault takes a product config and creates a Product containing all of Vault's seekers.
 func NewVault(cfg Config) (*Product, error) {
-	seekers, err := VaultSeekers(cfg.TmpDir, cfg.From, cfg.To)
+	seekers, err := VaultSeekers(cfg.TmpDir, cfg.Since, cfg.Until)
 	if err != nil {
 		return nil, err
 	}
@@ -26,7 +26,7 @@ func NewVault(cfg Config) (*Product, error) {
 }
 
 // VaultSeekers seek information about Vault.
-func VaultSeekers(tmpDir string, from, to time.Time) ([]*s.Seeker, error) {
+func VaultSeekers(tmpDir string, since, until time.Time) ([]*s.Seeker, error) {
 	api, err := client.NewVaultAPI()
 	if err != nil {
 		return nil, err
@@ -44,11 +44,11 @@ func VaultSeekers(tmpDir string, from, to time.Time) ([]*s.Seeker, error) {
 	// try to detect log location to copy
 	if logPath, err := client.GetVaultAuditLogPath(api); err == nil {
 		dest := filepath.Join(tmpDir, "logs/vault")
-		logCopier := s.NewCopier(logPath, dest, from, to)
+		logCopier := s.NewCopier(logPath, dest, since, until)
 		seekers = append([]*s.Seeker{logCopier}, seekers...)
 	}
 	// get logs from journald if available
-	if journald := s.JournaldGetter("vault", tmpDir); journald != nil {
+	if journald := s.JournaldGetter("vault", tmpDir, since, until); journald != nil {
 		seekers = append(seekers, journald)
 	}
 

--- a/seeker/copier.go
+++ b/seeker/copier.go
@@ -13,12 +13,12 @@ type Copier struct {
 	SourceDir string    `json:"source_directory"`
 	Filter    string    `json:"filter"`
 	DestDir   string    `json:"destination_directory"`
-	From      time.Time `json:"from"`
-	To        time.Time `json:"to"`
+	Since     time.Time `json:"since"`
+	Until     time.Time `json:"until"`
 }
 
 // NewCopier provides a Seeker for copying files to temp dir based on a filter.
-func NewCopier(path, destDir string, from, to time.Time) *Seeker {
+func NewCopier(path, destDir string, since, until time.Time) *Seeker {
 	sourceDir, filter := util.SplitFilepath(path)
 	return &Seeker{
 		Identifier: "copy " + filepath.Join(sourceDir, filter),
@@ -26,8 +26,8 @@ func NewCopier(path, destDir string, from, to time.Time) *Seeker {
 			SourceDir: sourceDir,
 			Filter:    filter,
 			DestDir:   destDir,
-			From:      from,
-			To:        to,
+			Since:     since,
+			Until:     until,
 		},
 	}
 }
@@ -41,7 +41,7 @@ func (c Copier) Run() (result interface{}, err error) {
 	}
 
 	// Find all the files
-	files, err := util.FilterWalk(c.SourceDir, c.Filter, c.From, c.To)
+	files, err := util.FilterWalk(c.SourceDir, c.Filter, c.Since, c.Until)
 	if err != nil {
 		return nil, err
 	}

--- a/seeker/journald.go
+++ b/seeker/journald.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 )
 
-const JournaldTimeLayout = "2022-02-22 16:09:51"
+const JournaldTimeLayout = "2006-01-02 15:04:05"
 
 // JournaldGetter attempts to pull logs from journald via shell command, e.g.:
 // journalctl -x -u {name} --since '3 days ago' --no-pager > {destDir}/journald-{name}.log

--- a/seeker/journald.go
+++ b/seeker/journald.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 )
 
+// JournaldTimeLayout custom go time layouts must match the reference time Jan 2 15:04:05 2006 MST
 const JournaldTimeLayout = "2006-01-02 15:04:05"
 
 // JournaldGetter attempts to pull logs from journald via shell command, e.g.:

--- a/seeker/journald_test.go
+++ b/seeker/journald_test.go
@@ -1,0 +1,57 @@
+package seeker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJournalctlGetLogsCmd(t *testing.T) {
+	testTable := []struct {
+		desc    string
+		name    string
+		destDir string
+		since   time.Time
+		until   time.Time
+		expect  string
+	}{
+		{
+			desc:    "No since or until",
+			name:    "nomad",
+			destDir: "/testing/test",
+			since:   time.Time{},
+			until:   time.Time{},
+			expect:  "journalctl -x -u nomad --no-pager > /testing/test/journald-nomad.log",
+		},
+		{
+			desc:    "With since but not until",
+			name:    "nomad",
+			destDir: "/testing/test",
+			since:   time.Date(1, 1, 1, 1, 1, 1, 1, &time.Location{}),
+			until:   time.Time{},
+			expect:  "journalctl -x -u nomad --since \"0001-01-01 01:01:01\" --no-pager > /testing/test/journald-nomad.log",
+		},
+		{
+			desc:    "With until but not since",
+			name:    "nomad",
+			destDir: "/testing/test",
+			since:   time.Time{},
+			until:   time.Date(2, 1, 1, 1, 1, 1, 1, &time.Location{}),
+			expect:  "journalctl -x -u nomad --until \"0002-01-01 01:01:01\" --no-pager > /testing/test/journald-nomad.log",
+		},
+		{
+			desc:    "with since and until",
+			name:    "nomad",
+			destDir: "/testing/test",
+			since:   time.Date(1, 1, 1, 1, 1, 1, 1, &time.Location{}),
+			until:   time.Date(2, 1, 1, 1, 1, 1, 1, &time.Location{}),
+			expect:  "journalctl -x -u nomad --since \"0001-01-01 01:01:01\" --until \"0002-01-01 01:01:01\" --no-pager > /testing/test/journald-nomad.log",
+		},
+	}
+
+	for _, tc := range testTable {
+		result := JournalctlGetLogsCmd(tc.name, tc.destDir, tc.since, tc.until)
+		assert.Equal(t, tc.expect, result)
+	}
+}

--- a/util/util.go
+++ b/util/util.go
@@ -149,24 +149,24 @@ func SplitFilepath(path string) (dir string, file string) {
 	return dir, file
 }
 
-func IsInRange(target, from, to time.Time) bool {
+func IsInRange(target, since, until time.Time) bool {
 	// Default true if no range provided
-	if from.IsZero() {
+	if since.IsZero() {
 		return true
 	}
 
 	// Check if the end of our range is zero
-	if to.IsZero() {
+	if until.IsZero() {
 		// Anything after the start time is valid
-		return target.After(from)
+		return target.After(since)
 	}
 
 	// Check if the fileTime is within range
-	return target.After(from) && target.Before(to)
+	return target.After(since) && target.Before(until)
 }
 
-// FilterWalk accepts a source directory, filter string, and from and to Times to return a list of matching files.
-func FilterWalk(srcDir, filter string, from, to time.Time) ([]string, error) {
+// FilterWalk accepts a source directory, filter string, and since and to Times to return a list of matching files.
+func FilterWalk(srcDir, filter string, since, until time.Time) ([]string, error) {
 	var fileMatches []string
 
 	// Filter the files
@@ -184,7 +184,7 @@ func FilterWalk(srcDir, filter string, from, to time.Time) ([]string, error) {
 				return err
 			}
 			mod := info.ModTime()
-			if IsInRange(mod, from, to) {
+			if IsInRange(mod, since, until) {
 				fileMatches = append(fileMatches, path)
 			}
 		}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -97,74 +97,74 @@ func TestFindInInterface(t *testing.T) {
 
 func TestIsInRange(t *testing.T) {
 	testTable := []struct {
-		desc             string
-		target, from, to time.Time
-		expect           bool
+		desc                 string
+		target, since, until time.Time
+		expect               bool
 	}{
 		{
 			desc:   "Target within range is valid",
 			target: time.Date(2000, 0, 0, 0, 0, 0, 0, &time.Location{}),
-			from:   time.Date(1977, 0, 0, 0, 0, 0, 0, &time.Location{}),
-			to:     time.Date(2200, 0, 0, 0, 0, 0, 0, &time.Location{}),
+			since:  time.Date(1977, 0, 0, 0, 0, 0, 0, &time.Location{}),
+			until:  time.Date(2200, 0, 0, 0, 0, 0, 0, &time.Location{}),
 			expect: true,
 		},
 		{
 			desc:   "Target after range is invalid",
 			target: time.Date(2300, 0, 0, 0, 0, 0, 0, &time.Location{}),
-			from:   time.Date(1977, 0, 0, 0, 0, 0, 0, &time.Location{}),
-			to:     time.Date(2200, 0, 0, 0, 0, 0, 0, &time.Location{}),
+			since:  time.Date(1977, 0, 0, 0, 0, 0, 0, &time.Location{}),
+			until:  time.Date(2200, 0, 0, 0, 0, 0, 0, &time.Location{}),
 			expect: false,
 		},
 		{
 			desc:   "Target before range is invalid",
 			target: time.Date(1800, 0, 0, 0, 0, 0, 0, &time.Location{}),
-			from:   time.Date(1977, 0, 0, 0, 0, 0, 0, &time.Location{}),
-			to:     time.Date(2200, 0, 0, 0, 0, 0, 0, &time.Location{}),
+			since:  time.Date(1977, 0, 0, 0, 0, 0, 0, &time.Location{}),
+			until:  time.Date(2200, 0, 0, 0, 0, 0, 0, &time.Location{}),
 			expect: false,
 		},
 		{
-			desc:   "Zeroed `from` is always in range",
+			desc:   "Zeroed `since` is always in range",
 			target: time.Now(),
 			expect: true,
 		},
 		{
-			desc:   "Zeroed `to` includes recent and/or actively-written-to target",
+			desc:   "Zeroed `until` includes recent and/or actively-written-until target",
 			target: time.Now(),
-			from:   time.Date(1977, 0, 0, 0, 0, 0, 0, &time.Location{}),
+			since:  time.Date(1977, 0, 0, 0, 0, 0, 0, &time.Location{}),
 			expect: true,
 		},
 		{
-			desc:   "Zeroed `to` does not include target before `from`",
+			desc:   "Zeroed `until` does not include target before `since`",
 			target: time.Date(1800, 0, 0, 0, 0, 0, 0, &time.Location{}),
-			from:   time.Date(1977, 0, 0, 0, 0, 0, 0, &time.Location{}),
+			since:  time.Date(1977, 0, 0, 0, 0, 0, 0, &time.Location{}),
 			expect: false,
 		},
 	}
 
 	for _, c := range testTable {
-		res := IsInRange(c.target, c.from, c.to)
+		res := IsInRange(c.target, c.since, c.until)
 		assert.Equal(t, res, c.expect, c.desc)
 	}
 }
 
-// FIXME(mkcp): Ensure the from and to works with modtime properly
+// FIXME(mkcp): Ensure the since and until works with modtime properly
 // func TestFilterWalk(t *testing.T) {
 // 	testTable := []struct{
 // 		filter   string
-// 		from     time.Time
-// 		to       time.Time
+// 		since     time.Time
+// 		until       time.Time
 // 		testCase func(t *testing.T)
 // 		expect   what
 // 	}{
 // 		{
 // 			filter: "",
-// 			from:   time.Time{},
-// 			to:     time.Time{},
+// 			since:   time.Time{},
+// 			until:     time.Time{},
 // 		},
 // 	}
 // 	for _, test := range testTable {
 // 		path := GenerateAbsolutePathIntoTestsResources()
-// 		res, err := FilterWalk(path, test.filter, test.from, test.to)
+// 		res, err := FilterWalk(path, test.filter, test.since, test.until)
 // 		assert.NoError(t, err)
 // 		for _, r := range res {
 // 			expect == r


### PR DESCRIPTION
Review guide:

- Readme updated
- substantial changes to how time is set in `main.go` including a bugfix for the time.Unix(x,y) which was setting the wrong relative time.
- everything in the agent->product->seeker flow should be simple renames.
- add since support to journald.