### PR TITLE
add ManifestSeekers with ID, error, and Status

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -273,7 +273,7 @@ func (a *Agent) RunProducts() error {
 	return nil
 }
 
-// RecordManifest writes additional data to the agent so for serialization to manifest.json
+// RecordManifest writes additional data to the agent to serialize into manifest.json
 func (a *Agent) RecordManifest() {
 	for name, p := range a.products {
 		for _, s := range p.Seekers {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -33,13 +33,17 @@ type Agent struct {
 	NumErrors   int       `json:"num_errors"`
 	NumSeekers  int       `json:"num_seekers"`
 	Config      Config    `json:"configuration"`
+	// ManifestSeekers holds a slice of seekers with a subset of normal seekers' fields so we can safely render them in
+	// `manifest.json`
+	ManifestSeekers map[string][]ManifestSeeker `json:"seekers"`
 }
 
 func NewAgent(config Config, logger hclog.Logger) *Agent {
 	a := Agent{
-		l:       logger,
-		results: make(map[string]map[string]interface{}),
-		Config:  config,
+		l:               logger,
+		results:         make(map[string]map[string]interface{}),
+		Config:          config,
+		ManifestSeekers: make(map[string][]ManifestSeeker),
 	}
 	return &a
 }
@@ -105,6 +109,11 @@ func (a *Agent) Run() []error {
 		errs = append(errs, errProduct)
 		a.l.Error("Failed running Products", "error", errProduct)
 	}
+
+	// Record metadata
+	// Build seeker metadata
+	a.l.Info("Recording manifest")
+	a.RecordManifest()
 
 	// Execution finished, write our results and cleanup
 	a.recordEnd()
@@ -262,6 +271,20 @@ func (a *Agent) RunProducts() error {
 	}
 
 	return nil
+}
+
+// RecordManifest writes additional data to the agent so for serialization to manifest.json
+func (a *Agent) RecordManifest() {
+	for name, p := range a.products {
+		for _, s := range p.Seekers {
+			m := ManifestSeeker{
+				ID:     s.Identifier,
+				Error:  s.ErrString,
+				Status: s.Status,
+			}
+			a.ManifestSeekers[name] = append(a.ManifestSeekers[name], m)
+		}
+	}
 }
 
 // WriteOutput renders the manifest and results of the diagnostics run and writes the compressed archive.

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -143,7 +143,6 @@ func TestRunProducts(t *testing.T) {
 	pCfg := product.Config{OS: "auto"}
 	p := make(map[string]*product.Product)
 	p["host"] = product.NewHost(pCfg)
-	// REVIEW(mkcp): Should we adapt this to call NewAgent? This seems like a symptom of poor boundaries between Agent and Products
 	a := Agent{
 		l:        hclog.Default(),
 		products: p,

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -143,6 +143,7 @@ func TestRunProducts(t *testing.T) {
 	pCfg := product.Config{OS: "auto"}
 	p := make(map[string]*product.Product)
 	p["host"] = product.NewHost(pCfg)
+	// REVIEW(mkcp): Should we adapt this to call NewAgent? This seems like a symptom of poor boundaries between Agent and Products
 	a := Agent{
 		l:        hclog.Default(),
 		products: p,
@@ -153,6 +154,23 @@ func TestRunProducts(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, a.products, 1, "has one product")
 	assert.NotNil(t, a.products["host"], "product is under \"host\" key")
+}
+
+func TestAgent_RecordManifest(t *testing.T) {
+	t.Run("adds to MetadataSeekers when seekers exist", func(t *testing.T) {
+		// Setup
+		testProduct := "host"
+		a := NewAgent(Config{}, hclog.Default())
+		pCfg := product.Config{OS: "auto"}
+		p := make(map[string]*product.Product)
+		p[testProduct] = product.NewHost(pCfg)
+		a.products = p
+		assert.NotEmptyf(t, a.products[testProduct].Seekers, "test setup failure, no seekers available")
+
+		// Record and check
+		a.RecordManifest()
+		assert.NotEmptyf(t, a.ManifestSeekers, "no seekers metadata added to manifest")
+	})
 }
 
 func TestWriteOutput(t *testing.T) {

--- a/agent/manifest.go
+++ b/agent/manifest.go
@@ -1,0 +1,11 @@
+package agent
+
+import "github.com/hashicorp/hcdiag/seeker"
+
+// ManifestSeeker provides a subset of seeker state, specifically excluding results, so we can safely render metadata
+// about seekers without exposing customer info in manifest.json
+type ManifestSeeker struct {
+	ID     string        `json:"seeker"`
+	Error  string        `json:"error"`
+	Status seeker.Status `json:"status"`
+}


### PR DESCRIPTION
Here we add a `ManifestSeeker` type containing seeker IDs, errors, and Statuses. Then we add `Agent.RecordManifest()` which stores a `ManifestSeeker` for each seeker run in each product. This allows us to inspect seeker statuses and errors at a glance. If the error alone is insufficient for understanding what happened in the seeker, then that gives us valuable info about another error case to handle.

In the future we can use this structure to save info about seeker duration and any other fields that help us understand seekers while avoiding any sensitive data.

Here's what the data looks like for `host` and `consul`
<img width="643" alt="Screen Shot 2022-04-20 at 1 21 50 PM" src="https://user-images.githubusercontent.com/938395/164316177-a687bca2-9e55-47e2-b428-eb49ddbab009.png">

entire manifest 
```
{
    "started_at": "2022-04-20T13:20:55.707717-07:00",
    "ended_at": "2022-04-20T13:21:08.125642-07:00",
    "duration": "12.417858688 seconds",
    "num_errors": 1,
    "num_seekers": 10,
    "configuration": {
        "host_config": null,
        "products_config": null,
        "operating_system": "auto",
        "serial": false,
        "dry_run": false,
        "consul_enabled": true,
        "nomad_enabled": false,
        "terraform_ent_enabled": false,
        "vault_enabled": false,
        "since": "2022-04-17T13:20:55.707503-07:00",
        "until": "0001-01-01T00:00:00Z",
        "includes": null,
        "destination": "."
    },
    "seekers": {
        "consul": [
            {
                "seeker": "consul version",
                "error": "",
                "status": "success"
            },
            {
                "seeker": "consul debug -output=hcdiag-2022-04-20T202055Z/ConsulDebug -duration=10s -interval=5s",
                "error": "",
                "status": "success"
            },
            {
                "seeker": "GET /v1/agent/self",
                "error": "",
                "status": "success"
            },
            {
                "seeker": "GET /v1/agent/metrics",
                "error": "",
                "status": "success"
            },
            {
                "seeker": "GET /v1/catalog/datacenters",
                "error": "",
                "status": "success"
            },
            {
                "seeker": "GET /v1/catalog/services",
                "error": "",
                "status": "success"
            },
            {
                "seeker": "GET /v1/namespace",
                "error": "404 Not Found",
                "status": "unknown"
            },
            {
                "seeker": "GET /v1/status/leader",
                "error": "",
                "status": "success"
            },
            {
                "seeker": "GET /v1/status/peers",
                "error": "",
                "status": "success"
            }
        ],
        "host": [
            {
                "seeker": "stats",
                "error": "",
                "status": "success"
            }
        ]
    }
}
```