### PR TITLE
Add Network Addresses & Interface Details

### DIFF
--- a/seeker/host/network.go
+++ b/seeker/host/network.go
@@ -1,10 +1,9 @@
 package host
 
 import (
-	"net"
-
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcdiag/seeker"
+	"github.com/shirou/gopsutil/v3/net"
 )
 
 var _ seeker.Runner = &Network{}
@@ -16,11 +15,11 @@ func NewNetwork() *seeker.Seeker {
 type Network struct{}
 
 func (n Network) Run() (interface{}, seeker.Status, error) {
-	networkInfo, err := net.Interfaces()
+	netInterfaces, err := net.Interfaces()
 	if err != nil {
 		hclog.L().Trace("seeker/host.Network.Run()", "error", err)
-		return networkInfo, seeker.Fail, err
+		return nil, seeker.Fail, err
 	}
 
-	return networkInfo, seeker.Success, err
+	return netInterfaces, seeker.Success, nil
 }


### PR DESCRIPTION
This merge adds more detail to the host network seeker, switching out the built-in `net` package usage with `gopsutil`. The format of each interface will go from something like the following:

```json
{
  "Index": 6,
  "MTU": 1500,
  "Name": "en0",
  "HardwareAddr": "abcagv5S",
  "Flags": 19
}
```

to the following, after this merge:

```json
{
  "index": 6,
  "mtu": 1500,
  "name": "en0",
  "hardwareAddr": "aa:bb:cc:82:fe:52",
  "flags": [
    "up",
    "broadcast",
    "multicast"
  ],
  "addrs": [
    {
      "addr": "fe80::743f/64"
    },
    {
      "addr": "192.168.1.1/24"
    }
  ]
}
```