### PR TITLE
add windows builds back in

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,16 +13,16 @@ builds:
   goos:
     - linux
     - darwin
-    # - windows
+    - windows
   goarch:
     - amd64
     - arm
     - arm64
   ignore:
-  #   - goarch: 'arm'
-  #     goos: windows
-  #   - goarch: 'arm64'
-  #     goos: windows
+    - goarch: 'arm'
+      goos: windows
+    - goarch: 'arm64'
+      goos: windows
 
 archives:
 - format: zip


### PR DESCRIPTION
Early on we maintained windows builds, but we dropped them due to low demand. Demand is back baby, this adds them back in!