### PR TITLE
Fix invalid yaml in integration test workflow

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -2,11 +2,10 @@ name: test-integration
 on:
   push:
     branches: [main]
-  pull_request_review:
-    types: [submitted, dismissed]
-  push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+*"
+  pull_request_review:
+    types: [submitted, dismissed]
 
 jobs:
   test-functional:


### PR DESCRIPTION
This workflow hasn't been running as expected on PR review submission.  @nwchandler observed that `push:` was defined twice, making it invalid yaml, i.e.

```
$ act --list
FATA[0000] yaml: unmarshal errors:
  line 7: mapping key "push" already defined at line 3
```

after this change, at least that act command looks right:

```
$ act --list                           
Stage  Job ID           Job name         Workflow name     Workflow file         Events                  
0      golangci         lint             golangci-lint     golangci-lint.yml     push,pull_request       
0      goreleaser       goreleaser       release           release.yml           push                    
0      test-functional  test-functional  test-integration  test-integration.yml  push,pull_request_review
0      build-and-test   build-and-test   test              test.yml              push,pull_request 
```