### PR TITLE
Assign Unique Names to Temporary Files & Store them in Destination Directory

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -1,5 +1,6 @@
 name: test-integration
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     tags:

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -1,6 +1,5 @@
 name: test-integration
 on:
-  workflow_dispatch:
   push:
     branches: [main]
     tags:

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -56,10 +56,10 @@ func (a *Agent) Run() []error {
 	a.Start = time.Now()
 
 	a.l.Info("Ensuring destination directory exists", "directory", a.Config.Destination)
-	errDest := a.makeDestinationDirectory()
+	errDest := util.EnsureDirectory(a.Config.Destination)
 	if errDest != nil {
 		errs = append(errs, errDest)
-		a.l.Error("Failed to verify or make destination directory", "error", errDest)
+		a.l.Error("Failed to ensure destination directory exists", "dir", a.Config.Destination, "error", errDest)
 	}
 
 	// File processing
@@ -303,8 +303,9 @@ func (a *Agent) WriteOutput() (err error) {
 		return nil
 	}
 
-	err = a.makeDestinationDirectory()
+	err = util.EnsureDirectory(a.Config.Destination)
 	if err != nil {
+		a.l.Error("Failed to ensure destination directory exists", "dir", a.Config.Destination, "error", err)
 		return err
 	}
 
@@ -339,19 +340,6 @@ func (a *Agent) WriteOutput() (err error) {
 		return err
 	}
 	a.l.Info("Compressed and archived output file", "dest", resultsDest)
-
-	return nil
-}
-
-// makeDestinationDirectory will ensure that the agent's destination directory exists. If the full
-// path exists, this is a no-op and will return nil. Otherwise, it will create any directories that do not
-// exist in the destination path.
-func (a *Agent) makeDestinationDirectory() error {
-	// MkdirAll handles cases where directories already exist, so we do not need to check for `os.ErrExist` errors.
-	if err := os.MkdirAll(a.Config.Destination, 0755); err != nil {
-		a.l.Error("Error encountered in creating destination directory", "error", err)
-		return err
-	}
 
 	return nil
 }

--- a/util/util.go
+++ b/util/util.go
@@ -66,7 +66,7 @@ func TarGz(sourceDir string, destFileName string, baseName string) error {
 			}
 
 			header := &tar.Header{
-				Name:    fmt.Sprint(baseName, strings.TrimPrefix(path, sourceDir)),
+				Name:    getTarRelativePathName(baseName, path, sourceDir),
 				Size:    stat.Size(),
 				Mode:    int64(stat.Mode()),
 				ModTime: stat.ModTime(),
@@ -89,6 +89,14 @@ func TarGz(sourceDir string, destFileName string, baseName string) error {
 	}
 
 	return nil
+}
+
+// getTarRelativePathName is a helper for building the Name of archived files in a way that allows for clean extraction.
+// The function takes a baseName, which is the desired directory name when the Tar is unarchived. It takes a filePath
+// which is the full path to the file that is to be archived. And, it takes a fileRoot, which is the portion of the
+// filePath to remove. The result will be, essentially, `baseName + (filePath - fileRoot)`.
+func getTarRelativePathName(baseName, filePath, fileRoot string) string {
+	return fmt.Sprint(baseName, strings.TrimPrefix(filePath, fileRoot))
 }
 
 // WriteJSON converts an interface{} to JSON then writes to filePath.

--- a/util/util.go
+++ b/util/util.go
@@ -15,8 +15,9 @@ import (
 	"github.com/hashicorp/go-hclog"
 )
 
-// TarGz accepts a source directory and destination file name to archive and compress files.
-// TODO: Update doc comment
+// TarGz is a utility function for archiving and compressing files. Its arguments include the source directory that
+// you wish to archive; a destination filename, which is the .tar.gz file you want to create; and a baseName, which
+// is the name of the directory that should be created when the resulting .tar.gz file is later extracted.
 func TarGz(sourceDir string, destFileName string, baseName string) error {
 	// tar
 	destFile, err := os.Create(destFileName)

--- a/util/util.go
+++ b/util/util.go
@@ -9,13 +9,15 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
 )
 
 // TarGz accepts a source directory and destination file name to archive and compress files.
-func TarGz(sourceDir string, destFileName string) error {
+// TODO: Update doc comment
+func TarGz(sourceDir string, destFileName string, baseName string) error {
 	// tar
 	destFile, err := os.Create(destFileName)
 	if err != nil {
@@ -64,7 +66,7 @@ func TarGz(sourceDir string, destFileName string) error {
 			}
 
 			header := &tar.Header{
-				Name:    path,
+				Name:    fmt.Sprint(baseName, strings.TrimPrefix(path, sourceDir)),
 				Size:    stat.Size(),
 				Mode:    int64(stat.Mode()),
 				ModTime: stat.ModTime(),

--- a/util/util.go
+++ b/util/util.go
@@ -238,3 +238,16 @@ func FindInInterface(iface interface{}, mapKeys ...string) (interface{}, error) 
 	}
 	return mapped, nil
 }
+
+// EnsureDirectory will ensure that the full path to the destination directory exists. If the full
+// path exists, this is a no-op and will return nil. Otherwise, it will create any directories that do not
+// exist in the destination path. Any directories created will be given file permissions 0755.
+func EnsureDirectory(dir string) error {
+	// MkdirAll handles cases where directories already exist, so we do not need to check for `os.ErrExist` errors.
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		hclog.L().Debug("util.EnsureDirectory() unable to ensure directory exists", "dir", dir, "error", err)
+		return err
+	}
+
+	return nil
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -147,6 +147,45 @@ func TestIsInRange(t *testing.T) {
 	}
 }
 
+func Test_getTarRelativePathName(t *testing.T) {
+	type arguments struct {
+		baseName string
+		filePath string
+		fileRoot string
+	}
+	testCases := []struct {
+		name     string
+		args     arguments
+		expected string
+	}{
+		{
+			name: "Test Source Files that are not Nested in File Root",
+			args: arguments{
+				baseName: "hcdiag0123456",
+				filePath: "/tmp/a/b/c/Results.json",
+				fileRoot: "/tmp/a/b/c",
+			},
+			expected: "hcdiag0123456/Results.json",
+		},
+		{
+			name: "Test Source Files that are Nested in File Root",
+			args: arguments{
+				baseName: "hcdiag0123456",
+				filePath: "/tmp/a/b/c/d/e/f/Results.json",
+				fileRoot: "/tmp/a/b/c",
+			},
+			expected: "hcdiag0123456/d/e/f/Results.json",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := getTarRelativePathName(tc.args.baseName, tc.args.filePath, tc.args.fileRoot)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
 // FIXME(mkcp): Ensure the since and until works with modtime properly
 // func TestFilterWalk(t *testing.T) {
 // 	testTable := []struct{


### PR DESCRIPTION
This PR enables concurrent runs of hcdiag, such as in functional tests, by ensuring temporary directories are uniquely named. The temporary directories will have a unique string appended to their names, ensuring that even if multiple hcdiag runs occur at the same time, a separate directory will be created for each one.

In addition, we also now use the destination directory as our working directory, rather than the current directory. By default, the behavior will be the same - because the current directory is also the destination, our temporary directory will be in the current working directory. However, when this value is overridden, the temporary directory will be placed within the destination directory instead of the current directory.