### PR TITLE
migrate agent.runSet to product.Run

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -273,8 +273,6 @@ func (a *Agent) RunProducts() error {
 	wg.Add(len(a.products))
 
 	// NOTE(mkcp): Create a closure around runSet, writing results to the agent's result map, and wg.Done().
-	//   This is a little complex, but saves us duplication in the product loop. Maybe we extract this to a private
-	//   package function in the future?
 	run := func(wg *sync.WaitGroup, name string, product *product.Product) {
 		result := product.Run()
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -266,6 +266,7 @@ func (a *Agent) CopyIncludes() (err error) {
 }
 
 // RunProducts executes all seekers for this run.
+// TODO(mkcp): This is due for a bit of a redesign
 func (a *Agent) RunProducts() error {
 	// Set up our waitgroup to make sure we don't proceed until all products execute.
 	wg := sync.WaitGroup{}
@@ -275,10 +276,7 @@ func (a *Agent) RunProducts() error {
 	//   This is a little complex, but saves us duplication in the product loop. Maybe we extract this to a private
 	//   package function in the future?
 	run := func(wg *sync.WaitGroup, name string, product *product.Product) {
-		result, err := product.Run()
-		if err != nil {
-			a.l.Error("Error running seekers", "product", product, "error", err)
-		}
+		result := product.Run()
 
 		// Write results
 		a.resultsLock.Lock()

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -123,12 +123,12 @@ func TestCopyIncludes(t *testing.T) {
 }
 
 func TestRunProducts(t *testing.T) {
+	l := hclog.Default()
 	pCfg := product.Config{OS: "auto"}
 	p := make(map[string]*product.Product)
-	p["host"] = product.NewHost(pCfg)
-
 	a := NewAgent(Config{}, hclog.Default())
 	a.products = p
+	p["host"] = product.NewHost(l, pCfg)
 
 	err := a.RunProducts()
 	assert.NoError(t, err)
@@ -143,7 +143,7 @@ func TestAgent_RecordManifest(t *testing.T) {
 		a := NewAgent(Config{}, hclog.Default())
 		pCfg := product.Config{OS: "auto"}
 		p := make(map[string]*product.Product)
-		p[testProduct] = product.NewHost(pCfg)
+		p[testProduct] = product.NewHost(hclog.Default(), pCfg)
 		a.products = p
 		assert.NotEmptyf(t, a.products[testProduct].Seekers, "test setup failure, no seekers available")
 

--- a/product/consul.go
+++ b/product/consul.go
@@ -28,7 +28,7 @@ func NewConsul(logger hclog.Logger, cfg Config) (*Product, error) {
 		return nil, err
 	}
 	return &Product{
-		l:       logger,
+		l:       logger.Named("product"),
 		Name:    Consul,
 		Seekers: seekers,
 		Config:  cfg,

--- a/product/consul.go
+++ b/product/consul.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/hashicorp/go-hclog"
+
 	"github.com/hashicorp/hcdiag/client"
 	s "github.com/hashicorp/hcdiag/seeker"
 	logs "github.com/hashicorp/hcdiag/seeker/log"
@@ -15,7 +17,7 @@ const (
 )
 
 // NewConsul takes a product config and creates a Product with all of Consul's default seekers
-func NewConsul(cfg Config) (*Product, error) {
+func NewConsul(logger hclog.Logger, cfg Config) (*Product, error) {
 	api, err := client.NewConsulAPI()
 	if err != nil {
 		return nil, err
@@ -26,8 +28,10 @@ func NewConsul(cfg Config) (*Product, error) {
 		return nil, err
 	}
 	return &Product{
+		l:       logger,
 		Name:    Consul,
 		Seekers: seekers,
+		Config:  cfg,
 	}, nil
 }
 

--- a/product/host.go
+++ b/product/host.go
@@ -12,7 +12,7 @@ import (
 // NewHost takes a product config and creates a Product containing all of the host's seekers.
 func NewHost(logger hclog.Logger, cfg Config) *Product {
 	return &Product{
-		l:       logger,
+		l:       logger.Named("product"),
 		Name:    Host,
 		Seekers: HostSeekers(cfg.OS),
 		Config:  cfg,

--- a/product/host.go
+++ b/product/host.go
@@ -3,15 +3,19 @@ package product
 import (
 	"runtime"
 
+	"github.com/hashicorp/go-hclog"
+
 	"github.com/hashicorp/hcdiag/seeker"
 	"github.com/hashicorp/hcdiag/seeker/host"
 )
 
 // NewHost takes a product config and creates a Product containing all of the host's seekers.
-func NewHost(cfg Config) *Product {
+func NewHost(logger hclog.Logger, cfg Config) *Product {
 	return &Product{
+		l:       logger,
 		Name:    Host,
 		Seekers: HostSeekers(cfg.OS),
+		Config:  cfg,
 	}
 }
 

--- a/product/nomad.go
+++ b/product/nomad.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/hashicorp/go-hclog"
+
 	"github.com/hashicorp/hcdiag/client"
 	s "github.com/hashicorp/hcdiag/seeker"
 	logs "github.com/hashicorp/hcdiag/seeker/log"
@@ -18,7 +20,7 @@ const (
 )
 
 // NewNomad takes a product config and creates a Product with all of Nomad's default seekers
-func NewNomad(cfg Config) (*Product, error) {
+func NewNomad(logger hclog.Logger, cfg Config) (*Product, error) {
 	api, err := client.NewNomadAPI()
 	if err != nil {
 		return nil, err
@@ -40,8 +42,10 @@ func NewNomad(cfg Config) (*Product, error) {
 	}
 
 	return &Product{
+		l:       logger,
 		Name:    Nomad,
 		Seekers: seekers,
+		Config:  cfg,
 	}, nil
 }
 

--- a/product/nomad.go
+++ b/product/nomad.go
@@ -42,7 +42,7 @@ func NewNomad(logger hclog.Logger, cfg Config) (*Product, error) {
 	}
 
 	return &Product{
-		l:       logger,
+		l:       logger.Named("product"),
 		Name:    Nomad,
 		Seekers: seekers,
 		Config:  cfg,

--- a/product/product.go
+++ b/product/product.go
@@ -41,14 +41,14 @@ type Product struct {
 }
 
 // Run runs the seekers
-// TODO(mkcp): Should we return a collection of errors from here?
-func (p *Product) Run() (map[string]interface{}, error) {
+func (p *Product) Run() map[string]interface{} {
 	p.l.Info("Running seekers for", "product", p.Name)
 	results := make(map[string]interface{})
 	for _, s := range p.Seekers {
 		p.l.Info("running operation", "product", p.Name, "seeker", s.Identifier)
 		result, err := s.Run()
 		results[s.Identifier] = s
+		// Note seeker errors to users and keep going.
 		if err != nil {
 			p.l.Warn("result",
 				"seeker", s.Identifier,
@@ -57,7 +57,7 @@ func (p *Product) Run() (map[string]interface{}, error) {
 			)
 		}
 	}
-	return results, nil
+	return results
 }
 
 // Filter applies our slices of exclude and select seeker.Identifier matchers to the set of the product's seekers

--- a/product/product.go
+++ b/product/product.go
@@ -22,7 +22,6 @@ const (
 )
 
 type Config struct {
-	Logger        *hclog.Logger
 	Name          string
 	TmpDir        string
 	Since         time.Time
@@ -33,10 +32,32 @@ type Config struct {
 }
 
 type Product struct {
+	l        hclog.Logger
 	Name     string
 	Seekers  []*seeker.Seeker
 	Excludes []string
 	Selects  []string
+	Config   Config
+}
+
+// Run runs the seekers
+// TODO(mkcp): Should we return a collection of errors from here?
+func (p *Product) Run() (map[string]interface{}, error) {
+	p.l.Info("Running seekers for", "product", p.Name)
+	results := make(map[string]interface{})
+	for _, s := range p.Seekers {
+		p.l.Info("running operation", "product", p.Name, "seeker", s.Identifier)
+		result, err := s.Run()
+		results[s.Identifier] = s
+		if err != nil {
+			p.l.Warn("result",
+				"seeker", s.Identifier,
+				"result", fmt.Sprintf("%s", result),
+				"error", err,
+			)
+		}
+	}
+	return results, nil
 }
 
 // Filter applies our slices of exclude and select seeker.Identifier matchers to the set of the product's seekers

--- a/product/tfe.go
+++ b/product/tfe.go
@@ -1,12 +1,13 @@
 package product
 
 import (
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcdiag/client"
 	s "github.com/hashicorp/hcdiag/seeker"
 )
 
 // NewTFE takes a product config and creates a Product containing all of TFE's seekers.
-func NewTFE(cfg Config) (*Product, error) {
+func NewTFE(logger hclog.Logger, cfg Config) (*Product, error) {
 	api, err := client.NewTFEAPI()
 	if err != nil {
 		return nil, err
@@ -17,8 +18,10 @@ func NewTFE(cfg Config) (*Product, error) {
 		return nil, err
 	}
 	return &Product{
+		l:       logger,
 		Name:    TFE,
 		Seekers: seekers,
+		Config:  cfg,
 	}, nil
 }
 

--- a/product/tfe.go
+++ b/product/tfe.go
@@ -18,7 +18,7 @@ func NewTFE(logger hclog.Logger, cfg Config) (*Product, error) {
 		return nil, err
 	}
 	return &Product{
-		l:       logger,
+		l:       logger.Named("product"),
 		Name:    TFE,
 		Seekers: seekers,
 		Config:  cfg,

--- a/product/vault.go
+++ b/product/vault.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/hashicorp/go-hclog"
+
 	logs "github.com/hashicorp/hcdiag/seeker/log"
 
 	"github.com/hashicorp/hcdiag/client"
@@ -16,7 +18,7 @@ const (
 )
 
 // NewVault takes a product config and creates a Product containing all of Vault's seekers.
-func NewVault(cfg Config) (*Product, error) {
+func NewVault(logger hclog.Logger, cfg Config) (*Product, error) {
 	api, err := client.NewVaultAPI()
 	if err != nil {
 		return nil, err
@@ -27,8 +29,10 @@ func NewVault(cfg Config) (*Product, error) {
 		return nil, err
 	}
 	return &Product{
+		l:       logger,
 		Name:    Vault,
 		Seekers: seekers,
+		Config:  cfg,
 	}, nil
 }
 

--- a/product/vault.go
+++ b/product/vault.go
@@ -29,7 +29,7 @@ func NewVault(logger hclog.Logger, cfg Config) (*Product, error) {
 		return nil, err
 	}
 	return &Product{
-		l:       logger,
+		l:       logger.Named("product"),
 		Name:    Vault,
 		Seekers: seekers,
 		Config:  cfg,


### PR DESCRIPTION
This PR aims to fix a strange abstraction jump where products store a list of seekers and have everything they need to run them, but instead the agent reached in and called seeker.Run() itself. This was a half-hearted attempt to use immutable data, but there's a better way we can accomplish the same thing. Instead, we have a product.Run() function that returns the immutable results, while all of the stateful stuff stays within the boundary of the methods operating on the product struct. Products also now need an application logger because that was previously read off of the agent.

Much better! 