### PR TITLE
Nomad seeker updates

### DIFF
--- a/product/nomad.go
+++ b/product/nomad.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	NomadClientCheck  = "nomad version"
-	NomadAgentCheck   = "nomad server members"
-	NomadDebugSeconds = 30
+	NomadClientCheck   = "nomad version"
+	NomadAgentCheck    = "nomad server members"
+	NomadDebugDuration = "2m"
+	NomadDebugInterval = "30s"
 )
 
 // NewNomad takes a product config and creates a Product with all of Nomad's default seekers
@@ -28,15 +29,26 @@ func NomadSeekers(tmpDir string, from, to time.Time) []*s.Seeker {
 
 	seekers := []*s.Seeker{
 		s.NewCommander("nomad version", "string"),
-		s.NewCommander("nomad node status -json", "json"),
+		s.NewCommander("nomad node status -self -json", "json"),
 		s.NewCommander("nomad agent-info -json", "json"),
-		s.NewCommander(fmt.Sprintf("nomad operator debug -output=%s -duration=%ds", tmpDir, NomadDebugSeconds), "string"),
-		// s.NewCommander("nomad operator metrics", "json", false), // TODO: uncomment (it's very verbose, so not noisy during testing)
+		s.NewCommander(fmt.Sprintf("nomad operator debug -log-level=TRACE -node-id=all -max-nodes=10 -output=%s -duration=%s -interval=%s", tmpDir, NomadDebugDuration, NomadDebugInterval), "string"),
 
-		s.NewHTTPer(api, "/v1/agent/members"),
-		s.NewHTTPer(api, "/v1/plugins?type=csi"),
-		s.NewHTTPer(api, "/v1/operator/autopilot/configuration"),
-		s.NewHTTPer(api, "/v1/operator/raft/configuration"),
+		s.NewHTTPer(api, "/v1/agent/members?stale=true"),
+		s.NewHTTPer(api, "/v1/operator/autopilot/configuration?stale=true"),
+		s.NewHTTPer(api, "/v1/operator/raft/configuration?stale=true"),
+
+		s.NewCommander("iptables -L -n -v", "string"),
+		s.NewCommander("iptables -L -n -v -t nat", "string"),
+		s.NewCommander("iptables -L -n -v -t mangle", "string"),
+
+		s.NewCommander("journalctl -xeu nomad.service --since yesterday", "string"),
+		s.NewCommander("journalctl --list-boots", "string"),
+
+		s.NewCommander("systemctl show nomad.service", "string"),
+		s.NewCommander("systemctl show docker.service", "string"),
+
+		s.NewCommander("docker version --format='{{json .}}'", "string"),
+		s.NewCommander("docker info --format='{{json .}}'", "string"),
 	}
 
 	// try to detect log location to copy

--- a/product/nomad.go
+++ b/product/nomad.go
@@ -36,19 +36,6 @@ func NomadSeekers(tmpDir string, from, to time.Time) []*s.Seeker {
 		s.NewHTTPer(api, "/v1/agent/members?stale=true"),
 		s.NewHTTPer(api, "/v1/operator/autopilot/configuration?stale=true"),
 		s.NewHTTPer(api, "/v1/operator/raft/configuration?stale=true"),
-
-		s.NewCommander("iptables -L -n -v", "string"),
-		s.NewCommander("iptables -L -n -v -t nat", "string"),
-		s.NewCommander("iptables -L -n -v -t mangle", "string"),
-
-		s.NewCommander("journalctl -xeu nomad.service --since yesterday", "string"),
-		s.NewCommander("journalctl --list-boots", "string"),
-
-		s.NewCommander("systemctl show nomad.service", "string"),
-		s.NewCommander("systemctl show docker.service", "string"),
-
-		s.NewCommander("docker version --format='{{json .}}'", "string"),
-		s.NewCommander("docker info --format='{{json .}}'", "string"),
 	}
 
 	// try to detect log location to copy


### PR DESCRIPTION
PR from pairing with Dave.

Adds multiple sample windows with duration/interval in the support bundle, and changes the api calls to perform potentially stale cluster state reads from the node being read from.