### PR TITLE
update to v0.3.0

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/hcdiag/agent"
 )
 
-const SemVer string = "0.1.3"
+const SemVer string = "0.3.0"
 
 // SeventyTwoHours represents the duration "72h" parsed in nanoseconds
 const SeventyTwoHours time.Duration = 259200000000000


### PR DESCRIPTION
We missed on main after v0.2.0 (but it is on the release branch) so I figure we skip v0.2.0 on main now and rolling forward to v0.3.0 for ongoing work.