### PR TITLE
Add seeker statuses

### DIFF
--- a/product/host.go
+++ b/product/host.go
@@ -39,7 +39,7 @@ type HostSeeker struct {
 	OS string `json:"os"`
 }
 
-func (hs *HostSeeker) Run() (interface{}, error) {
+func (hs *HostSeeker) Run() (interface{}, s.Status, error) {
 	results := make(map[string]interface{})
 	var errors *multierror.Error
 
@@ -76,7 +76,7 @@ func (hs *HostSeeker) Run() (interface{}, error) {
 		results["network"] = tmpResult
 	}
 
-	return results, errors.ErrorOrNil()
+	return results, s.Success, errors.ErrorOrNil()
 }
 
 // GetNetwork stuff

--- a/seeker/commander.go
+++ b/seeker/commander.go
@@ -22,29 +22,38 @@ func NewCommander(command string, format string) *Seeker {
 	}
 }
 
-func (c Commander) Run() (result interface{}, err error) {
+// Run executes the Command
+func (c Commander) Run() (interface{}, Status, error) {
+	var result interface{}
+	var err error
+
 	bits := strings.Split(c.Command, " ")
 	cmd := bits[0]
 	args := bits[1:]
 
-	bts, err := exec.Command(cmd, args...).CombinedOutput()
+	// TODO(mkcp): Add cross-platform commandExists() func to ensure there's a bin we can call
 
+	// Execute command
+	bts, err := exec.Command(cmd, args...).CombinedOutput()
 	if err != nil {
-		err = fmt.Errorf("exec.Command error: %s", err)
+		return string(bts), Unknown, fmt.Errorf("exec.Command error: %s", err)
 	}
 
+	// Parse result
+	// TODO(mkcp): This can be detected rather than branching on user input
 	switch {
 	case c.format == "string":
 		result = strings.TrimSuffix(string(bts), "\n")
 
 	case c.format == "json":
 		if e := json.Unmarshal(bts, &result); e != nil {
-			err = fmt.Errorf("json.Unmarshal error: %s", e)
+			return nil, Fail, fmt.Errorf("json.Unmarshal error: %s", e)
 		}
 
 	default:
 		err = errors.New("command output format must be either 'string' or 'json'")
+		return result, Fail, err
 	}
 
-	return result, err
+	return result, Success, nil
 }

--- a/seeker/copier.go
+++ b/seeker/copier.go
@@ -33,26 +33,26 @@ func NewCopier(path, destDir string, since, until time.Time) *Seeker {
 }
 
 // Run satisfies the Runner interface and copies the filtered source files to the destination.
-func (c Copier) Run() (result interface{}, err error) {
+func (c Copier) Run() (interface{}, Status, error) {
 	// Ensure destination directory exists
-	err = os.MkdirAll(c.DestDir, 0755)
+	err := os.MkdirAll(c.DestDir, 0755)
 	if err != nil {
-		return nil, err
+		return nil, Fail, err
 	}
 
 	// Find all the files
 	files, err := util.FilterWalk(c.SourceDir, c.Filter, c.Since, c.Until)
 	if err != nil {
-		return nil, err
+		return nil, Fail, err
 	}
 
 	// Copy the files
 	for _, s := range files {
-		err := util.CopyDir(c.DestDir, s)
+		err = util.CopyDir(c.DestDir, s)
 		if err != nil {
-			return nil, err
+			return nil, Fail, err
 		}
 	}
 
-	return files, nil
+	return files, Success, nil
 }

--- a/seeker/httper.go
+++ b/seeker/httper.go
@@ -20,6 +20,11 @@ func NewHTTPer(client *client.APIClient, path string) *Seeker {
 	}
 }
 
-func (h HTTPer) Run() (interface{}, error) {
-	return h.Client.Get(h.Path)
+// Run executes a GET request to the Path using the Client
+func (h HTTPer) Run() (interface{}, Status, error) {
+	result, err := h.Client.Get(h.Path)
+	if err != nil {
+		return result, Unknown, err
+	}
+	return result, Success, nil
 }

--- a/seeker/seeker.go
+++ b/seeker/seeker.go
@@ -5,12 +5,17 @@ import (
 	"path/filepath"
 )
 
-// status describes the result of a seeker run
+// Status describes the result of a seeker run
 type Status string
 
 const (
+	// Success means all systems green
 	Success Status = "success"
-	Fail    Status = "fail"
+	// Fail means that we detected a known error and can conclusively say that the seeker did not complete.
+	Fail Status = "fail"
+	// Unknown means that we detected an error and the result is indeterminate (e.g. some side effect like disk or
+	//   network may or may not have completed) or we don't recognize the error. If we don't recognize the error that's
+	//   a signal to improve the error handling to account for it.
 	Unknown Status = "unknown"
 )
 

--- a/seeker/seeker_test.go
+++ b/seeker/seeker_test.go
@@ -11,12 +11,13 @@ import (
 var (
 	mockResult = "get mock'd"
 	errFake    = errors.New("uh oh a fake error")
+	testStatus = Status("test")
 )
 
 type MockRunner struct{}
 
-func (r MockRunner) Run() (interface{}, error) {
-	return mockResult, errFake
+func (r MockRunner) Run() (interface{}, Status, error) {
+	return mockResult, testStatus, errFake
 }
 
 func TestSeekerRun(t *testing.T) {

--- a/seeker/sheller.go
+++ b/seeker/sheller.go
@@ -21,14 +21,23 @@ func NewSheller(command string) *Seeker {
 	}
 }
 
-func (s *Sheller) Run() (result interface{}, err error) {
-	if s.Shell, err = util.GetShell(); err != nil {
-		return nil, err
+// Run ensures a shell exists and optimistically executes the given Command string
+func (s *Sheller) Run() (interface{}, Status, error) {
+	// Read the shell from the environment
+	shell, err := util.GetShell()
+	if err != nil {
+		return nil, Fail, err
 	}
+	s.Shell = shell
+
+	// Run the command
 	args := []string{"-c", s.Command}
 	bts, err := exec.Command(s.Shell, args...).CombinedOutput()
 	if err != nil {
-		err = fmt.Errorf("exec.Command error: %s", err)
+		// Return the stdout result even on failure
+		// TODO(mkcp): This is a good place to check for more kinds of errors
+		return string(bts), Unknown, fmt.Errorf("exec.Command error: %s", err)
 	}
-	return string(bts), err
+
+	return string(bts), Success, nil
 }


### PR DESCRIPTION
Here we:
- Declares the `seeker.Status` type and 3 `Status`es e.g.: `[]Status{Success, Fail, Unknown}`
- Add `Status` as to the return values of `Runner.Run()`
- Add `Status` to the `Seeker` struct and write it in `Seeker.Run()`
- Migrate existing seeker implementations to return a `Status`.

Following this work, we want to read each status from seekers in each Product, and report the sum of a product's statuses  via logs, Manifest, and Results.