### PR TITLE
Refactor host seeker

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/hashicorp/go-hclog v0.16.2
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/hcl/v2 v2.10.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-ps v1.0.0
@@ -19,6 +20,7 @@ require (
 	github.com/fatih/color v1.12.0 // indirect
 	github.com/go-ole/go-ole v1.2.5 // indirect
 	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,12 @@ github.com/golang/protobuf v1.3.4/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaW
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-hclog v0.16.2 h1:K4ev2ib4LdQETX5cSZBG0DVLk1jwGqSPXBjdah3veNs=
 github.com/hashicorp/go-hclog v0.16.2/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/hcl/v2 v2.10.1 h1:h4Xx4fsrRE26ohAk/1iGF/JBqRQbyUqu5Lvj60U54ys=
 github.com/hashicorp/hcl/v2 v2.10.1/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/product/host.go
+++ b/product/host.go
@@ -66,77 +66,13 @@ func (hs *HostSeeker) Run() (interface{}, error) {
 	l.Debug("Host seeker capture begin")
 
 	hs.capture("uname", s.NewCommander("uname -v", "string").Run)
-	hs.capture("host", GetHost)
-	hs.capture("memory", GetMemory)
-	hs.capture("disk", GetDisk)
-	hs.capture("processes", GetProcesses)
-	hs.capture("network", GetNetwork)
+
+	hs.capture("host", func() (interface{}, error) { return host.Info() })
+	hs.capture("memory", func() (interface{}, error) { return mem.VirtualMemory() })
+	hs.capture("disk", func() (interface{}, error) { return disk.Partitions(true) })
+	hs.capture("processes", func() (interface{}, error) { return ps.Processes() })
+	hs.capture("network", func() (interface{}, error) { return net.Interfaces() })
 
 	l.Debug("Host seeker capture complete")
 	return hs.results, hs.errors.ErrorOrNil()
-}
-
-// GetNetwork stuff
-func GetNetwork() (interface{}, error) {
-	networkInfo, err := net.Interfaces()
-	if err != nil {
-		hclog.L().Error("GetNetwork", "Error getting network information", err)
-		return networkInfo, err
-	}
-
-	return networkInfo, err
-}
-
-// GetProcesses stuff
-func GetProcesses() (interface{}, error) {
-	processes, err := ps.Processes()
-	if err != nil {
-		hclog.L().Error("GetProcesses", "Error getting process information", err)
-		return processes, err
-	}
-
-	processInfo := make([]string, 0)
-
-	for eachProcess := range processes {
-		process := processes[eachProcess]
-		processInfo = append(processInfo, process.Executable())
-	}
-
-	return processInfo, err
-}
-
-// GetMemory stuff
-func GetMemory() (interface{}, error) {
-	// third party
-	memoryInfo, err := mem.VirtualMemory()
-	if err != nil {
-		hclog.L().Error("GetMemory", "Error getting memory information", err)
-		return memoryInfo, err
-	}
-
-	return memoryInfo, err
-}
-
-// GetDisk stuff
-func GetDisk() (interface{}, error) {
-	// third party
-	diskInfo, err := disk.Partitions(true)
-	if err != nil {
-		hclog.L().Error("GetDisk", "Error getting disk information", err)
-		return diskInfo, err
-	}
-
-	return diskInfo, err
-}
-
-// GetHost stuff
-func GetHost() (interface{}, error) {
-	// third party
-	hostInfo, err := host.Info()
-	if err != nil {
-		hclog.L().Error("GetHost", "Error getting host information", err)
-		return hostInfo, err
-	}
-
-	return hostInfo, err
 }

--- a/product/host.go
+++ b/product/host.go
@@ -68,7 +68,8 @@ func (hs *HostSeeker) Run() (interface{}, error) {
 	hs.capture("uname", s.NewCommander("uname -v", "string").Run)
 
 	hs.capture("host", func() (interface{}, error) { return host.Info() })
-	hs.capture("memory", func() (interface{}, error) { return mem.VirtualMemory() })
+	hs.capture("memory-virtual", func() (interface{}, error) { return mem.VirtualMemory() })
+	hs.capture("memory-swap", func() (interface{}, error) { return mem.SwapMemory() })
 	hs.capture("disk", func() (interface{}, error) { return disk.Partitions(true) })
 	hs.capture("processes", func() (interface{}, error) { return ps.Processes() })
 	hs.capture("network", func() (interface{}, error) { return net.Interfaces() })


### PR DESCRIPTION
This PR refactors the host seekers to:
* simplify control logic
* remove extra code
* improve logging

During the process I discovered that we were missing swap memory as well as process ID / parent ID information.  Those were both addressed here as well but could be split out if necessary.