### PR TITLE
Allow APIClient Injection into Product Seeker Creation Functions

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -449,7 +449,10 @@ func (a *Agent) Setup() (map[string]*product.Product, error) {
 		p[product.Nomad] = newNomad
 	}
 	if a.Config.TFE {
-		newTFE := product.NewTFE(cfg)
+		newTFE, err := product.NewTFE(cfg)
+		if err != nil {
+			return nil, err
+		}
 		if tfe != nil {
 			customSeekers, err := customSeekers(tfe, a.tmpDir)
 			if err != nil {
@@ -571,7 +574,7 @@ func customSeekers(cfg *ProductConfig, tmpDir string) ([]*seeker.Seeker, error) 
 	case product.Nomad:
 		c, err = client.NewNomadAPI()
 	case product.TFE:
-		c = client.NewTFEAPI()
+		c, err = client.NewTFEAPI()
 	case product.Vault:
 		c, err = client.NewVaultAPI()
 	}

--- a/client/tfe.go
+++ b/client/tfe.go
@@ -9,7 +9,7 @@ import (
 const DefaultTFEAddr = "https://127.0.0.1"
 
 // NewTFEAPI returns an APIClient for TFE.
-func NewTFEAPI() *APIClient {
+func NewTFEAPI() (*APIClient, error) {
 	addr := os.Getenv("TFE_HTTP_ADDR")
 	if addr == "" {
 		addr = DefaultTFEAddr
@@ -23,7 +23,7 @@ func NewTFEAPI() *APIClient {
 
 	apiClient, err := NewAPIClient("terraform-ent", addr, headers, TLSConfig{})
 	if err != nil {
-		return nil
+		return nil, err
 	}
-	return apiClient
+	return apiClient, nil
 }

--- a/client/tfe_test.go
+++ b/client/tfe_test.go
@@ -7,7 +7,8 @@ import (
 )
 
 func TestNewTFEAPI(t *testing.T) {
-	api := NewTFEAPI()
+	api, err := NewTFEAPI()
+	assert.NoError(t, err)
 	assert.Equal(t, "terraform-ent", api.Product)
 	assert.Equal(t, api.BaseURL, DefaultTFEAddr)
 }

--- a/product/nomad.go
+++ b/product/nomad.go
@@ -3,7 +3,6 @@ package product
 import (
 	"fmt"
 	"path/filepath"
-	"time"
 
 	"github.com/hashicorp/hcdiag/client"
 	s "github.com/hashicorp/hcdiag/seeker"
@@ -19,7 +18,12 @@ const (
 
 // NewNomad takes a product config and creates a Product with all of Nomad's default seekers
 func NewNomad(cfg Config) (*Product, error) {
-	seekers, err := NomadSeekers(cfg.TmpDir, cfg.Since, cfg.Until)
+	api, err := client.NewNomadAPI()
+	if err != nil {
+		return nil, err
+	}
+
+	seekers, err := NomadSeekers(cfg, api)
 	if err != nil {
 		return nil, err
 	}
@@ -29,33 +33,28 @@ func NewNomad(cfg Config) (*Product, error) {
 }
 
 // NomadSeekers seek information about Nomad.
-func NomadSeekers(tmpDir string, since, until time.Time) ([]*s.Seeker, error) {
-	api, err := client.NewNomadAPI()
-	if err != nil {
-		return nil, err
-	}
-
+func NomadSeekers(cfg Config, api *client.APIClient) ([]*s.Seeker, error) {
 	seekers := []*s.Seeker{
 		s.NewCommander("nomad version", "string"),
 		s.NewCommander("nomad node status -self -json", "json"),
 		s.NewCommander("nomad agent-info -json", "json"),
-		s.NewCommander(fmt.Sprintf("nomad operator debug -log-level=TRACE -node-id=all -max-nodes=10 -output=%s -duration=%s -interval=%s", tmpDir, NomadDebugDuration, NomadDebugInterval), "string"),
+		s.NewCommander(fmt.Sprintf("nomad operator debug -log-level=TRACE -node-id=all -max-nodes=10 -output=%s -duration=%s -interval=%s", cfg.TmpDir, NomadDebugDuration, NomadDebugInterval), "string"),
 
 		s.NewHTTPer(api, "/v1/agent/members?stale=true"),
 		s.NewHTTPer(api, "/v1/operator/autopilot/configuration?stale=true"),
 		s.NewHTTPer(api, "/v1/operator/raft/configuration?stale=true"),
 
-		logs.NewDocker("nomad", tmpDir, since),
+		logs.NewDocker("nomad", cfg.TmpDir, cfg.Since),
 	}
 
 	// try to detect log location to copy
 	if logPath, err := client.GetNomadLogPath(api); err == nil {
-		dest := filepath.Join(tmpDir, "logs", "nomad")
-		logCopier := s.NewCopier(logPath, dest, since, until)
+		dest := filepath.Join(cfg.TmpDir, "logs", "nomad")
+		logCopier := s.NewCopier(logPath, dest, cfg.Since, cfg.Until)
 		seekers = append([]*s.Seeker{logCopier}, seekers...)
 	}
 	// get logs from journald if available
-	if journald := s.JournaldGetter("nomad", tmpDir, since, until); journald != nil {
+	if journald := s.JournaldGetter("nomad", cfg.TmpDir, cfg.Since, cfg.Until); journald != nil {
 		seekers = append(seekers, journald)
 	}
 

--- a/product/vault.go
+++ b/product/vault.go
@@ -3,7 +3,6 @@ package product
 import (
 	"fmt"
 	"path/filepath"
-	"time"
 
 	logs "github.com/hashicorp/hcdiag/seeker/log"
 
@@ -18,7 +17,12 @@ const (
 
 // NewVault takes a product config and creates a Product containing all of Vault's seekers.
 func NewVault(cfg Config) (*Product, error) {
-	seekers, err := VaultSeekers(cfg.TmpDir, cfg.Since, cfg.Until)
+	api, err := client.NewVaultAPI()
+	if err != nil {
+		return nil, err
+	}
+
+	seekers, err := VaultSeekers(cfg, api)
 	if err != nil {
 		return nil, err
 	}
@@ -28,31 +32,26 @@ func NewVault(cfg Config) (*Product, error) {
 }
 
 // VaultSeekers seek information about Vault.
-func VaultSeekers(tmpDir string, since, until time.Time) ([]*s.Seeker, error) {
-	api, err := client.NewVaultAPI()
-	if err != nil {
-		return nil, err
-	}
-
+func VaultSeekers(cfg Config, api *client.APIClient) ([]*s.Seeker, error) {
 	seekers := []*s.Seeker{
 		s.NewCommander("vault version", "string"),
 		s.NewCommander("vault status -format=json", "json"),
 		s.NewCommander("vault read sys/health -format=json", "json"),
 		s.NewCommander("vault read sys/seal-status -format=json", "json"),
 		s.NewCommander("vault read sys/host-info -format=json", "json"),
-		s.NewCommander(fmt.Sprintf("vault debug -output=%s/VaultDebug.tar.gz -duration=%ds", tmpDir, DefaultDebugSeconds), "string"),
+		s.NewCommander(fmt.Sprintf("vault debug -output=%s/VaultDebug.tar.gz -duration=%ds", cfg.TmpDir, DefaultDebugSeconds), "string"),
 
-		logs.NewDocker("vault", tmpDir, since),
+		logs.NewDocker("vault", cfg.TmpDir, cfg.Since),
 	}
 
 	// try to detect log location to copy
 	if logPath, err := client.GetVaultAuditLogPath(api); err == nil {
-		dest := filepath.Join(tmpDir, "logs/vault")
-		logCopier := s.NewCopier(logPath, dest, since, until)
+		dest := filepath.Join(cfg.TmpDir, "logs/vault")
+		logCopier := s.NewCopier(logPath, dest, cfg.Since, cfg.Until)
 		seekers = append([]*s.Seeker{logCopier}, seekers...)
 	}
 	// get logs from journald if available
-	if journald := s.JournaldGetter("vault", tmpDir, since, until); journald != nil {
+	if journald := s.JournaldGetter("vault", cfg.TmpDir, cfg.Since, cfg.Until); journald != nil {
 		seekers = append(seekers, journald)
 	}
 


### PR DESCRIPTION
This merge moves the responsibility of creating an `APIClient` out of the new product seeker functions and into the new product functions. Behavior should remain unchanged in this, but the separation allows for dependency injection and should enable easier maintenance in the future.

In addition, the TFE product setup was made more similar to the existing products, primarily by allowing errors to be returned from a couple of key functions (`client. NewTFEAPI` and `product. NewTFE`) and then bubbling those up accordingly.