### PR TITLE
Standardize Agent Test Definitions

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -117,7 +117,7 @@ func TestCopyIncludes(t *testing.T) {
 
 	// execute what we're aiming to test
 	err = a.CopyIncludes()
-	assert.NoError(t, err, "could not copy includes")
+	assert.NoError(t, err, "Could not copy includes")
 
 	// verify expected file locations
 	for _, data := range testTable {
@@ -203,45 +203,58 @@ func TestWriteOutput(t *testing.T) {
 }
 
 func TestSetup(t *testing.T) {
-	t.Run("Should only get host if no products enabled", func(t *testing.T) {
-		cfg := Config{OS: "auto"}
-		a := NewAgent(cfg, hclog.Default())
-		p, err := a.Setup()
-		assert.NoError(t, err)
-		assert.Len(t, p, 1)
-	})
-	t.Run("Should have host and nomad enabled", func(t *testing.T) {
-		cfg := Config{
-			Nomad: true,
-			OS:    "auto",
-		}
-		a := NewAgent(cfg, hclog.Default())
-		p, err := a.Setup()
-		assert.NoError(t, err)
-		assert.Len(t, p, 2)
-	})
+	testCases := []struct {
+		name        string
+		cfg         Config
+		expectedLen int
+	}{
+		{
+			name: "Should only get host if no products enabled",
+			cfg: Config{
+				OS: "auto",
+			},
+			expectedLen: 1,
+		},
+		{
+			name: "Should have host and nomad enabled",
+			cfg: Config{
+				Nomad: true,
+				OS:    "auto",
+			},
+			expectedLen: 2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := NewAgent(tc.cfg, hclog.Default())
+			p, err := a.Setup()
+			assert.NoError(t, err)
+			assert.Len(t, p, tc.expectedLen)
+		})
+	}
 }
 
 func TestParseHCL(t *testing.T) {
-	testTable := []struct {
-		desc   string
+	testCases := []struct {
+		name   string
 		path   string
 		expect Config
 	}{
 		{
-			desc:   "Empty config is valid",
+			name:   "Empty config is valid",
 			path:   "../tests/resources/config/empty.hcl",
 			expect: Config{},
 		},
 		{
-			desc: "Host with no attributes is valid",
+			name: "Host with no attributes is valid",
 			path: "../tests/resources/config/host_no_seekers.hcl",
 			expect: Config{
 				Host: &HostConfig{},
 			},
 		},
 		{
-			desc: "Host with one of each seeker is valid",
+			name: "Host with one of each seeker is valid",
 			path: "../tests/resources/config/host_each_seeker.hcl",
 			expect: Config{
 				Host: &HostConfig{
@@ -261,7 +274,7 @@ func TestParseHCL(t *testing.T) {
 			},
 		},
 		{
-			desc: "Host with multiple of a seeker type is valid",
+			name: "Host with multiple of a seeker type is valid",
 			path: "../tests/resources/config/multi_seekers.hcl",
 			expect: Config{
 				Host: &HostConfig{
@@ -283,7 +296,7 @@ func TestParseHCL(t *testing.T) {
 			},
 		},
 		{
-			desc: "Config with a host and one product with everything is valid",
+			name: "Config with a host and one product with everything is valid",
 			path: "../tests/resources/config/config.hcl",
 			expect: Config{
 				Host: &HostConfig{
@@ -317,7 +330,7 @@ func TestParseHCL(t *testing.T) {
 			},
 		},
 		{
-			desc: "Config with multiple products is valid",
+			name: "Config with multiple products is valid",
 			path: "../tests/resources/config/multi_product.hcl",
 			expect: Config{
 				Products: []*ProductConfig{
@@ -338,10 +351,12 @@ func TestParseHCL(t *testing.T) {
 		},
 	}
 
-	for _, c := range testTable {
-		res, err := ParseHCL(c.path)
-		assert.NoError(t, err)
-		assert.Equal(t, c.expect, res, c.desc)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := ParseHCL(tc.path)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expect, res, tc.name)
+		})
 	}
 }
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -22,26 +22,17 @@ func TestNewAgent(t *testing.T) {
 func TestStartAndEnd(t *testing.T) {
 	a := NewAgent(Config{}, hclog.Default())
 
-	// Start and End fields should be nil at first,
+	// Start and End fields should be zero at first,
 	// and Duration should be empty ""
-	if !a.Start.IsZero() {
-		t.Errorf("Start value non-zero before start(): %s", a.Start)
-	}
-	if !a.End.IsZero() {
-		t.Errorf("End value non-zero before start(): %s", a.Start)
-	}
-	if a.Duration != "" {
-		t.Errorf("Duration value not an empty string before start(): %s", a.Duration)
-	}
+	assert.Zero(t, a.Start, "Start value non-zero before start")
+	assert.Zero(t, a.End, "End value non-zero before start")
+	assert.Equal(t, "", a.Duration, "Duration value not an empty string before start")
 
 	// recordEnd should set a time and calculate a duration
 	a.recordEnd()
-	if a.End.IsZero() {
-		t.Errorf("End value still zero after start(): %s", a.Start)
-	}
-	if a.Duration == "" {
-		t.Error("Duration value still an empty string after start()")
-	}
+
+	assert.NotZero(t, a.End, "End value still zero after recordEnd()")
+	assert.NotEqual(t, "", a.Duration, "Duration value still an empty string after recordEnd()")
 }
 
 func TestCreateTemp(t *testing.T) {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -138,7 +138,6 @@ func TestRunProducts(t *testing.T) {
 
 	a := NewAgent(Config{}, hclog.Default())
 	a.products = p
-	a.results = make(map[string]map[string]interface{})
 
 	err := a.RunProducts()
 	assert.NoError(t, err)
@@ -165,7 +164,6 @@ func TestAgent_RecordManifest(t *testing.T) {
 
 func TestWriteOutput(t *testing.T) {
 	a := NewAgent(Config{}, hclog.Default())
-	a.results = make(map[string]map[string]interface{})
 
 	testOut := "."
 	resultsDest := a.TempDir() + ".tar.gz"
@@ -174,13 +172,20 @@ func TestWriteOutput(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to create tempDir, err=%s", err)
 	}
+
 	defer func() {
 		if err := a.Cleanup(); err != nil {
 			a.l.Error("Failed to cleanup", "error", err)
 		}
 	}()
-	// NOTE(mkcp): Should we handle the error back from this?
-	defer os.Remove(resultsDest)
+
+	defer func() {
+		err := os.Remove(resultsDest)
+		if err != nil {
+			// Simply log this case because it's not an error in the function we're testing
+			t.Logf("Error removing test results file: %s", resultsDest)
+		}
+	}()
 
 	if err := a.WriteOutput(); err != nil {
 		t.Errorf("Error writing outputs: %s", err)


### PR DESCRIPTION
This PR attempts to improve standardization among agent_test.go test definitions. Specifically, the following improvements are included:

1. Cases where Agent objects had been manually created have been replaced with calls to NewAgent()
2. Test Table definitions have been made more consistent with test tables in other parts of the code
3. Conditionals on test assertions have been replaced with more concise calls to functions from the testify/assert package
4. An unhandled deferred file cleanup error is now handled with a t.Log message