### PR TITLE
add host/proc_file.go

### DIFF
--- a/product/host.go
+++ b/product/host.go
@@ -28,7 +28,7 @@ func HostSeekers(os string) []*seeker.Seeker {
 		host.NewNetwork(),
 		host.NewEtcHosts(),
 		host.NewIPTables(),
-		host.NewProcFile(),
+		host.NewProcFile(os),
 		host.NewFSTab(os),
 	}
 }

--- a/product/host.go
+++ b/product/host.go
@@ -28,5 +28,6 @@ func HostSeekers(os string) []*seeker.Seeker {
 		host.NewNetwork(),
 		host.NewEtcHosts(),
 		host.NewIPTables(),
+		host.NewProcFile(),
 	}
 }

--- a/seeker/host/proc_file.go
+++ b/seeker/host/proc_file.go
@@ -1,0 +1,46 @@
+package host
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/hashicorp/hcdiag/seeker"
+)
+
+var _ seeker.Runner = ProcFile{}
+
+type ProcFile struct {
+	os       string
+	commands []string
+}
+
+func NewProcFile() *seeker.Seeker {
+	return &seeker.Seeker{
+		Identifier: "/proc/ files",
+		Runner: ProcFile{
+			os: runtime.GOOS,
+			commands: []string{
+				"cat /proc/cpuinfo",
+				"cat /proc/loadavg",
+				"cat /proc/version",
+				"cat /proc/vmstat",
+			},
+		},
+	}
+}
+
+func (s ProcFile) Run() (interface{}, seeker.Status, error) {
+	if s.os != "linux" {
+		// TODO(mkcp): Replace status with seeker.Skip when we implement it
+		return nil, seeker.Success, fmt.Errorf("os not linux, skipping, os=%s", s.os)
+	}
+	m := make(map[string]interface{})
+	for _, c := range s.commands {
+		res, _, err := seeker.NewSheller(c).Runner.Run()
+		m[c] = res
+		if err != nil {
+			return m, seeker.Fail, err
+		}
+	}
+	return m, seeker.Success, nil
+}

--- a/seeker/host/proc_file.go
+++ b/seeker/host/proc_file.go
@@ -2,7 +2,6 @@ package host
 
 import (
 	"fmt"
-	"runtime"
 
 	"github.com/hashicorp/hcdiag/seeker"
 )
@@ -14,11 +13,11 @@ type ProcFile struct {
 	commands []string
 }
 
-func NewProcFile() *seeker.Seeker {
+func NewProcFile(os string) *seeker.Seeker {
 	return &seeker.Seeker{
 		Identifier: "/proc/ files",
 		Runner: ProcFile{
-			os: runtime.GOOS,
+			os: os,
 			commands: []string{
 				"cat /proc/cpuinfo",
 				"cat /proc/loadavg",


### PR DESCRIPTION
The results entries aren't very readable without pretty-printing, but it works for now.

A better impl. may employ a list of file locations rather than commands, so a sheller (or catter!) can cat the files to results, and a copier copies the files over to the bundle.

<img width="1440" alt="Screen Shot 2022-05-20 at 1 35 48 PM" src="https://user-images.githubusercontent.com/938395/169607066-333ab9f7-4dd3-493f-8d23-db4173c791a8.png">
!