### PR TITLE
Add error types to Sheller and Commander

### DIFF
--- a/seeker/commander.go
+++ b/seeker/commander.go
@@ -17,7 +17,10 @@ type Commander struct {
 func NewCommander(command string, format string) *Seeker {
 	return &Seeker{
 		Identifier: command,
-		Runner:     Commander{Command: command, format: format},
+		Runner: Commander{
+			Command: command,
+			format:  format,
+		},
 	}
 }
 
@@ -34,7 +37,7 @@ func (c Commander) Run() (interface{}, Status, error) {
 	// Execute command
 	bts, err := exec.Command(cmd, args...).CombinedOutput()
 	if err != nil {
-		return string(bts), Unknown, CommandExecError{c.Command, c.format, err}
+		return string(bts), Unknown, CommandExecError{command: c.Command, format: c.format, err: err}
 	}
 
 	// Parse result
@@ -46,11 +49,11 @@ func (c Commander) Run() (interface{}, Status, error) {
 	case c.format == "json":
 		if err := json.Unmarshal(bts, &result); err != nil {
 			// Return the command's response even if we can't parse it as json
-			return string(bts), Unknown, UnmarshalError{c.Command, err}
+			return string(bts), Unknown, UnmarshalError{command: c.Command, err: err}
 		}
 
 	default:
-		return result, Fail, FormatUnknownError{c.Command, c.format}
+		return result, Fail, FormatUnknownError{command: c.Command, format: c.format}
 	}
 
 	return result, Success, nil

--- a/seeker/commander.go
+++ b/seeker/commander.go
@@ -34,7 +34,7 @@ func (c Commander) Run() (interface{}, Status, error) {
 	// Execute command
 	bts, err := exec.Command(cmd, args...).CombinedOutput()
 	if err != nil {
-		return string(bts), Unknown, ExecError{c.Command, c.format, err}
+		return string(bts), Unknown, CommandExecError{c.Command, c.format, err}
 	}
 
 	// Parse result
@@ -56,17 +56,17 @@ func (c Commander) Run() (interface{}, Status, error) {
 	return result, Success, nil
 }
 
-type ExecError struct {
+type CommandExecError struct {
 	command string
 	format  string
 	err     error
 }
 
-func (e ExecError) Error() string {
+func (e CommandExecError) Error() string {
 	return fmt.Sprintf("exec error, command=%s, format=%s, error=%s", e.command, e.format, e.err.Error())
 }
 
-func (e ExecError) Unwrap() error {
+func (e CommandExecError) Unwrap() error {
 	return e.err
 }
 

--- a/seeker/commander_test.go
+++ b/seeker/commander_test.go
@@ -1,9 +1,7 @@
 package seeker
 
 import (
-	"fmt"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -59,16 +57,12 @@ func TestCommanderRunError(t *testing.T) {
 	// we should get the command's error output
 	assert.Contains(t, out, "No such file")
 
-	// and the error from os/exec.Command()
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "exec.Command error:")
-	}
+	// and an error
+	assert.Error(t, err)
 }
 
 func TestCommanderBadJSON(t *testing.T) {
 	c := NewCommander(`echo {"bad",}`, "json")
 	_, err := c.Run()
-	if !strings.Contains(fmt.Sprintf("%s", err), "json.Unmarshal error") {
-		t.Errorf("got unexpected error instead of json.Unmarshal: \"%s\"", err)
-	}
+	assert.Errorf(t, err, "commander.Run() should error on bad json")
 }

--- a/seeker/sheller.go
+++ b/seeker/sheller.go
@@ -35,9 +35,25 @@ func (s *Sheller) Run() (interface{}, Status, error) {
 	bts, err := exec.Command(s.Shell, args...).CombinedOutput()
 	if err != nil {
 		// Return the stdout result even on failure
-		// TODO(mkcp): This is a good place to check for more kinds of errors
-		return string(bts), Unknown, fmt.Errorf("exec.Command error: %s", err)
+		// TODO(mkcp): This is a good place to switch on exec.Command errors and provide better guidance.
+		return string(bts), Unknown, ShellExecError{
+			command: s.Command,
+			err:     err,
+		}
 	}
 
 	return string(bts), Success, nil
+}
+
+type ShellExecError struct {
+	command string
+	err     error
+}
+
+func (e ShellExecError) Error() string {
+	return fmt.Sprintf("exec error, command=%s, error=%s", e.command, e.err.Error())
+}
+
+func (e ShellExecError) Unwrap() error {
+	return e.err
 }


### PR DESCRIPTION
In this PR we add error types that identify the known failure cases in Commander and Seeker and print out helpful seeker-specific fields in the error message. We also make sure that we're not matching specific tests in the error messages via https://github.com/golang/go/wiki/TestComments#test-error-semantics