### PR TITLE
Add APIConfig Struct

### DIFF
--- a/client/apiclient.go
+++ b/client/apiclient.go
@@ -18,37 +18,6 @@ type HTTPClient interface {
 	Do(*http.Request) (*http.Response, error)
 }
 
-// TLSConfig contains the parameters needed to configure TLS on the HTTP client
-// used to communicate with an API.
-type TLSConfig struct {
-	// CACert is the path to a PEM-encoded CA cert file to use to verify the
-	// server SSL certificate. It takes precedence over CACertBytes
-	// and CAPath.
-	CACert string
-
-	// CACertBytes is a PEM-encoded certificate or bundle. It takes precedence
-	// over CAPath.
-	CACertBytes []byte
-
-	// CAPath is the path to a directory of PEM-encoded CA cert files to verify
-	// the server SSL certificate.
-	CAPath string
-
-	// ClientCert is the path to the certificate for communication
-	ClientCert string
-
-	// ClientKey is the path to the private key for communication
-	ClientKey string
-
-	// TLSServerName, if set, is used to set the SNI host when connecting via
-	// TLS.
-	TLSServerName string
-
-	// Insecure enables or disables SSL verification. Setting to `true` is highly
-	// discouraged.
-	Insecure bool
-}
-
 // NewAPIClient gets an API client for a product.
 func NewAPIClient(cfg APIConfig) (*APIClient, error) {
 	transportConfig := httpTransportConfig{
@@ -68,85 +37,6 @@ func NewAPIClient(cfg APIConfig) (*APIClient, error) {
 		APIConfig: cfg,
 		http:      client,
 	}, nil
-}
-
-type httpTransportConfig struct {
-	tlsConfig         TLSConfig
-	tlsConfigFunction func(config TLSConfig) (*tls.Config, error)
-}
-
-// newHTTPTransport builds a *http.Transport beginning with a clone of http.DefaultTransport
-// and then applying changes described by an input parameter httpTransportConfig.
-func newHTTPTransport(tc httpTransportConfig) (*http.Transport, error) {
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-
-	// If TLSConfig is set, then we need to configure the TLSClientConfig on the transport.
-	if !reflect.DeepEqual(tc.tlsConfig, TLSConfig{}) {
-		if tc.tlsConfigFunction == nil {
-			tc.tlsConfigFunction = createTLSClientConfig
-		}
-		tlsClientConfig, err := tc.tlsConfigFunction(tc.tlsConfig)
-		if err != nil {
-			return nil, err
-		}
-		transport.TLSClientConfig = tlsClientConfig
-	}
-	return transport, nil
-}
-
-func createTLSClientConfig(t TLSConfig) (*tls.Config, error) {
-	tlsClientConfig := &tls.Config{}
-
-	// If the input TLSConfig object is default, we do not need to update tlsClientConfig.
-	if reflect.DeepEqual(t, TLSConfig{}) {
-		return tlsClientConfig, nil
-	}
-
-	tlsClientConfig.InsecureSkipVerify = t.Insecure
-	tlsClientConfig.ServerName = t.TLSServerName
-
-	if t.CACert != "" || len(t.CACertBytes) != 0 || t.CAPath != "" {
-		rootConfig := &rootcerts.Config{
-			CAFile:        t.CACert,
-			CACertificate: t.CACertBytes,
-			CAPath:        t.CAPath,
-		}
-		if err := rootcerts.ConfigureTLS(tlsClientConfig, rootConfig); err != nil {
-			return nil, err
-		}
-	}
-
-	var clientCert tls.Certificate
-	foundClientCert := false
-
-	switch {
-	case t.ClientCert != "" && t.ClientKey != "":
-		var err error
-		clientCert, err = tls.LoadX509KeyPair(t.ClientCert, t.ClientKey)
-		if err != nil {
-			return nil, err
-		}
-		foundClientCert = true
-	case t.ClientCert != "" || t.ClientKey != "":
-		return nil, fmt.Errorf("both client cert and client key must be provided")
-	}
-
-	if foundClientCert {
-		// We use `GetClientCertificate` here because it works with Vault, along with other products. In Vault
-		// client authentication can use a different CA than the one used for Vault's certificate. However, it
-		// will indicate that its CA should be used when sending the client certificate request. If the client
-		// certificate does not share this CA, Go will fail with a "remote error: tls: bad certificate" error.
-		// By providing an override for `GetClientCertificate`, we ensure that we send the client certificate
-		// anytime one is requested, even if the CA does not match.
-		//
-		// See GitHub issue https://github.com/hashicorp/vault/issues/2946 for more context on why Vault
-		// uses this mechanism when building their own clients.
-		tlsClientConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
-			return &clientCert, nil
-		}
-	}
-
-	return tlsClientConfig, nil
 }
 
 // APIConfig contains the configuration details for an APIClient.
@@ -234,4 +124,114 @@ func (c *APIClient) request(method string, path string, data []byte) (interface{
 	}
 
 	return iface, err
+}
+
+// TLSConfig contains the parameters needed to configure TLS on the HTTP client
+// used to communicate with an API.
+type TLSConfig struct {
+	// CACert is the path to a PEM-encoded CA cert file to use to verify the
+	// server SSL certificate. It takes precedence over CACertBytes
+	// and CAPath.
+	CACert string
+
+	// CACertBytes is a PEM-encoded certificate or bundle. It takes precedence
+	// over CAPath.
+	CACertBytes []byte
+
+	// CAPath is the path to a directory of PEM-encoded CA cert files to verify
+	// the server SSL certificate.
+	CAPath string
+
+	// ClientCert is the path to the certificate for communication
+	ClientCert string
+
+	// ClientKey is the path to the private key for communication
+	ClientKey string
+
+	// TLSServerName, if set, is used to set the SNI host when connecting via
+	// TLS.
+	TLSServerName string
+
+	// Insecure enables or disables SSL verification. Setting to `true` is highly
+	// discouraged.
+	Insecure bool
+}
+
+func createTLSClientConfig(t TLSConfig) (*tls.Config, error) {
+	tlsClientConfig := &tls.Config{}
+
+	// If the input TLSConfig object is default, we do not need to update tlsClientConfig.
+	if reflect.DeepEqual(t, TLSConfig{}) {
+		return tlsClientConfig, nil
+	}
+
+	tlsClientConfig.InsecureSkipVerify = t.Insecure
+	tlsClientConfig.ServerName = t.TLSServerName
+
+	if t.CACert != "" || len(t.CACertBytes) != 0 || t.CAPath != "" {
+		rootConfig := &rootcerts.Config{
+			CAFile:        t.CACert,
+			CACertificate: t.CACertBytes,
+			CAPath:        t.CAPath,
+		}
+		if err := rootcerts.ConfigureTLS(tlsClientConfig, rootConfig); err != nil {
+			return nil, err
+		}
+	}
+
+	var clientCert tls.Certificate
+	foundClientCert := false
+
+	switch {
+	case t.ClientCert != "" && t.ClientKey != "":
+		var err error
+		clientCert, err = tls.LoadX509KeyPair(t.ClientCert, t.ClientKey)
+		if err != nil {
+			return nil, err
+		}
+		foundClientCert = true
+	case t.ClientCert != "" || t.ClientKey != "":
+		return nil, fmt.Errorf("both client cert and client key must be provided")
+	}
+
+	if foundClientCert {
+		// We use `GetClientCertificate` here because it works with Vault, along with other products. In Vault
+		// client authentication can use a different CA than the one used for Vault's certificate. However, it
+		// will indicate that its CA should be used when sending the client certificate request. If the client
+		// certificate does not share this CA, Go will fail with a "remote error: tls: bad certificate" error.
+		// By providing an override for `GetClientCertificate`, we ensure that we send the client certificate
+		// anytime one is requested, even if the CA does not match.
+		//
+		// See GitHub issue https://github.com/hashicorp/vault/issues/2946 for more context on why Vault
+		// uses this mechanism when building their own clients.
+		tlsClientConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return &clientCert, nil
+		}
+	}
+
+	return tlsClientConfig, nil
+}
+
+type httpTransportConfig struct {
+	tlsConfig         TLSConfig
+	tlsConfigFunction func(config TLSConfig) (*tls.Config, error)
+}
+
+// newHTTPTransport builds a *http.Transport beginning with a clone of http.DefaultTransport
+// and then applying changes described by an input parameter httpTransportConfig.
+func newHTTPTransport(tc httpTransportConfig) (*http.Transport, error) {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+
+	// If TLSConfig is set, then we need to configure the TLSClientConfig on the transport.
+	if !reflect.DeepEqual(tc.tlsConfig, TLSConfig{}) {
+		if tc.tlsConfigFunction == nil {
+			tc.tlsConfigFunction = createTLSClientConfig
+		}
+		tlsClientConfig, err := tc.tlsConfigFunction(tc.tlsConfig)
+		if err != nil {
+			return nil, err
+		}
+		transport.TLSClientConfig = tlsClientConfig
+	}
+	return transport, nil
 }

--- a/client/apiclient.go
+++ b/client/apiclient.go
@@ -50,9 +50,9 @@ type TLSConfig struct {
 }
 
 // NewAPIClient gets an API client for a product.
-func NewAPIClient(product, baseURL string, headers map[string]string, tlsConfig TLSConfig) (*APIClient, error) {
+func NewAPIClient(cfg APIConfig) (*APIClient, error) {
 	transportConfig := httpTransportConfig{
-		tlsConfig: tlsConfig,
+		tlsConfig: cfg.TLSConfig,
 	}
 
 	transport, err := newHTTPTransport(transportConfig)
@@ -65,10 +65,8 @@ func NewAPIClient(product, baseURL string, headers map[string]string, tlsConfig 
 	}
 
 	return &APIClient{
-		Product: product,
-		BaseURL: baseURL,
-		headers: headers,
-		http:    client,
+		APIConfig: cfg,
+		http:      client,
 	}, nil
 }
 
@@ -151,13 +149,21 @@ func createTLSClientConfig(t TLSConfig) (*tls.Config, error) {
 	return tlsClientConfig, nil
 }
 
-// APIClient can make API calls.
-type APIClient struct {
-	Product string `json:"product"`
-	BaseURL string `json:"baseurl"`
+// APIConfig contains the configuration details for an APIClient.
+type APIConfig struct {
+	Product   string    `json:"product"`
+	BaseURL   string    `json:"baseurl"`
+	TLSConfig TLSConfig `json:"-"`
+
 	// headers may contain secrets, so *do not export*
 	headers map[string]string
-	http    HTTPClient
+}
+
+// APIClient can make API calls.
+type APIClient struct {
+	APIConfig
+
+	http HTTPClient
 }
 
 type APIResponse struct {

--- a/client/apiclient_test.go
+++ b/client/apiclient_test.go
@@ -89,14 +89,19 @@ func TestNewHTTPTransport(t *testing.T) {
 
 // This is not a super thorough test, but it's something
 func TestAPIClientGet(t *testing.T) {
-	// set up mock
 	testBaseURL := "test://local"
-	testResp := `{"hello":"there"}`
-	headers := map[string]string{
-		"special": "headeroni",
+	cfg := APIConfig{
+		Product: "test",
+		BaseURL: testBaseURL,
+		headers: map[string]string{
+			"special": "headeroni",
+		},
+		TLSConfig: TLSConfig{},
 	}
+	// set up mock
+	testResp := `{"hello":"there"}`
 	mock := &mockHTTP{resp: testResp}
-	c, err := NewAPIClient("test", testBaseURL, headers, TLSConfig{})
+	c, err := NewAPIClient(cfg)
 	if err != nil {
 		t.Errorf("NewAPIClient returned error: %s", err)
 	}
@@ -141,8 +146,14 @@ func TestAPIClientGet(t *testing.T) {
 func TestAPIClientGetStringValue(t *testing.T) {
 	// this also implicily tests APIClient.GetValue()
 
+	cfg := APIConfig{
+		Product:   "test",
+		BaseURL:   "test://local",
+		TLSConfig: TLSConfig{},
+		headers:   map[string]string{},
+	}
 	mock := &mockHTTP{resp: `{"one": {"two": "three"}}`}
-	c, err := NewAPIClient("test", "test://local", map[string]string{}, TLSConfig{})
+	c, err := NewAPIClient(cfg)
 	if err != nil {
 		t.Errorf("NewAPIClient returned error: %s", err)
 	}

--- a/client/consul.go
+++ b/client/consul.go
@@ -22,6 +22,8 @@ const (
 
 // NewConsulAPI returns an APIClient for Consul.
 func NewConsulAPI() (*APIClient, error) {
+	product := "consul"
+
 	addr := os.Getenv("CONSUL_HTTP_ADDR")
 	if addr == "" {
 		addr = DefaultConsulAddr
@@ -38,7 +40,14 @@ func NewConsulAPI() (*APIClient, error) {
 		return nil, err
 	}
 
-	apiClient, err := NewAPIClient("consul", addr, headers, tlsConfig)
+	cfg := APIConfig{
+		Product:   product,
+		BaseURL:   addr,
+		TLSConfig: tlsConfig,
+		headers:   headers,
+	}
+
+	apiClient, err := NewAPIClient(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/client/nomad.go
+++ b/client/nomad.go
@@ -23,6 +23,8 @@ const (
 
 // NewNomadAPI returns an APIClient for Nomad.
 func NewNomadAPI() (*APIClient, error) {
+	product := "nomad"
+
 	addr := os.Getenv("NOMAD_ADDR")
 	if addr == "" {
 		addr = DefaultNomadAddr
@@ -39,7 +41,14 @@ func NewNomadAPI() (*APIClient, error) {
 		return nil, err
 	}
 
-	apiClient, err := NewAPIClient("nomad", addr, headers, tlsConfig)
+	cfg := APIConfig{
+		Product:   product,
+		BaseURL:   addr,
+		TLSConfig: tlsConfig,
+		headers:   headers,
+	}
+
+	apiClient, err := NewAPIClient(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/client/tfe.go
+++ b/client/tfe.go
@@ -10,6 +10,8 @@ const DefaultTFEAddr = "https://127.0.0.1"
 
 // NewTFEAPI returns an APIClient for TFE.
 func NewTFEAPI() *APIClient {
+	product := "terraform-ent"
+
 	addr := os.Getenv("TFE_HTTP_ADDR")
 	if addr == "" {
 		addr = DefaultTFEAddr
@@ -21,7 +23,14 @@ func NewTFEAPI() *APIClient {
 		headers["Authorization"] = "Bearer " + token
 	}
 
-	apiClient, err := NewAPIClient("terraform-ent", addr, headers, TLSConfig{})
+	cfg := APIConfig{
+		Product:   product,
+		BaseURL:   addr,
+		TLSConfig: TLSConfig{}, // Custom TLS Configuration is not yet supported for Terraform Enterprise
+		headers:   headers,
+	}
+
+	apiClient, err := NewAPIClient(cfg)
 	if err != nil {
 		return nil
 	}

--- a/client/vault.go
+++ b/client/vault.go
@@ -24,6 +24,8 @@ const (
 
 // NewVaultAPI returns an APIClient for Vault.
 func NewVaultAPI() (*APIClient, error) {
+	product := "vault"
+
 	addr := os.Getenv("VAULT_ADDR")
 	if addr == "" {
 		addr = DefaultVaultAddr
@@ -53,7 +55,14 @@ func NewVaultAPI() (*APIClient, error) {
 		return nil, err
 	}
 
-	apiClient, err := NewAPIClient("vault", addr, headers, tlsConfig)
+	cfg := APIConfig{
+		Product:   product,
+		BaseURL:   addr,
+		TLSConfig: tlsConfig,
+		headers:   headers,
+	}
+
+	apiClient, err := NewAPIClient(cfg)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This merge adds an `APIConfig` struct to collect the parameters required by an `APIClient`. The `NewAPIClient` function has been updated to use this new struct, and any callers of `NewAPIClient` have been updated to use an `APIConfig` structure.

`NewAPIClient` tests were updated to use this structure, but validation was not updated, so that we could verify that behavior remained consistent.

As a bit of cleanup, TLS config and setup were moved in the api client file, so that API concerns and TLS/HTTP Transport concerns were closer to similar code. Previously, they were interspersed.