### PR TITLE
Kick off packaging promotion

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -199,7 +199,7 @@ event "promote-production" {
 }
 
 event "promote-production-packaging" {
-  depends = ["promote-production-docker"]
+  depends = ["promote-production"]
   action "promote-production-packaging" {
     organization = "hashicorp"
     repository = "crt-workflows-common"


### PR DESCRIPTION
Update the `depends` key in the `promote-production-packaging` event to point to `promote-production`, which is the event that this keys off of. Since there is no docker build/promotion step, the promote linux packaging job is currently not being kicked off. We'll want to get this merged before the next production release of hcdiag. 

Related slack thread: https://hashicorp.slack.com/archives/C0343CNK7T7/p1654650620740039?thread_ts=1654637610.207269&cid=C0343CNK7T7