### PR TITLE
wrap status stuff in dryrun checks

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -111,8 +111,10 @@ func (a *Agent) Run() []error {
 
 	// Record metadata
 	// Build seeker metadata
-	a.l.Info("Recording manifest")
-	a.RecordManifest()
+	if !a.Config.Dryrun {
+		a.l.Info("Recording manifest")
+		a.RecordManifest()
+	}
 
 	// Execution finished, write our results and cleanup
 	a.recordEnd()
@@ -240,12 +242,14 @@ func (a *Agent) RunProducts() error {
 		a.results[name] = result
 		a.resultsLock.Unlock()
 
-		statuses, err := seeker.StatusCounts(product.Seekers)
-		if err != nil {
-			a.l.Error("Error rendering seeker statuses", "product", product, "error", err)
-		}
+		if !a.Config.Dryrun {
+			statuses, err := seeker.StatusCounts(product.Seekers)
+			if err != nil {
+				a.l.Error("Error rendering seeker statuses", "product", product, "error", err)
+			}
 
-		a.l.Info("Product done", "product", name, "statuses", statuses)
+			a.l.Info("Product done", "product", name, "statuses", statuses)
+		}
 		wg.Done()
 	}
 


### PR DESCRIPTION
This ensures we don't error when running -dryrun anymore! 😅
Current:
<img width="1428" alt="Screen Shot 2022-05-12 at 3 07 21 PM" src="https://user-images.githubusercontent.com/938395/168175782-0e750de6-e548-47e7-89d6-90c2a18f998a.png">

Fix:
<img width="1359" alt="Screen Shot 2022-05-12 at 3 06 45 PM" src="https://user-images.githubusercontent.com/938395/168175722-f9ece75d-fdb2-428b-be64-68f38c6ab5de.png">
 