### PR TITLE
Allow TLS Configuration on API Calls

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -401,7 +401,10 @@ func (a *Agent) Setup() (map[string]*product.Product, error) {
 	}
 	p := make(map[string]*product.Product)
 	if a.Config.Consul {
-		newConsul := product.NewConsul(cfg)
+		newConsul, err := product.NewConsul(cfg)
+		if err != nil {
+			return nil, err
+		}
 		if consul != nil {
 			customSeekers, err := customSeekers(consul, a.tmpDir)
 			if err != nil {
@@ -415,7 +418,10 @@ func (a *Agent) Setup() (map[string]*product.Product, error) {
 
 	}
 	if a.Config.Nomad {
-		newNomad := product.NewNomad(cfg)
+		newNomad, err := product.NewNomad(cfg)
+		if err != nil {
+			return nil, err
+		}
 		if nomad != nil {
 			customSeekers, err := customSeekers(nomad, a.tmpDir)
 			if err != nil {
@@ -548,7 +554,7 @@ func customSeekers(cfg *ProductConfig, tmpDir string) ([]*seeker.Seeker, error) 
 	case product.Consul:
 		c, err = client.NewConsulAPI()
 	case product.Nomad:
-		c = client.NewNomadAPI()
+		c, err = client.NewNomadAPI()
 	case product.TFE:
 		c = client.NewTFEAPI()
 	case product.Vault:

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -546,7 +546,7 @@ func customSeekers(cfg *ProductConfig, tmpDir string) ([]*seeker.Seeker, error) 
 	var err error
 	switch cfg.Name {
 	case product.Consul:
-		c = client.NewConsulAPI()
+		c, err = client.NewConsulAPI()
 	case product.Nomad:
 		c = client.NewNomadAPI()
 	case product.TFE:

--- a/client/apiclient.go
+++ b/client/apiclient.go
@@ -51,15 +51,19 @@ type TLSConfig struct {
 
 // NewAPIClient gets an API client for a product.
 func NewAPIClient(product, baseURL string, headers map[string]string, t TLSConfig) (*APIClient, error) {
-	tlsClientConfig, err := createTLSClientConfig(t)
-	if err != nil {
-		return nil, err
+	transport := http.DefaultTransport.(*http.Transport)
+
+	// If TLSConfig is set, then we need to configure the TLSClientConfig on the transport.
+	if !reflect.DeepEqual(t, TLSConfig{}) {
+		tlsClientConfig, err := createTLSClientConfig(t)
+		if err != nil {
+			return nil, err
+		}
+		transport.TLSClientConfig = tlsClientConfig
 	}
 
 	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: tlsClientConfig,
-		},
+		Transport: transport,
 	}
 
 	return &APIClient{

--- a/client/apiclient.go
+++ b/client/apiclient.go
@@ -57,7 +57,8 @@ func (t TLSConfig) IsDefault() bool {
 		len(t.CACertBytes) == 0 &&
 		t.ClientCert == "" &&
 		t.TLSServerName == "" &&
-		t.Insecure == false
+		// Check whether Insecure is false
+		!t.Insecure
 }
 
 // NewAPIClient gets an API client for a product.

--- a/client/apiclient.go
+++ b/client/apiclient.go
@@ -48,6 +48,8 @@ type TLSConfig struct {
 	Insecure bool
 }
 
+// IsDefault checks whether a TLSConfig structure has had any fields changed from their defaults.
+// If any field is non-default, it returns false; otherwise, it returns true.
 func (t TLSConfig) IsDefault() bool {
 	return t.CACert == "" &&
 		t.CAPath == "" &&
@@ -163,7 +165,6 @@ func configureHttpClientTLS(client *http.Client, t *TLSConfig) error {
 	if clientTransport.TLSClientConfig == nil {
 		clientTransport.TLSClientConfig = &tls.Config{}
 	}
-
 	clientTLSConfig := clientTransport.TLSClientConfig
 
 	if t.CACert != "" || len(t.CACertBytes) != 0 || t.CAPath != "" {

--- a/client/apiclient.go
+++ b/client/apiclient.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"reflect"
 
 	"github.com/hashicorp/go-rootcerts"
 	"github.com/hashicorp/hcdiag/util"
@@ -68,6 +69,15 @@ func NewAPIClient(product, baseURL string, headers map[string]string) *APIClient
 		BaseURL: baseURL,
 		headers: headers,
 		http:    http.DefaultClient,
+	}
+}
+
+func NewAPIClientFromHTTP(product, baseURL string, headers map[string]string, httpClient HTTPClient) *APIClient {
+	return &APIClient{
+		Product: product,
+		BaseURL: baseURL,
+		headers: headers,
+		http:    httpClient,
 	}
 }
 
@@ -152,7 +162,7 @@ func (c *APIClient) request(method string, path string, data []byte) (interface{
 
 func configureHttpClientTLS(client *http.Client, t *TLSConfig) error {
 	// We don't need to configure TLS if the TLSConfig struct is default.
-	if t.IsDefault() {
+	if !reflect.DeepEqual(*t, TLSConfig{}) {
 		return nil
 	}
 
@@ -179,9 +189,7 @@ func configureHttpClientTLS(client *http.Client, t *TLSConfig) error {
 		}
 	}
 
-	if t.Insecure {
-		clientTLSConfig.InsecureSkipVerify = true
-	}
+	clientTLSConfig.InsecureSkipVerify = t.Insecure
 
 	if t.TLSServerName != "" {
 		clientTLSConfig.ServerName = t.TLSServerName

--- a/client/apiclient_test.go
+++ b/client/apiclient_test.go
@@ -11,6 +11,8 @@ import (
 type mockHTTP struct {
 	called []*http.Request
 	resp   string
+
+	Transport *http.Transport
 }
 
 func (m *mockHTTP) Do(r *http.Request) (*http.Response, error) {
@@ -30,7 +32,10 @@ func TestAPIClientGet(t *testing.T) {
 		"special": "headeroni",
 	}
 	mock := &mockHTTP{resp: testResp}
-	c := NewAPIClient("test", testBaseURL, headers)
+	c, err := NewAPIClient("test", testBaseURL, headers, TLSConfig{})
+	if err != nil {
+		t.Errorf("NewAPIClient returned error: %s", err)
+	}
 	c.http = mock
 
 	// make the request
@@ -73,7 +78,10 @@ func TestAPIClientGetStringValue(t *testing.T) {
 	// this also implicily tests APIClient.GetValue()
 
 	mock := &mockHTTP{resp: `{"one": {"two": "three"}}`}
-	c := NewAPIClient("test", "test://local", map[string]string{})
+	c, err := NewAPIClient("test", "test://local", map[string]string{}, TLSConfig{})
+	if err != nil {
+		t.Errorf("NewAPIClient returned error: %s", err)
+	}
 	c.http = mock
 
 	resp, err := c.GetStringValue("/fake/path", "one", "two")

--- a/client/consul.go
+++ b/client/consul.go
@@ -4,7 +4,6 @@ package client
 
 import (
 	"errors"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -34,65 +33,117 @@ func NewConsulAPI() (*APIClient, error) {
 		headers["X-Consul-Token"] = token
 	}
 
-	httpClient, err := NewConsulHTTPClient()
+	t, err := NewConsulTLSConfig()
 	if err != nil {
 		return nil, err
 	}
 
-	apiClient := NewAPIClientFromHTTP("consul", addr, headers, httpClient)
+	apiClient, err := NewAPIClient("consul", addr, headers, *t)
+	if err != nil {
+		return nil, err
+	}
 
 	return apiClient, nil
 }
 
-func NewConsulHTTPClient() (*http.Client, error) {
-	tlsConfig, err := NewConsulTLSConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	httpClient, err := NewHTTPClientWithTLS(tlsConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	return httpClient, nil
-}
-
-func NewHTTPClientWithTLS(t *TLSConfig) (*http.Client, error) {
-	c := http.DefaultClient
-
-	err := configureHttpClientTLS(c, t)
-	if err != nil {
-		return nil, err
-	}
-
-	return c, nil
-}
+//func NewConsulHTTPClient() (*http.Client, error) {
+//	t, err := NewConsulTLSConfig()
+//	if err != nil {
+//		return nil, err
+//	}
+//
+//	client := http.DefaultClient
+//
+//	// We don't need to configure TLS if the TLSConfig struct is default.
+//	if reflect.DeepEqual(*t, TLSConfig{}) {
+//		return client, nil
+//	}
+//
+//	if client.Transport == nil {
+//		client.Transport = &http.Transport{
+//			TLSClientConfig: &tls.Config{},
+//		}
+//	}
+//	clientTransport := client.Transport.(*http.Transport)
+//
+//	if clientTransport.TLSClientConfig == nil {
+//		clientTransport.TLSClientConfig = &tls.Config{}
+//	}
+//	clientTLSConfig := clientTransport.TLSClientConfig
+//
+//	if t.CACert != "" || len(t.CACertBytes) != 0 || t.CAPath != "" {
+//		rootConfig := &rootcerts.Config{
+//			CAFile:        t.CACert,
+//			CACertificate: t.CACertBytes,
+//			CAPath:        t.CAPath,
+//		}
+//		if err := rootcerts.ConfigureTLS(clientTLSConfig, rootConfig); err != nil {
+//			return nil, err
+//		}
+//	}
+//
+//	clientTLSConfig.InsecureSkipVerify = t.Insecure
+//
+//	if t.TLSServerName != "" {
+//		clientTLSConfig.ServerName = t.TLSServerName
+//	}
+//
+//	var clientCert tls.Certificate
+//	foundClientCert := false
+//
+//	switch {
+//	case t.ClientCert != "" && t.ClientKey != "":
+//		var err error
+//		clientCert, err = tls.LoadX509KeyPair(t.ClientCert, t.ClientKey)
+//		if err != nil {
+//			return nil, err
+//		}
+//		foundClientCert = true
+//	case t.ClientCert != "" || t.ClientKey != "":
+//		return nil, fmt.Errorf("both client cert and client key must be provided")
+//	}
+//
+//	if foundClientCert {
+//		// We use `GetClientCertificate` here because it works with Vault, along with other products. In Vault
+//		// client authentication can use a different CA than the one used for Vault's certificate. However, it
+//		// will indicate that its CA should be used when sending the client certificate request. If the client
+//		// certificate does not share this CA, Go will fail with a "remote error: tls: bad certificate" error.
+//		// By providing an override for `GetClientCertificate`, we ensure that we send the client certificate
+//		// anytime one is requested, even if the CA does not match.
+//		//
+//		// See GitHub issue https://github.com/hashicorp/vault/issues/2946 for more context on why Vault
+//		// uses this mechanism when building their own clients.
+//		clientTLSConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+//			return &clientCert, nil
+//		}
+//	}
+//
+//	return client, nil
+//}
 
 // NewConsulTLSConfig returns a *TLSConfig object, using
 // default environment variables to build up the object.
 func NewConsulTLSConfig() (*TLSConfig, error) {
-	tlsConfig := TLSConfig{
+	shouldVerify := true
+	if v := os.Getenv(EnvConsulHttpSslVerify); v != "" {
+		// The semantics Consul uses to indicate whether verification should be done
+		// is the opposite of the `tlsConfig.Insecure` field; we negate the value indicated by
+		// EnvConsulHttpSslVerify environment variable here to align them.
+		var err error
+		shouldVerify, err = strconv.ParseBool(v)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &TLSConfig{
 		CACert:        os.Getenv(EnvConsulCaCert),
 		CAPath:        os.Getenv(EnvConsulCaPath),
 		ClientCert:    os.Getenv(EnvConsulClientCert),
 		ClientKey:     os.Getenv(EnvConsulClientKey),
 		TLSServerName: os.Getenv(EnvConsulTlsServerName),
-	}
-
-	if v := os.Getenv(EnvConsulHttpSslVerify); v != "" {
-		shouldVerify, err := strconv.ParseBool(v)
-		if err != nil {
-			return nil, err
-		}
-
-		// The semantics Consul uses to indicate whether verification should be done
-		// is the opposite of the `tlsConfig.Insecure` field; we negate the value indicated by
-		// EnvConsulHttpSslVerify environment variable here to align them.
-		tlsConfig.Insecure = !shouldVerify
-	}
-
-	return &tlsConfig, nil
+		Insecure:      !shouldVerify,
+	}, nil
 }
 
 func GetConsulLogPath(api *APIClient) (string, error) {

--- a/client/consul.go
+++ b/client/consul.go
@@ -46,89 +46,16 @@ func NewConsulAPI() (*APIClient, error) {
 	return apiClient, nil
 }
 
-//func NewConsulHTTPClient() (*http.Client, error) {
-//	t, err := NewConsulTLSConfig()
-//	if err != nil {
-//		return nil, err
-//	}
-//
-//	client := http.DefaultClient
-//
-//	// We don't need to configure TLS if the TLSConfig struct is default.
-//	if reflect.DeepEqual(*t, TLSConfig{}) {
-//		return client, nil
-//	}
-//
-//	if client.Transport == nil {
-//		client.Transport = &http.Transport{
-//			TLSClientConfig: &tls.Config{},
-//		}
-//	}
-//	clientTransport := client.Transport.(*http.Transport)
-//
-//	if clientTransport.TLSClientConfig == nil {
-//		clientTransport.TLSClientConfig = &tls.Config{}
-//	}
-//	clientTLSConfig := clientTransport.TLSClientConfig
-//
-//	if t.CACert != "" || len(t.CACertBytes) != 0 || t.CAPath != "" {
-//		rootConfig := &rootcerts.Config{
-//			CAFile:        t.CACert,
-//			CACertificate: t.CACertBytes,
-//			CAPath:        t.CAPath,
-//		}
-//		if err := rootcerts.ConfigureTLS(clientTLSConfig, rootConfig); err != nil {
-//			return nil, err
-//		}
-//	}
-//
-//	clientTLSConfig.InsecureSkipVerify = t.Insecure
-//
-//	if t.TLSServerName != "" {
-//		clientTLSConfig.ServerName = t.TLSServerName
-//	}
-//
-//	var clientCert tls.Certificate
-//	foundClientCert := false
-//
-//	switch {
-//	case t.ClientCert != "" && t.ClientKey != "":
-//		var err error
-//		clientCert, err = tls.LoadX509KeyPair(t.ClientCert, t.ClientKey)
-//		if err != nil {
-//			return nil, err
-//		}
-//		foundClientCert = true
-//	case t.ClientCert != "" || t.ClientKey != "":
-//		return nil, fmt.Errorf("both client cert and client key must be provided")
-//	}
-//
-//	if foundClientCert {
-//		// We use `GetClientCertificate` here because it works with Vault, along with other products. In Vault
-//		// client authentication can use a different CA than the one used for Vault's certificate. However, it
-//		// will indicate that its CA should be used when sending the client certificate request. If the client
-//		// certificate does not share this CA, Go will fail with a "remote error: tls: bad certificate" error.
-//		// By providing an override for `GetClientCertificate`, we ensure that we send the client certificate
-//		// anytime one is requested, even if the CA does not match.
-//		//
-//		// See GitHub issue https://github.com/hashicorp/vault/issues/2946 for more context on why Vault
-//		// uses this mechanism when building their own clients.
-//		clientTLSConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
-//			return &clientCert, nil
-//		}
-//	}
-//
-//	return client, nil
-//}
-
 // NewConsulTLSConfig returns a *TLSConfig object, using
 // default environment variables to build up the object.
 func NewConsulTLSConfig() (*TLSConfig, error) {
+	// The semantics Consul uses to indicate whether verification should be done
+	// is the opposite of the `tlsConfig.Insecure` field. So, we default shouldVerify
+	// to true, determine whether we should actually change it based on the env var,
+	// and assign the negation to the `Insecure` field in the return.
 	shouldVerify := true
+
 	if v := os.Getenv(EnvConsulHttpSslVerify); v != "" {
-		// The semantics Consul uses to indicate whether verification should be done
-		// is the opposite of the `tlsConfig.Insecure` field; we negate the value indicated by
-		// EnvConsulHttpSslVerify environment variable here to align them.
 		var err error
 		shouldVerify, err = strconv.ParseBool(v)
 		if err != nil {

--- a/client/consul.go
+++ b/client/consul.go
@@ -33,12 +33,12 @@ func NewConsulAPI() (*APIClient, error) {
 		headers["X-Consul-Token"] = token
 	}
 
-	t, err := NewConsulTLSConfig()
+	tlsConfig, err := NewConsulTLSConfig()
 	if err != nil {
 		return nil, err
 	}
 
-	apiClient, err := NewAPIClient("consul", addr, headers, *t)
+	apiClient, err := NewAPIClient("consul", addr, headers, tlsConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -46,9 +46,9 @@ func NewConsulAPI() (*APIClient, error) {
 	return apiClient, nil
 }
 
-// NewConsulTLSConfig returns a *TLSConfig object, using
+// NewConsulTLSConfig returns a TLSConfig object, using
 // default environment variables to build up the object.
-func NewConsulTLSConfig() (*TLSConfig, error) {
+func NewConsulTLSConfig() (TLSConfig, error) {
 	// The semantics Consul uses to indicate whether verification should be done
 	// is the opposite of the `tlsConfig.Insecure` field. So, we default shouldVerify
 	// to true, determine whether we should actually change it based on the env var,
@@ -59,11 +59,11 @@ func NewConsulTLSConfig() (*TLSConfig, error) {
 		var err error
 		shouldVerify, err = strconv.ParseBool(v)
 		if err != nil {
-			return nil, err
+			return TLSConfig{}, err
 		}
 	}
 
-	return &TLSConfig{
+	return TLSConfig{
 		CACert:        os.Getenv(EnvConsulCaCert),
 		CAPath:        os.Getenv(EnvConsulCaPath),
 		ClientCert:    os.Getenv(EnvConsulClientCert),

--- a/client/consul.go
+++ b/client/consul.go
@@ -34,19 +34,39 @@ func NewConsulAPI() (*APIClient, error) {
 		headers["X-Consul-Token"] = token
 	}
 
+	httpClient, err := NewConsulHTTPClient()
+	if err != nil {
+		return nil, err
+	}
+
+	apiClient := NewAPIClientFromHTTP("consul", addr, headers, httpClient)
+
+	return apiClient, nil
+}
+
+func NewConsulHTTPClient() (*http.Client, error) {
 	tlsConfig, err := NewConsulTLSConfig()
 	if err != nil {
 		return nil, err
 	}
 
-	apiClient := NewAPIClient("consul", addr, headers)
-
-	err = configureHttpClientTLS(apiClient.http.(*http.Client), tlsConfig)
+	httpClient, err := NewHTTPClientWithTLS(tlsConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	return apiClient, nil
+	return httpClient, nil
+}
+
+func NewHTTPClientWithTLS(t *TLSConfig) (*http.Client, error) {
+	c := http.DefaultClient
+
+	err := configureHttpClientTLS(c, t)
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
 }
 
 // NewConsulTLSConfig returns a *TLSConfig object, using

--- a/client/consul_test.go
+++ b/client/consul_test.go
@@ -124,8 +124,7 @@ func TestNewConsulTLSConfig(t *testing.T) {
 				require.Error(t, err, "an error was expected, but was not raised")
 			} else {
 				require.NoError(t, err, "encountered unexpected error in NewConsulTLSConfig")
-				require.NotNil(t, actual, "expected output object to not be nil")
-				require.Equal(t, tc.expected, *actual, "actual TLSConfig does not match the expected struct")
+				require.Equal(t, tc.expected, actual, "actual TLSConfig does not match the expected struct")
 			}
 		})
 	}

--- a/client/consul_test.go
+++ b/client/consul_test.go
@@ -7,7 +7,10 @@ import (
 )
 
 func TestNewConsulAPI(t *testing.T) {
-	api := NewConsulAPI()
+	api, err := NewConsulAPI()
+	if err != nil {
+		t.Errorf("encountered error from NewConsulAPI(); error: %s", err)
+	}
 
 	if api.Product != "consul" {
 		t.Errorf("expected Product to be 'consul'; got '%s'", api.Product)
@@ -22,7 +25,10 @@ func TestGetConsulLogPathPDir(t *testing.T) {
 	mock := &mockHTTP{
 		resp: `{"DebugConfig": {"Logging": {"LogFilePath": "/some/dir/"}}}`,
 	}
-	api := NewConsulAPI()
+	api, err := NewConsulAPI()
+	if err != nil {
+		t.Errorf("encountered error from NewConsulAPI(); error: %s", err)
+	}
 	api.http = mock
 
 	path, err := GetConsulLogPath(api)
@@ -40,7 +46,10 @@ func TestGetConsulLogPathPrefix(t *testing.T) {
 	mock := &mockHTTP{
 		resp: `{"DebugConfig": {"Logging": {"LogFilePath": "/some/prefix"}}}`,
 	}
-	api := NewConsulAPI()
+	api, err := NewConsulAPI()
+	if err != nil {
+		t.Errorf("encountered error from NewConsulAPI(); error: %s", err)
+	}
 	api.http = mock
 
 	path, err := GetConsulLogPath(api)

--- a/client/nomad.go
+++ b/client/nomad.go
@@ -50,23 +50,23 @@ func NewNomadAPI() (*APIClient, error) {
 // NewNomadTLSConfig returns a *TLSConfig object, using
 // default environment variables to build up the object.
 func NewNomadTLSConfig() (*TLSConfig, error) {
-	tlsConfig := TLSConfig{
+	skipVerify := false
+	if v := os.Getenv(EnvNomadSkipVerify); v != "" {
+		var err error
+		skipVerify, err = strconv.ParseBool(v)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &TLSConfig{
 		CACert:        os.Getenv(EnvNomadCaCert),
 		CAPath:        os.Getenv(EnvNomadCaPath),
 		ClientCert:    os.Getenv(EnvNomadClientCert),
 		ClientKey:     os.Getenv(EnvNomadClientKey),
 		TLSServerName: os.Getenv(EnvNomadTlsServerName),
-	}
-
-	if v := os.Getenv(EnvNomadSkipVerify); v != "" {
-		skipVerify, err := strconv.ParseBool(v)
-		if err != nil {
-			return nil, err
-		}
-		tlsConfig.Insecure = skipVerify
-	}
-
-	return &tlsConfig, nil
+		Insecure:      skipVerify,
+	}, nil
 }
 
 func GetNomadLogPath(api *APIClient) (string, error) {

--- a/client/nomad.go
+++ b/client/nomad.go
@@ -39,7 +39,7 @@ func NewNomadAPI() (*APIClient, error) {
 		return nil, err
 	}
 
-	apiClient, err := NewAPIClient("nomad", addr, headers, *tlsConfig)
+	apiClient, err := NewAPIClient("nomad", addr, headers, tlsConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -47,19 +47,19 @@ func NewNomadAPI() (*APIClient, error) {
 	return apiClient, nil
 }
 
-// NewNomadTLSConfig returns a *TLSConfig object, using
+// NewNomadTLSConfig returns a TLSConfig object, using
 // default environment variables to build up the object.
-func NewNomadTLSConfig() (*TLSConfig, error) {
+func NewNomadTLSConfig() (TLSConfig, error) {
 	skipVerify := false
 	if v := os.Getenv(EnvNomadSkipVerify); v != "" {
 		var err error
 		skipVerify, err = strconv.ParseBool(v)
 		if err != nil {
-			return nil, err
+			return TLSConfig{}, err
 		}
 	}
 
-	return &TLSConfig{
+	return TLSConfig{
 		CACert:        os.Getenv(EnvNomadCaCert),
 		CAPath:        os.Getenv(EnvNomadCaPath),
 		ClientCert:    os.Getenv(EnvNomadClientCert),

--- a/client/nomad.go
+++ b/client/nomad.go
@@ -4,7 +4,6 @@ package client
 
 import (
 	"errors"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -40,9 +39,7 @@ func NewNomadAPI() (*APIClient, error) {
 		return nil, err
 	}
 
-	apiClient := NewAPIClient("nomad", addr, headers)
-
-	err = configureHttpClientTLS(apiClient.http.(*http.Client), tlsConfig)
+	apiClient, err := NewAPIClient("nomad", addr, headers, *tlsConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/client/nomad_test.go
+++ b/client/nomad_test.go
@@ -7,7 +7,10 @@ import (
 )
 
 func TestNewNomadAPI(t *testing.T) {
-	api := NewNomadAPI()
+	api, err := NewNomadAPI()
+	if err != nil {
+		t.Errorf("encountered error from NewNomadAPI(); error: %s", err)
+	}
 
 	if api.Product != "nomad" {
 		t.Errorf("expected Product to be 'nomad'; got '%s'", api.Product)
@@ -22,7 +25,10 @@ func TestGetNomadLogPathPDir(t *testing.T) {
 	mock := &mockHTTP{
 		resp: `{"config": {"LogFile": "/some/dir/"}}`,
 	}
-	api := NewNomadAPI()
+	api, err := NewNomadAPI()
+	if err != nil {
+		t.Errorf("encountered error from NewNomadAPI(); error: %s", err)
+	}
 	api.http = mock
 
 	path, err := GetNomadLogPath(api)
@@ -40,7 +46,10 @@ func TestGetNomadLogPathPrefix(t *testing.T) {
 	mock := &mockHTTP{
 		resp: `{"config": {"LogFile": "/some/prefix"}}`,
 	}
-	api := NewNomadAPI()
+	api, err := NewNomadAPI()
+	if err != nil {
+		t.Errorf("encountered error from NewNomadAPI(); error: %s", err)
+	}
 	api.http = mock
 
 	path, err := GetNomadLogPath(api)

--- a/client/nomad_test.go
+++ b/client/nomad_test.go
@@ -124,8 +124,7 @@ func TestNewNomadTLSConfig(t *testing.T) {
 				require.Error(t, err, "an error was expected, but was not raised")
 			} else {
 				require.NoError(t, err, "encountered unexpected error in NewConsulTLSConfig")
-				require.NotNil(t, actual, "expected output object to not be nil")
-				require.Equal(t, tc.expected, *actual, "actual TLSConfig does not match the expected struct")
+				require.Equal(t, tc.expected, actual, "actual TLSConfig does not match the expected struct")
 			}
 		})
 	}

--- a/client/tfe.go
+++ b/client/tfe.go
@@ -21,5 +21,9 @@ func NewTFEAPI() *APIClient {
 		headers["Authorization"] = "Bearer " + token
 	}
 
-	return NewAPIClient("terraform-ent", addr, headers)
+	apiClient, err := NewAPIClient("terraform-ent", addr, headers, TLSConfig{})
+	if err != nil {
+		return nil
+	}
+	return apiClient
 }

--- a/client/vault.go
+++ b/client/vault.go
@@ -5,7 +5,6 @@ package client
 import (
 	"errors"
 	"io/ioutil"
-	"net/http"
 	"os"
 	"strconv"
 
@@ -54,9 +53,7 @@ func NewVaultAPI() (*APIClient, error) {
 		return nil, err
 	}
 
-	apiClient := NewAPIClient("vault", addr, headers)
-
-	err = configureHttpClientTLS(apiClient.http.(*http.Client), tlsConfig)
+	apiClient, err := NewAPIClient("vault", addr, headers, *tlsConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/client/vault.go
+++ b/client/vault.go
@@ -5,6 +5,7 @@ package client
 import (
 	"errors"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"strconv"
 
@@ -48,7 +49,19 @@ func NewVaultAPI() (*APIClient, error) {
 	}
 	headers["X-Vault-Token"] = token
 
-	return NewAPIClient("vault", addr, headers), nil
+	tlsConfig, err := NewVaultTLSConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	apiClient := NewAPIClient("vault", addr, headers)
+
+	err = configureHttpClientTLS(apiClient.http.(*http.Client), tlsConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return apiClient, nil
 }
 
 // NewVaultTLSConfig returns a *TLSConfig object, using

--- a/client/vault.go
+++ b/client/vault.go
@@ -53,7 +53,7 @@ func NewVaultAPI() (*APIClient, error) {
 		return nil, err
 	}
 
-	apiClient, err := NewAPIClient("vault", addr, headers, *tlsConfig)
+	apiClient, err := NewAPIClient("vault", addr, headers, tlsConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -61,19 +61,19 @@ func NewVaultAPI() (*APIClient, error) {
 	return apiClient, nil
 }
 
-// NewVaultTLSConfig returns a *TLSConfig object, using
+// NewVaultTLSConfig returns a TLSConfig object, using
 // default environment variables to build up the object.
-func NewVaultTLSConfig() (*TLSConfig, error) {
+func NewVaultTLSConfig() (TLSConfig, error) {
 	skipVerify := false
 	if v := os.Getenv(EnvVaultSkipVerify); v != "" {
 		var err error
 		skipVerify, err = strconv.ParseBool(v)
 		if err != nil {
-			return nil, err
+			return TLSConfig{}, err
 		}
 	}
 
-	return &TLSConfig{
+	return TLSConfig{
 		CACert:        os.Getenv(EnvVaultCaCert),
 		CAPath:        os.Getenv(EnvVaultCaPath),
 		ClientCert:    os.Getenv(EnvVaultClientCert),

--- a/client/vault.go
+++ b/client/vault.go
@@ -64,23 +64,23 @@ func NewVaultAPI() (*APIClient, error) {
 // NewVaultTLSConfig returns a *TLSConfig object, using
 // default environment variables to build up the object.
 func NewVaultTLSConfig() (*TLSConfig, error) {
-	tlsConfig := TLSConfig{
+	skipVerify := false
+	if v := os.Getenv(EnvVaultSkipVerify); v != "" {
+		var err error
+		skipVerify, err = strconv.ParseBool(v)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &TLSConfig{
 		CACert:        os.Getenv(EnvVaultCaCert),
 		CAPath:        os.Getenv(EnvVaultCaPath),
 		ClientCert:    os.Getenv(EnvVaultClientCert),
 		ClientKey:     os.Getenv(EnvVaultClientKey),
 		TLSServerName: os.Getenv(EnvVaultTlsServerName),
-	}
-
-	if v := os.Getenv(EnvVaultSkipVerify); v != "" {
-		skipVerify, err := strconv.ParseBool(v)
-		if err != nil {
-			return nil, err
-		}
-		tlsConfig.Insecure = skipVerify
-	}
-
-	return &tlsConfig, nil
+		Insecure:      skipVerify,
+	}, nil
 }
 
 func GetVaultAuditLogPath(api *APIClient) (string, error) {

--- a/client/vault_test.go
+++ b/client/vault_test.go
@@ -113,8 +113,7 @@ func TestNewVaultTLSConfig(t *testing.T) {
 				require.Error(t, err, "an error was expected, but was not raised")
 			} else {
 				require.NoError(t, err, "encountered unexpected error in NewConsulTLSConfig")
-				require.NotNil(t, actual, "expected output object to not be nil")
-				require.Equal(t, tc.expected, *actual, "actual TLSConfig does not match the expected struct")
+				require.Equal(t, tc.expected, actual, "actual TLSConfig does not match the expected struct")
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/hashicorp/go-hclog v0.16.2
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/hashicorp/go-rootcerts v1.0.2
 	github.com/hashicorp/hcl/v2 v2.11.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-ps v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/hashicorp/go-hclog v0.16.2 h1:K4ev2ib4LdQETX5cSZBG0DVLk1jwGqSPXBjdah3
 github.com/hashicorp/go-hclog v0.16.2/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5Oi2viEzc=
+github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/hcl/v2 v2.11.1 h1:yTyWcXcm9XB0TEkyU/JCRU6rYy4K+mgLtzn2wlrJbcc=
 github.com/hashicorp/hcl/v2 v2.11.1/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=

--- a/product/consul.go
+++ b/product/consul.go
@@ -15,16 +15,22 @@ const (
 )
 
 // NewConsul takes a product config and creates a Product with all of Consul's default seekers
-func NewConsul(cfg Config) *Product {
-	return &Product{
-		Seekers: ConsulSeekers(cfg.TmpDir, cfg.Since, cfg.Until),
+func NewConsul(cfg Config) (*Product, error) {
+	seekers, err := ConsulSeekers(cfg.TmpDir, cfg.Since, cfg.Until)
+	if err != nil {
+		return nil, err
 	}
+	return &Product{
+		Seekers: seekers,
+	}, nil
 }
 
 // ConsulSeekers seek information about Consul.
-func ConsulSeekers(tmpDir string, since, until time.Time) []*s.Seeker {
-	// todo: handle error
-	api, _ := client.NewConsulAPI()
+func ConsulSeekers(tmpDir string, since, until time.Time) ([]*s.Seeker, error) {
+	api, err := client.NewConsulAPI()
+	if err != nil {
+		return nil, err
+	}
 
 	seekers := []*s.Seeker{
 		s.NewCommander("consul version", "string"),
@@ -50,5 +56,5 @@ func ConsulSeekers(tmpDir string, since, until time.Time) []*s.Seeker {
 		seekers = append(seekers, journald)
 	}
 
-	return seekers
+	return seekers, nil
 }

--- a/product/consul.go
+++ b/product/consul.go
@@ -23,7 +23,8 @@ func NewConsul(cfg Config) *Product {
 
 // ConsulSeekers seek information about Consul.
 func ConsulSeekers(tmpDir string, since, until time.Time) []*s.Seeker {
-	api := client.NewConsulAPI()
+	// todo: handle error
+	api, _ := client.NewConsulAPI()
 
 	seekers := []*s.Seeker{
 		s.NewCommander("consul version", "string"),

--- a/product/nomad.go
+++ b/product/nomad.go
@@ -17,15 +17,22 @@ const (
 )
 
 // NewNomad takes a product config and creates a Product with all of Nomad's default seekers
-func NewNomad(cfg Config) *Product {
-	return &Product{
-		Seekers: NomadSeekers(cfg.TmpDir, cfg.Since, cfg.Until),
+func NewNomad(cfg Config) (*Product, error) {
+	seekers, err := NomadSeekers(cfg.TmpDir, cfg.Since, cfg.Until)
+	if err != nil {
+		return nil, err
 	}
+	return &Product{
+		Seekers: seekers,
+	}, nil
 }
 
 // NomadSeekers seek information about Nomad.
-func NomadSeekers(tmpDir string, since, until time.Time) []*s.Seeker {
-	api := client.NewNomadAPI()
+func NomadSeekers(tmpDir string, since, until time.Time) ([]*s.Seeker, error) {
+	api, err := client.NewNomadAPI()
+	if err != nil {
+		return nil, err
+	}
 
 	seekers := []*s.Seeker{
 		s.NewCommander("nomad version", "string"),
@@ -49,5 +56,5 @@ func NomadSeekers(tmpDir string, since, until time.Time) []*s.Seeker {
 		seekers = append(seekers, journald)
 	}
 
-	return seekers
+	return seekers, nil
 }


### PR DESCRIPTION
This merge allows Consul, Vault, and Nomad API calls to use TLS, with configuration settings provided using standard environment variables for each product. It builds on the work previously merged from PR #99.