### PR TITLE
Add error types for copier operations AND add copier test

### DIFF
--- a/seeker/copier_test.go
+++ b/seeker/copier_test.go
@@ -1,0 +1,29 @@
+package seeker
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestNewCopier(t *testing.T) {
+	src := "/testing/src"
+	dest := "/testing/dest"
+	since := time.Time{}
+	until := time.Now()
+	expect := Seeker{
+		Identifier: "copy /testing/src",
+		Runner: Copier{
+			SourceDir: "/testing/",
+			Filter:    "src",
+			DestDir:   dest,
+			Since:     since,
+			Until:     until,
+		},
+	}
+	copier := NewCopier(src, dest, since, until)
+
+	if !reflect.DeepEqual(&expect, copier) {
+		t.Errorf("unexpected copier field, expected=%#v, actual=%#v", expect, copier)
+	}
+}


### PR DESCRIPTION
2 distinct threads here from the same investigation:

Thread 1: Here we create error types for the operations that can fail in Copier.Run(), adding relevant fields like the path and files we attempted to copy.

Thread 2: Also added in a test for NewCopier. I briefly looked into testing fs operations with testing/fstest, but the file operations in `util` are a better place focus unit testing efforts (https://hashicorp.atlassian.net/browse/CORI-51). In the future a cross-platform unit test for Copier.Run() would be valuable.

Example seeker pkg error that wraps the error from `util`:
![Screen Shot 2022-04-14 at 11 32 11 AM](https://user-images.githubusercontent.com/938395/163457048-c05d4887-ba7d-4197-bd0d-f936fc02ba15.png)
 
This shows a bit of inconsistency in our logging between the agent and seekers. We ought to find good reference examples w/ hclog and see how we can match or improve on it!