### PR TITLE
Migrate osinfo out of hostseeker and into seeker/host

### DIFF
--- a/product/host.go
+++ b/product/host.go
@@ -4,7 +4,7 @@ import (
 	"runtime"
 
 	"github.com/hashicorp/hcdiag/seeker"
-	s "github.com/hashicorp/hcdiag/seeker"
+	"github.com/hashicorp/hcdiag/seeker/host"
 )
 
 // NewHost takes a product config and creates a Product containing all of the host's seekers.
@@ -15,16 +15,17 @@ func NewHost(cfg Config) *Product {
 }
 
 // HostSeekers checks the operating system and passes it into the seekers.
-func HostSeekers(os string) []*s.Seeker {
+func HostSeekers(os string) []*seeker.Seeker {
 	if os == "auto" {
 		os = runtime.GOOS
 	}
-	return []*s.Seeker{
+	return []*seeker.Seeker{
 		{
 			Identifier: "stats",
 			Runner: &seeker.Host{
 				OS: os,
 			},
 		},
+		host.NewOSInfo(os),
 	}
 }

--- a/product/host.go
+++ b/product/host.go
@@ -10,20 +10,21 @@ import (
 // NewHost takes a product config and creates a Product containing all of the host's seekers.
 func NewHost(cfg Config) *Product {
 	return &Product{
-		Seekers: []*s.Seeker{
-			HostSeekers(cfg.OS),
-		},
+		Seekers: HostSeekers(cfg.OS),
 	}
 }
 
-func HostSeekers(os string) *s.Seeker {
+// HostSeekers checks the operating system and passes it into the seekers.
+func HostSeekers(os string) []*s.Seeker {
 	if os == "auto" {
 		os = runtime.GOOS
 	}
-	return &s.Seeker{
-		Identifier: "stats",
-		Runner: &seeker.Host{
-			OS: os,
+	return []*s.Seeker{
+		{
+			Identifier: "stats",
+			Runner: &seeker.Host{
+				OS: os,
+			},
 		},
 	}
 }

--- a/seeker/host.go
+++ b/seeker/host.go
@@ -19,16 +19,6 @@ func (hs *Host) Run() (interface{}, Status, error) {
 	results := make(map[string]interface{})
 	var errors *multierror.Error
 
-	osInfoCmd := "uname -v"
-	if hs.OS == "windows" {
-		osInfoCmd = "systeminfo"
-	}
-	if tmpResult, err := NewCommander(osInfoCmd, "string").Run(); err != nil {
-		errors = multierror.Append(errors, err)
-	} else {
-		results["osinfo"] = tmpResult
-	}
-
 	if tmpResult, err := GetHost(); err != nil {
 		errors = multierror.Append(errors, err)
 	} else {

--- a/seeker/host/os_info.go
+++ b/seeker/host/os_info.go
@@ -1,0 +1,34 @@
+package host
+
+import (
+	"github.com/hashicorp/hcdiag/seeker"
+)
+
+var _ seeker.Runner = OSInfo{}
+
+type OSInfo struct {
+	OS      string `json:"os"`
+	command string
+}
+
+// NewOSInfo calls the utility to get information on the operating system
+func NewOSInfo(os string) *seeker.Seeker {
+	osInfoCmd := "uname -v"
+	if os == "windows" {
+		osInfoCmd = "systeminfo"
+	}
+
+	return &seeker.Seeker{
+		Identifier: osInfoCmd,
+		Runner: OSInfo{
+			OS:      os,
+			command: osInfoCmd,
+		},
+	}
+}
+
+func (o OSInfo) Run() (interface{}, seeker.Status, error) {
+	// NOTE(mkcp): This seeker can be made consistent between multiple operating systems if we parse the output of
+	//   systeminfo to match uname's scope of concerns.
+	return seeker.NewCommander(o.command, "string").Runner.Run()
+}


### PR DESCRIPTION
Let's hold off on merging this until we can discuss our release process more. Do new seekers belong in minor versions instead of patches? 