### PR TITLE
Update Slack Notification Channel & Extend Integration Test Workflow Triggers

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -1,11 +1,19 @@
 name: test-integration
 on:
+  # Allow manual runs
+  workflow_dispatch:
+
   push:
-    branches: [main]
+    branches:
+      - "main"
+      - "release/**"
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+*"
-  pull_request_review:
-    types: [submitted, dismissed]
+
+  pull_request:
+    branches:
+      - "main"
+      - "release/**"
 
 jobs:
   test-functional:

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -4,7 +4,7 @@ project "hcdiag" {
   // the team key is not used by CRT currently
   team = "hcdiag"
   slack {
-    notification_channel = "C02DAMQFX36" // Team Customer Connections
+    notification_channel = "C03LH6ELB5E" // hcdiag project channel
   }
   github {
     organization = "hashicorp"


### PR DESCRIPTION
The Slack notification channel in our release definition is updated to point to the hcdiag project channel, as opposed to a team channel.

Additionally, the functional test workflow has been updated for the following:
1. We can now trigger the workflow manually instead of only through automation;
2. Pushes to both main and any release branch will trigger the workflow;
3. The workflow is triggered when pull requests are opened, synchronized (changes pushed), or re-opened, as opposed to triggering on review comments.