### PR TITLE
add flags and agent config for DebugDuration and DebugInterval. 

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -408,11 +408,13 @@ func (a *Agent) Setup() (map[string]*product.Product, error) {
 	}
 
 	cfg := product.Config{
-		Logger: &a.l,
-		TmpDir: a.tmpDir,
-		Since:  a.Config.Since,
-		Until:  a.Config.Until,
-		OS:     a.Config.OS,
+		Logger:        &a.l,
+		TmpDir:        a.tmpDir,
+		Since:         a.Config.Since,
+		Until:         a.Config.Until,
+		OS:            a.Config.OS,
+		DebugDuration: a.Config.DebugDuration,
+		DebugInterval: a.Config.DebugInterval,
 	}
 	p := make(map[string]*product.Product)
 	if a.Config.Consul {

--- a/agent/config.go
+++ b/agent/config.go
@@ -19,6 +19,11 @@ type Config struct {
 	Until       time.Time `json:"until"`
 	Includes    []string  `json:"includes"`
 	Destination string    `json:"destination"`
+
+	// DebugDuration
+	DebugDuration time.Duration `json:"debug_duration"`
+	// DebugInterval
+	DebugInterval time.Duration `json:"debug_interval"`
 }
 
 type HostConfig struct {

--- a/main.go
+++ b/main.go
@@ -160,11 +160,8 @@ func (f *Flags) parseFlags(args []string) error {
 	flags.BoolVar(&f.Version, "version", false, "Print the current version of hcdiag")
 	flags.DurationVar(&f.IncludeSince, "include-since", SeventyTwoHours, "Alias for -since, will be overridden if -since is also provided, usage examples: `72h`, `25m`, `45s`, `120h1m90s`")
 	flags.DurationVar(&f.Since, "since", SeventyTwoHours, "Collect information within this time. Takes a 'go-formatted' duration, usage examples: `72h`, `25m`, `45s`, `120h1m90s`")
-
-	// FIXME(mkcp): Figure out what is going on with backticked strings in the usage showing up next to the flag as the param.
-	flags.DurationVar(&f.DebugDuration, "debug-duration", TenSeconds, "`10s` How long to run product debug bundle commands. See: -duration in `vault debug`, `consul debug`, and `nomad operator debug`")
-	flags.DurationVar(&f.DebugInterval, "debug-interval", FiveSeconds, "`5s` How long metrics collection intervals in product debug commands last. See: -interval in `vault debug`, `consul debug`, and `nomad operator debug`")
-
+	flags.DurationVar(&f.DebugDuration, "debug-duration", TenSeconds, "How long to run product debug bundle commands. Provide a duration ex: `00h00m00s`. See: -duration in `vault debug`, `consul debug`, and `nomad operator debug`")
+	flags.DurationVar(&f.DebugInterval, "debug-interval", FiveSeconds, "How long metrics collection intervals in product debug commands last. Provide a duration ex: `00h00m00s`. See: -interval in `vault debug`, `consul debug`, and `nomad operator debug`")
 	flags.StringVar(&f.OS, "os", "auto", "Override operating system detection")
 	flags.StringVar(&f.Destination, "destination", ".", "Path to the directory the bundle should be written in")
 	flags.StringVar(&f.Destination, "dest", ".", "Shorthand for -destination")

--- a/main.go
+++ b/main.go
@@ -16,7 +16,9 @@ import (
 const SemVer string = "0.3.0"
 
 // SeventyTwoHours represents the duration "72h" parsed in nanoseconds
-const SeventyTwoHours time.Duration = 259200000000000
+const SeventyTwoHours = 72 * time.Hour
+const TenSeconds = 10 * time.Second
+const FiveSeconds = 5 * time.Second
 
 func main() {
 	os.Exit(realMain())
@@ -122,6 +124,12 @@ type Flags struct {
 
 	// Get hcdiag version
 	Version bool
+
+	// Duration param for product debug bundles
+	DebugDuration time.Duration
+
+	// Interval param for product debug bundles
+	DebugInterval time.Duration
 }
 
 type CSVFlag struct {
@@ -149,14 +157,16 @@ func (f *Flags) parseFlags(args []string) error {
 	flags.BoolVar(&f.TFE, "terraform-ent", false, "(Experimental) Run Terraform Enterprise diagnostics")
 	flags.BoolVar(&f.Vault, "vault", false, "Run Vault diagnostics")
 	flags.BoolVar(&f.AllProducts, "all", false, "DEPRECATED: Run all available product diagnostics")
+	flags.BoolVar(&f.Version, "version", false, "Print the current version of hcdiag")
+	flags.DurationVar(&f.IncludeSince, "include-since", SeventyTwoHours, "Alias for -since, will be overridden if -since is also provided, usage examples: `72h`, `25m`, `45s`, `120h1m90s`")
+	flags.DurationVar(&f.Since, "since", SeventyTwoHours, "Collect information within this time. Takes a 'go-formatted' duration, usage examples: `72h`, `25m`, `45s`, `120h1m90s`")
+	flags.DurationVar(&f.DebugDuration, "debug-duration", TenSeconds, "How long to run product debug bundle commands. See: -duration in `vault debug`, `consul debug`, and `nomad operator debug`")
+	flags.DurationVar(&f.DebugInterval, "debug-interval", FiveSeconds, "How long metrics collection intervals in product debug commands last. See: -interval in `vault debug`, `consul debug`, and `nomad operator debug`")
 	flags.StringVar(&f.OS, "os", "auto", "Override operating system detection")
 	flags.StringVar(&f.Destination, "destination", ".", "Path to the directory the bundle should be written in")
 	flags.StringVar(&f.Destination, "dest", ".", "Shorthand for -destination")
 	flags.StringVar(&f.Config, "config", "", "Path to HCL configuration file")
-	flags.DurationVar(&f.IncludeSince, "include-since", SeventyTwoHours, "Alias for -since, will be overridden if -since is also provided, usage examples: `72h`, `25m`, `45s`, `120h1m90s`")
-	flags.DurationVar(&f.Since, "since", SeventyTwoHours, "Collect information within this time. Takes a 'go-formatted' duration, usage examples: `72h`, `25m`, `45s`, `120h1m90s`")
 	flags.Var(&CSVFlag{&f.Includes}, "includes", "files or directories to include (comma-separated, file-*-globbing available if 'wrapped-*-in-single-quotes')\ne.g. '/var/log/consul-*,/var/log/nomad-*'")
-	flags.BoolVar(&f.Version, "version", false, "Print the current version of hcdiag")
 
 	// Ensure f.Destination points to some kind of directory by its notation
 	// FIXME(mkcp): trailing slashes should be trimmed in path.Dir... why does a double slash end in a slash?
@@ -185,6 +195,9 @@ func mergeAgentConfig(config agent.Config, flags Flags) agent.Config {
 
 	// Bundle write location
 	config.Destination = flags.Destination
+
+	config.DebugDuration = flags.DebugDuration
+	config.DebugInterval = flags.DebugInterval
 
 	return config
 }

--- a/main.go
+++ b/main.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/hcdiag/product"
+
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcdiag/agent"
 )
@@ -17,8 +19,6 @@ const SemVer string = "0.3.0"
 
 // SeventyTwoHours represents the duration "72h" parsed in nanoseconds
 const SeventyTwoHours = 72 * time.Hour
-const TenSeconds = 10 * time.Second
-const FiveSeconds = 5 * time.Second
 
 func main() {
 	os.Exit(realMain())
@@ -160,8 +160,8 @@ func (f *Flags) parseFlags(args []string) error {
 	flags.BoolVar(&f.Version, "version", false, "Print the current version of hcdiag")
 	flags.DurationVar(&f.IncludeSince, "include-since", SeventyTwoHours, "Alias for -since, will be overridden if -since is also provided, usage examples: `72h`, `25m`, `45s`, `120h1m90s`")
 	flags.DurationVar(&f.Since, "since", SeventyTwoHours, "Collect information within this time. Takes a 'go-formatted' duration, usage examples: `72h`, `25m`, `45s`, `120h1m90s`")
-	flags.DurationVar(&f.DebugDuration, "debug-duration", TenSeconds, "How long to run product debug bundle commands. Provide a duration ex: `00h00m00s`. See: -duration in `vault debug`, `consul debug`, and `nomad operator debug`")
-	flags.DurationVar(&f.DebugInterval, "debug-interval", FiveSeconds, "How long metrics collection intervals in product debug commands last. Provide a duration ex: `00h00m00s`. See: -interval in `vault debug`, `consul debug`, and `nomad operator debug`")
+	flags.DurationVar(&f.DebugDuration, "debug-duration", product.DefaultDuration, "How long to run product debug bundle commands. Provide a duration ex: `00h00m00s`. See: -duration in `vault debug`, `consul debug`, and `nomad operator debug`")
+	flags.DurationVar(&f.DebugInterval, "debug-interval", product.DefaultInterval, "How long metrics collection intervals in product debug commands last. Provide a duration ex: `00h00m00s`. See: -interval in `vault debug`, `consul debug`, and `nomad operator debug`")
 	flags.StringVar(&f.OS, "os", "auto", "Override operating system detection")
 	flags.StringVar(&f.Destination, "destination", ".", "Path to the directory the bundle should be written in")
 	flags.StringVar(&f.Destination, "dest", ".", "Shorthand for -destination")
@@ -196,6 +196,7 @@ func mergeAgentConfig(config agent.Config, flags Flags) agent.Config {
 	// Bundle write location
 	config.Destination = flags.Destination
 
+	// Apply Debug{Duration,Interval}
 	config.DebugDuration = flags.DebugDuration
 	config.DebugInterval = flags.DebugInterval
 

--- a/main.go
+++ b/main.go
@@ -160,8 +160,11 @@ func (f *Flags) parseFlags(args []string) error {
 	flags.BoolVar(&f.Version, "version", false, "Print the current version of hcdiag")
 	flags.DurationVar(&f.IncludeSince, "include-since", SeventyTwoHours, "Alias for -since, will be overridden if -since is also provided, usage examples: `72h`, `25m`, `45s`, `120h1m90s`")
 	flags.DurationVar(&f.Since, "since", SeventyTwoHours, "Collect information within this time. Takes a 'go-formatted' duration, usage examples: `72h`, `25m`, `45s`, `120h1m90s`")
-	flags.DurationVar(&f.DebugDuration, "debug-duration", TenSeconds, "How long to run product debug bundle commands. See: -duration in `vault debug`, `consul debug`, and `nomad operator debug`")
-	flags.DurationVar(&f.DebugInterval, "debug-interval", FiveSeconds, "How long metrics collection intervals in product debug commands last. See: -interval in `vault debug`, `consul debug`, and `nomad operator debug`")
+
+	// FIXME(mkcp): Figure out what is going on with backticked strings in the usage showing up next to the flag as the param.
+	flags.DurationVar(&f.DebugDuration, "debug-duration", TenSeconds, "`10s` How long to run product debug bundle commands. See: -duration in `vault debug`, `consul debug`, and `nomad operator debug`")
+	flags.DurationVar(&f.DebugInterval, "debug-interval", FiveSeconds, "`5s` How long metrics collection intervals in product debug commands last. See: -interval in `vault debug`, `consul debug`, and `nomad operator debug`")
+
 	flags.StringVar(&f.OS, "os", "auto", "Override operating system detection")
 	flags.StringVar(&f.Destination, "destination", ".", "Path to the directory the bundle should be written in")
 	flags.StringVar(&f.Destination, "dest", ".", "Shorthand for -destination")

--- a/product/consul.go
+++ b/product/consul.go
@@ -34,7 +34,7 @@ func NewConsul(cfg Config) (*Product, error) {
 func ConsulSeekers(cfg Config, api *client.APIClient) ([]*s.Seeker, error) {
 	seekers := []*s.Seeker{
 		s.NewCommander("consul version", "string"),
-		s.NewCommander(fmt.Sprintf("consul debug -output=%s/ConsulDebug -duration=%ds -interval=%ds", cfg.TmpDir, DefaultDebugSeconds, DefaultIntervalSeconds), "string"),
+		s.NewCommander(fmt.Sprintf("consul debug -output=%s/ConsulDebug -duration=%s -interval=%s", cfg.TmpDir, cfg.DebugDuration, cfg.DebugInterval), "string"),
 
 		s.NewHTTPer(api, "/v1/agent/self"),
 		s.NewHTTPer(api, "/v1/agent/metrics"),

--- a/product/nomad.go
+++ b/product/nomad.go
@@ -3,6 +3,7 @@ package product
 import (
 	"fmt"
 	"path/filepath"
+	"time"
 
 	"github.com/hashicorp/hcdiag/client"
 	s "github.com/hashicorp/hcdiag/seeker"
@@ -39,9 +40,7 @@ func NewNomad(cfg Config) (*Product, error) {
 	}
 
 	return &Product{
-		Seekers:       seekers,
-		DebugDuration: dur,
-		DebugInterval: interval,
+		Seekers: seekers,
 	}, nil
 }
 
@@ -51,7 +50,8 @@ func NomadSeekers(cfg Config, api *client.APIClient) ([]*s.Seeker, error) {
 		s.NewCommander("nomad version", "string"),
 		s.NewCommander("nomad node status -self -json", "json"),
 		s.NewCommander("nomad agent-info -json", "json"),
-		s.NewCommander(fmt.Sprintf("nomad operator debug -log-level=TRACE -node-id=all -max-nodes=10 -output=%s -duration=%s -interval=%s", cfg.TmpDir, NomadDebugDuration, NomadDebugInterval), "string"),
+		// TODO(mkcp): Override interval and duration with nomad defaults if CLI defaults are unchanged.
+		s.NewCommander(fmt.Sprintf("nomad operator debug -log-level=TRACE -node-id=all -max-nodes=10 -output=%s -duration=%s -interval=%s", cfg.TmpDir, cfg.DebugDuration, cfg.DebugInterval), "string"),
 
 		s.NewHTTPer(api, "/v1/agent/members?stale=true"),
 		s.NewHTTPer(api, "/v1/operator/autopilot/configuration?stale=true"),

--- a/product/nomad.go
+++ b/product/nomad.go
@@ -24,13 +24,14 @@ func NewNomad(cfg Config) (*Product, error) {
 		return nil, err
 	}
 
-	// Apply nomad duration and interval default if CLI is using global defaults
-	// NOTE(mkcp): This isn't ideal because we're using magic numbers here to match the CLI defaults. We could pass a
-	//  tuple or something in from the CLI that describes both the default and the user-set value... but i'm timeboxing this.
-	if cfg.DebugDuration == 10*time.Second {
+	// Apply nomad duration and interval default if CLI is using global defaults.
+	// NOTE(mkcp): The downside to this approach is that Nomad cannot be run with a 10s duration and 5s interval.
+	//  passing in a zero value from the agent would allow us to do that, but the flags library requires a default value
+	//  to be set in order to _show_ that default to the user, so we have to set the agent with that default.
+	if DefaultDuration == cfg.DebugDuration {
 		cfg.DebugDuration = NomadDebugDuration
 	}
-	if cfg.DebugInterval == 5*time.Second {
+	if DefaultInterval == cfg.DebugDuration {
 		cfg.DebugInterval = NomadDebugInterval
 	}
 	seekers, err := NomadSeekers(cfg, api)

--- a/product/nomad.go
+++ b/product/nomad.go
@@ -12,8 +12,8 @@ import (
 const (
 	NomadClientCheck   = "nomad version"
 	NomadAgentCheck    = "nomad server members"
-	NomadDebugDuration = "2m"
-	NomadDebugInterval = "30s"
+	NomadDebugDuration = 2 * time.Minute
+	NomadDebugInterval = 30 * time.Second
 )
 
 // NewNomad takes a product config and creates a Product with all of Nomad's default seekers
@@ -27,8 +27,21 @@ func NewNomad(cfg Config) (*Product, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Apply nomad duration and interval default if CLI is using global defaults
+	dur := cfg.DebugDuration
+	if dur == 10*time.Second {
+		dur = NomadDebugDuration
+	}
+	interval := cfg.DebugInterval
+	if interval == 5*time.Second {
+		interval = NomadDebugInterval
+	}
+
 	return &Product{
-		Seekers: seekers,
+		Seekers:       seekers,
+		DebugDuration: dur,
+		DebugInterval: interval,
 	}, nil
 }
 

--- a/product/product.go
+++ b/product/product.go
@@ -16,6 +16,11 @@ const (
 	Vault  = "vault"
 )
 
+const (
+	DefaultDuration = 10 * time.Second
+	DefaultInterval = 5 * time.Second
+)
+
 type Config struct {
 	Logger        *hclog.Logger
 	Name          string
@@ -53,7 +58,7 @@ func (p *Product) Filter() error {
 	return err
 }
 
-// CommanderHealthCheck employs the the CLI to check if the client and then the agent are available.
+// CommanderHealthCheck employs the CLI to check if the client and then the agent are available.
 func CommanderHealthCheck(client, agent string) error {
 	isClientAvailable := seeker.NewCommander(client, "string")
 	if result, err := isClientAvailable.Run(); err != nil {

--- a/product/product.go
+++ b/product/product.go
@@ -22,19 +22,23 @@ const (
 )
 
 type Config struct {
-	Logger *hclog.Logger
-	Name   string
-	TmpDir string
-	Since  time.Time
-	Until  time.Time
-	OS     string
+	Logger        *hclog.Logger
+	Name          string
+	TmpDir        string
+	Since         time.Time
+	Until         time.Time
+	OS            string
+	DebugDuration time.Duration
+	DebugInterval time.Duration
 }
 
 type Product struct {
-	Name     string
-	Seekers  []*seeker.Seeker
-	Excludes []string
-	Selects  []string
+	Name          string
+	Seekers       []*seeker.Seeker
+	Excludes      []string
+	Selects       []string
+	DebugDuration time.Duration
+	DebugInterval time.Duration
 }
 
 // Filter applies our slices of exclude and select seeker.Identifier matchers to the set of the product's seekers

--- a/product/product.go
+++ b/product/product.go
@@ -16,11 +16,6 @@ const (
 	Vault  = "vault"
 )
 
-const (
-	DefaultDebugSeconds    = 10
-	DefaultIntervalSeconds = 5
-)
-
 type Config struct {
 	Logger        *hclog.Logger
 	Name          string
@@ -33,12 +28,10 @@ type Config struct {
 }
 
 type Product struct {
-	Name          string
-	Seekers       []*seeker.Seeker
-	Excludes      []string
-	Selects       []string
-	DebugDuration time.Duration
-	DebugInterval time.Duration
+	Name     string
+	Seekers  []*seeker.Seeker
+	Excludes []string
+	Selects  []string
 }
 
 // Filter applies our slices of exclude and select seeker.Identifier matchers to the set of the product's seekers

--- a/product/vault.go
+++ b/product/vault.go
@@ -39,7 +39,7 @@ func VaultSeekers(cfg Config, api *client.APIClient) ([]*s.Seeker, error) {
 		s.NewCommander("vault read sys/health -format=json", "json"),
 		s.NewCommander("vault read sys/seal-status -format=json", "json"),
 		s.NewCommander("vault read sys/host-info -format=json", "json"),
-		s.NewCommander(fmt.Sprintf("vault debug -output=%s/VaultDebug.tar.gz -duration=%ds", cfg.TmpDir, DefaultDebugSeconds), "string"),
+		s.NewCommander(fmt.Sprintf("vault debug -output=%s/VaultDebug.tar.gz -duration=%s -interval=%s", cfg.TmpDir, cfg.DebugDuration, cfg.DebugInterval), "string"),
 
 		logs.NewDocker("vault", cfg.TmpDir, cfg.Since),
 	}


### PR DESCRIPTION
This adds the CLI flags and starts passing the values through the agent. It's not done yet, because the values aren't applied in product seekers yet. It'll be easier to take params once some changes are applied via the TLSConfig refactors. So just pushing it up as a draft to get it up off my machine.