### PR TITLE
Run systeminfo on Windows instead of uname

### DIFF
--- a/product/host.go
+++ b/product/host.go
@@ -43,11 +43,16 @@ func (hs *HostSeeker) Run() (interface{}, error) {
 	results := make(map[string]interface{})
 	var errors *multierror.Error
 
-	if tmpResult, err := s.NewCommander("uname -v", "string").Run(); err != nil {
+	osInfoCmd := "uname -v"
+	if hs.OS == "windows" {
+		osInfoCmd = "systeminfo"
+	}
+	if tmpResult, err := s.NewCommander(osInfoCmd, "string").Run(); err != nil {
 		errors = multierror.Append(errors, err)
 	} else {
-		results["uname"] = tmpResult
+		results["osinfo"] = tmpResult
 	}
+
 	if tmpResult, err := GetHost(); err != nil {
 		errors = multierror.Append(errors, err)
 	} else {


### PR DESCRIPTION
Fix very very noisy warning output on Windows due to `uname` not existing there.

@davemay99 recommended that we run `systeminfo.exe` instead to get similar useful information.

It is really very noisy:

> 2022-04-01T15:13:13.129-0700 [WARN]  hcdiag: result: seeker=stats result="map[disk:[{"device":"C:","mountpoint":"C:","fstype":"NTFS","opts":["rw","compress"]} {"device":"D:","mountpoint":"D:","fstype":"CDFS","opts":["ro"]} {"device":"G:","mountpoint":"G:","fstype":"VBoxSharedFolderFS","opts":["rw"]}] host:{"hostname":"DESKTOP-FQ0DJRT","uptime":6486,"bootTime":1648844707,"procs":75,"os":"windows","platform":"Microsoft Windows 10 Pro","platformFamily":"Standalone Workstation","platformVersion":"10.0.19043 Build 19043","kernelVersion":"10.0.19043 Build 19043","kernelArch":"x86_64","virtualizationSystem":"","virtualizationRole":"","hostId":"863c4cd2-6c34-4b48-b8de-5e6358298ab7"} memory:{"total":2147012608,"available":915529728,"used":1231482880,"usedPercent":57,"free":915529728,"active":0,"inactive":0,"wired":0,"laundry":0,"buffers":0,"cached":0,"writeBack":0,"dirty":0,"writeBackTmp":0,"shared":0,"slab":0,"sreclaimable":0,"sunreclaim":0,"pageTables":0,"swapCached":0,"commitLimit":0,"committedAS":0,"highTotal":0,"highFree":0,"lowTotal":0,"lowFree":0,"swapTotal":0,"swapFree":0,"mapped":0,"vmallocTotal":0,"vmallocUsed":0,"vmallocChunk":0,"hugePagesTotal":0,"hugePagesFree":0,"hugePageSize":0} network:[{%!s(int=4) %!s(int=1500) Ethernet 08:00:27:84:1b:ad up|broadcast|multicast} {%!s(int=1) %!s(int=-1) Loopback Pseudo-Interface 1  up|loopback|multicast}] processes:[[System Process] System Registry smss.exe csrss.exe wininit.exe csrss.exe winlogon.exe services.exe lsass.exe svchost.exe fontdrvhost.exe fontdrvhost.exe svchost.exe dwm.exe svchost.exe svchost.exe svchost.exe svchost.exe svchost.exe svchost.exe VBoxService.exe Memory Compression svchost.exe svchost.exe svchost.exe svchost.exe svchost.exe svchost.exe spoolsv.exe svchost.exe MsMpEng.exe sihost.exe svchost.exe taskhostw.exe ctfmon.exe explorer.exe svchost.exe SearchIndexer.exe svchost.exe MoUsoCoreWorker.exe StartMenuExperienceHost.exe RuntimeBroker.exe SearchApp.exe RuntimeBroker.exe YourPhone.exe NisSrv.exe LockApp.exe RuntimeBroker.exe RuntimeBroker.exe RuntimeBroker.exe SecurityHealthSystray.exe SecurityHealthService.exe VBoxTray.exe OneDrive.exe svchost.exe ShellExperienceHost.exe RuntimeBroker.exe SystemSettings.exe ApplicationFrameHost.exe UserOOBEBroker.exe powershell.exe conhost.exe SgrmBroker.exe svchost.exe svchost.exe Microsoft.Photos.exe RuntimeBroker.exe svchost.exe svchost.exe WmiPrvSE.exe WmiPrvSE.exe TrustedInstaller.exe TiWorker.exe hcdiag.exe]]"
  error=
  | 1 error occurred:
  |     * exec.Command error: exec: "uname": executable file not found in %PATH%
  |

Afterwards, it is not noisy!  The output of `systeminfo.exe` is more verbose than `uname -v` is, but more is more.