### PR TITLE
add log/docker seeker

### DIFF
--- a/product/consul.go
+++ b/product/consul.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/hcdiag/client"
 	s "github.com/hashicorp/hcdiag/seeker"
+	logs "github.com/hashicorp/hcdiag/seeker/log"
 )
 
 const (
@@ -43,6 +44,8 @@ func ConsulSeekers(tmpDir string, since, until time.Time) ([]*s.Seeker, error) {
 		s.NewHTTPer(api, "/v1/namespace"),
 		s.NewHTTPer(api, "/v1/status/leader"),
 		s.NewHTTPer(api, "/v1/status/peers"),
+
+		logs.NewDocker("consul", tmpDir, since, until),
 	}
 
 	// try to detect log location to copy

--- a/product/consul.go
+++ b/product/consul.go
@@ -45,7 +45,7 @@ func ConsulSeekers(tmpDir string, since, until time.Time) ([]*s.Seeker, error) {
 		s.NewHTTPer(api, "/v1/status/leader"),
 		s.NewHTTPer(api, "/v1/status/peers"),
 
-		logs.NewDocker("consul", tmpDir, since, until),
+		logs.NewDocker("consul", tmpDir, since),
 	}
 
 	// try to detect log location to copy

--- a/product/nomad.go
+++ b/product/nomad.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/hcdiag/client"
 	s "github.com/hashicorp/hcdiag/seeker"
+	logs "github.com/hashicorp/hcdiag/seeker/log"
 )
 
 const (
@@ -43,6 +44,8 @@ func NomadSeekers(tmpDir string, since, until time.Time) ([]*s.Seeker, error) {
 		s.NewHTTPer(api, "/v1/agent/members?stale=true"),
 		s.NewHTTPer(api, "/v1/operator/autopilot/configuration?stale=true"),
 		s.NewHTTPer(api, "/v1/operator/raft/configuration?stale=true"),
+
+		logs.NewDocker("nomad", tmpDir, since, until),
 	}
 
 	// try to detect log location to copy

--- a/product/nomad.go
+++ b/product/nomad.go
@@ -45,7 +45,7 @@ func NomadSeekers(tmpDir string, since, until time.Time) ([]*s.Seeker, error) {
 		s.NewHTTPer(api, "/v1/operator/autopilot/configuration?stale=true"),
 		s.NewHTTPer(api, "/v1/operator/raft/configuration?stale=true"),
 
-		logs.NewDocker("nomad", tmpDir, since, until),
+		logs.NewDocker("nomad", tmpDir, since),
 	}
 
 	// try to detect log location to copy

--- a/product/vault.go
+++ b/product/vault.go
@@ -42,7 +42,7 @@ func VaultSeekers(tmpDir string, since, until time.Time) ([]*s.Seeker, error) {
 		s.NewCommander("vault read sys/host-info -format=json", "json"),
 		s.NewCommander(fmt.Sprintf("vault debug -output=%s/VaultDebug.tar.gz -duration=%ds", tmpDir, DefaultDebugSeconds), "string"),
 
-		logs.NewDocker("vault", tmpDir, since, until),
+		logs.NewDocker("vault", tmpDir, since),
 	}
 
 	// try to detect log location to copy

--- a/product/vault.go
+++ b/product/vault.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"time"
 
+	logs "github.com/hashicorp/hcdiag/seeker/log"
+
 	"github.com/hashicorp/hcdiag/client"
 	s "github.com/hashicorp/hcdiag/seeker"
 )
@@ -39,6 +41,8 @@ func VaultSeekers(tmpDir string, since, until time.Time) ([]*s.Seeker, error) {
 		s.NewCommander("vault read sys/seal-status -format=json", "json"),
 		s.NewCommander("vault read sys/host-info -format=json", "json"),
 		s.NewCommander(fmt.Sprintf("vault debug -output=%s/VaultDebug.tar.gz -duration=%ds", tmpDir, DefaultDebugSeconds), "string"),
+
+		logs.NewDocker("vault", tmpDir, since, until),
 	}
 
 	// try to detect log location to copy

--- a/seeker/log/docker.go
+++ b/seeker/log/docker.go
@@ -1,0 +1,99 @@
+package log
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/hcdiag/seeker"
+)
+
+var _ seeker.Runner = Docker{}
+
+// NewDocker returns a seeker with an identifier and fully configured docker runner
+func NewDocker(container, destDir string, since, until time.Time) *seeker.Seeker {
+	return &seeker.Seeker{
+		Identifier: "log/docker " + container,
+		Runner: &Docker{
+			Container: container,
+			DestDir:   destDir,
+			Since:     since,
+			Until:     until,
+		},
+	}
+}
+
+// Docker allows logs to be retrieved for a docker container
+type Docker struct {
+	// Container is the name of the docker container to get logs from
+	Container string
+	// DestDir is the directory we will write the logs to
+	DestDir string
+	// Since marks the beginning of the time range to include logs
+	Since time.Time
+	// Until is not implemented yet, and is always "now"
+	Until time.Time
+}
+
+// Run executes the runner
+func (d Docker) Run() (interface{}, seeker.Status, error) {
+	// Check that docker exists
+	checkResult, _, err := seeker.NewSheller("docker version").Runner.Run()
+	if err != nil {
+		return checkResult, seeker.Fail, DockerNotFoundError{
+			container: d.Container,
+			err:       err,
+		}
+	}
+
+	// Retrieve logs
+	cmd := DockerLogCmd(d.Container, d.DestDir, d.Since)
+	logResult, status, err := seeker.NewSheller(cmd).Runner.Run()
+	// NOTE(mkcp): If the container does not exist, docker will exit non-zero and it'll surface as a ShellExecError.
+	//  The result actionably states that the container wasn't found. In the future we may want to scrub the result
+	//  and only return an actionable error message
+	if err != nil {
+		return logResult, status, err
+	}
+	if logResult == "" {
+		return logResult, seeker.Unknown, DockerNoLogsError{container: d.Container}
+	}
+
+	return logResult, seeker.Success, nil
+}
+
+func DockerLogCmd(container, destDir string, since time.Time) string {
+	var sinceFlag string
+	if !since.IsZero() {
+		sinceFlag = fmt.Sprintf(" --since %s", since.Format(time.RFC3339))
+	}
+
+	// Add our write destination
+	dest := fmt.Sprintf("%s/docker-%s.log", destDir, container)
+
+	// Compose the service name with flags and write to dest
+	cmd := fmt.Sprintf("docker logs --timestamps%s %s > %s", sinceFlag, container, dest)
+	return cmd
+}
+
+var _ error = DockerNotFoundError{}
+
+type DockerNotFoundError struct {
+	container string
+	err       error
+}
+
+func (e DockerNotFoundError) Error() string {
+	return fmt.Sprintf("docker not found, container=%s, error=%s", e.container, e.err)
+}
+
+func (e DockerNotFoundError) Unwrap() error {
+	return e.err
+}
+
+type DockerNoLogsError struct {
+	container string
+}
+
+func (e DockerNoLogsError) Error() string {
+	return fmt.Sprintf("docker container found but results were empty, container=%s", e.container)
+}

--- a/seeker/log/docker.go
+++ b/seeker/log/docker.go
@@ -10,14 +10,13 @@ import (
 var _ seeker.Runner = Docker{}
 
 // NewDocker returns a seeker with an identifier and fully configured docker runner
-func NewDocker(container, destDir string, since, until time.Time) *seeker.Seeker {
+func NewDocker(container, destDir string, since time.Time) *seeker.Seeker {
 	return &seeker.Seeker{
 		Identifier: "log/docker " + container,
 		Runner: &Docker{
 			Container: container,
 			DestDir:   destDir,
 			Since:     since,
-			Until:     until,
 		},
 	}
 }
@@ -30,8 +29,6 @@ type Docker struct {
 	DestDir string
 	// Since marks the beginning of the time range to include logs
 	Since time.Time
-	// Until is not implemented yet, and is always "now"
-	Until time.Time
 }
 
 // Run executes the runner

--- a/seeker/log/docker_test.go
+++ b/seeker/log/docker_test.go
@@ -1,0 +1,51 @@
+package log
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDockerLogCmd(t *testing.T) {
+	testTable := []struct {
+		desc    string
+		name    string
+		destDir string
+		since   time.Time
+		until   time.Time
+		expect  string
+	}{
+		{
+			desc:    "DockerLogCmd() with since",
+			name:    "with-since",
+			destDir: "/testing/test",
+			since:   time.Date(1, 1, 1, 1, 1, 1, 1, &time.Location{}),
+			expect: "docker logs --timestamps --since 0001-01-01T01:01:01Z with-since " +
+				"> /testing/test/docker-with-since.log",
+		},
+		{
+			desc:    "DockerLogCmd() without since",
+			name:    "no-since",
+			destDir: "/testing/test",
+			since:   time.Time{},
+			expect:  "docker logs --timestamps no-since > /testing/test/docker-no-since.log",
+		},
+		{
+			desc:    "DockerLogCmd() with until does nothing",
+			name:    "ignore-until",
+			destDir: "/testing/test",
+			until:   time.Date(1, 1, 1, 1, 1, 1, 1, &time.Location{}),
+			expect:  "docker logs --timestamps ignore-until > /testing/test/docker-ignore-until.log",
+		},
+	}
+
+	for _, tc := range testTable {
+		result := DockerLogCmd(tc.name, tc.destDir, tc.since)
+		assert.Equal(t, tc.expect, result)
+	}
+}
+
+func TestDocker_Run(t *testing.T) {
+	t.Skip("TestDocker_Run not implemented yet")
+}


### PR DESCRIPTION
Added a seeker that checks if docker if available on the machine, and grabs logs from the given image name (currently called container, which docker has some fuzzy matching for). We also check if logs are empty in case nothing shows up in the time range.

While this is a good building block, there's going to be cases where there are many containers on a machine that are relevant and we need to grab logs for. One path forward is that we grab and write log files from _all_ containers that contain the product name.