### PR TITLE
Print Summary to Standard Out at end of Agent Run

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -538,6 +538,22 @@ func ParseHCL(path string) (Config, error) {
 	return config, nil
 }
 
+func formatReportLine(cells ...string) string {
+	format := ""
+
+	// The coercion from the argument of type []string to type []interface is required for the later
+	// call to fmt.Sprintf, in which variadic arguments must be of type any/interface{}.
+	strValues := make([]interface{}, len(cells))
+	for i, cell := range cells {
+		format += "%s\t"
+		strValues[i] = cell
+	}
+
+	format += "\n"
+
+	return fmt.Sprintf(format, strValues...)
+}
+
 // TODO(mkcp): This duplicates much of customSeekers and can certainly be improved.
 func customHostSeekers(cfg *HostConfig, tmpDir string) ([]*seeker.Seeker, error) {
 	seekers := make([]*seeker.Seeker, 0)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -550,17 +550,6 @@ func ParseHCL(path string) (Config, error) {
 // WriteSummary writes a summary report that includes the products and seeker statuses present in the agent's
 // ManifestSeekers. The intended use case is to write to output at the end of the Agent's Run.
 func (a *Agent) WriteSummary(writer io.Writer) error {
-	title := "SUMMARY OF SEEKER STATUS BY PRODUCT"
-	_, err := fmt.Fprintln(writer, title)
-	if err != nil {
-		return err
-	}
-
-	_, err = fmt.Fprintln(writer, strings.Repeat("-", len(title)))
-	if err != nil {
-		return err
-	}
-
 	t := tabwriter.NewWriter(writer, 0, 0, 2, ' ', 0)
 	headers := []string{
 		"product",
@@ -570,7 +559,7 @@ func (a *Agent) WriteSummary(writer io.Writer) error {
 		"total",
 	}
 
-	_, err = fmt.Fprint(t, formatReportLine(headers...))
+	_, err := fmt.Fprint(t, formatReportLine(headers...))
 	if err != nil {
 		return err
 	}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -358,6 +358,10 @@ func TestParseHCL(t *testing.T) {
 }
 
 func TestAgent_WriteSummary(t *testing.T) {
+	// NOTE: If you make changes to WriteSummary, you may break existing unit tests until the golden files are updated
+	// to reflect your changes. To update them, run `go test ./agent -update`, and then manually verify that the new
+	// files under testdata/WriteSummary look like you expect. If so, commit them to source control, and future
+	// test executions should succeed.
 	testCases := []struct {
 		name  string
 		agent *Agent

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -351,6 +351,37 @@ func TestParseHCL(t *testing.T) {
 	}
 }
 
+func Test_formatReportLine(t *testing.T) {
+	testCases := []struct {
+		name   string
+		cells  []string
+		expect string
+	}{
+		{
+			name:   "Test Nil Input",
+			cells:  nil,
+			expect: "\n",
+		},
+		{
+			name:   "Test Empty Input",
+			cells:  []string{},
+			expect: "\n",
+		},
+		{
+			name:   "Test Sample Header Row",
+			cells:  []string{"product", "success", "failed", "unknown", "total"},
+			expect: "product\tsuccess\tfailed\tunknown\ttotal\t\n",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := formatReportLine(tc.cells...)
+			assert.Equal(t, tc.expect, res, tc.name)
+		})
+	}
+}
+
 func cleanupHelper(t *testing.T, a *Agent) {
 	err := a.Cleanup()
 	if err != nil {

--- a/agent/testdata/WriteSummary/Test Header Only.golden
+++ b/agent/testdata/WriteSummary/Test Header Only.golden
@@ -1,0 +1,3 @@
+SUMMARY OF SEEKER STATUS BY PRODUCT
+-----------------------------------
+product  success  fail  unknown  total  

--- a/agent/testdata/WriteSummary/Test Header Only.golden
+++ b/agent/testdata/WriteSummary/Test Header Only.golden
@@ -1,3 +1,1 @@
-SUMMARY OF SEEKER STATUS BY PRODUCT
------------------------------------
 product  success  fail  unknown  total  

--- a/agent/testdata/WriteSummary/Test with Products.golden
+++ b/agent/testdata/WriteSummary/Test with Products.golden
@@ -1,5 +1,3 @@
-SUMMARY OF SEEKER STATUS BY PRODUCT
------------------------------------
 product  success  fail  unknown  total  
 consul   2        1     1        4      
 nomad    0        1     1        2      

--- a/agent/testdata/WriteSummary/Test with Products.golden
+++ b/agent/testdata/WriteSummary/Test with Products.golden
@@ -1,0 +1,5 @@
+SUMMARY OF SEEKER STATUS BY PRODUCT
+-----------------------------------
+product  success  fail  unknown  total  
+consul   2        1     1        4      
+nomad    0        1     1        2      


### PR DESCRIPTION
This merge adds a summary report to the end of an hcdiag agent run, with the intention of making it a bit easier for users to quickly see the overall status of seekers. The report is a simple table, which includes - for each product that was part of the run - a count of successful, failed, and unknown seekers, as well as the total number of seekers.

Unlike log messages, the report goes to Standard Out, meaning the run can be piped to an output file if desired.