### PR TITLE
migrate the weird curl host getter into its own seeker type

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/hcdiag/seeker/host"
+
 	"github.com/hashicorp/hcdiag/client"
 	"github.com/hashicorp/hcdiag/version"
 	"github.com/hashicorp/hcl/v2/hclsimple"
@@ -525,11 +527,7 @@ func customHostSeekers(cfg *HostConfig, tmpDir string) ([]*seeker.Seeker, error)
 	}
 
 	for _, g := range cfg.GETs {
-		cmd := strings.Join([]string{"curl -s", g.Path}, " ")
-		// NOTE(mkcp): We will get JSON back from a lot of requests, so this can be improved
-		format := "string"
-		cmder := seeker.NewCommander(cmd, format)
-		seekers = append(seekers, cmder)
+		seekers = append(seekers, host.NewGetter(g.Path))
 	}
 
 	// Build copiers

--- a/seeker/host/get.go
+++ b/seeker/host/get.go
@@ -1,0 +1,29 @@
+package host
+
+import (
+	"strings"
+
+	"github.com/hashicorp/hcdiag/seeker"
+)
+
+var _ seeker.Runner = Get{}
+
+type Get struct {
+	path string
+}
+
+func NewGetter(path string) *seeker.Seeker {
+	return &seeker.Seeker{
+		Identifier: "GET" + " " + path,
+		Runner: Get{
+			path: path,
+		},
+	}
+}
+
+func (g Get) Run() (interface{}, seeker.Status, error) {
+	cmd := strings.Join([]string{"curl -s", g.path}, " ")
+	// NOTE(mkcp): We will get JSON back from a lot of requests, so this can be improved
+	format := "string"
+	return seeker.NewCommander(cmd, format).Runner.Run()
+}


### PR DESCRIPTION
This little seeker here is the reason why we have two different functions to create custom seekers for normal products and for hosts! Now that we've extracted it as a seeker, it should be possible to collapse those functions into one when we rework the configuration. This is a small incremental step because ideally it'll just use an HTTPer -- that wasn't possible before because the host didn't have state to hold a client. So we're making things a little better in the meantime, so we can make it much better in the future.

Example config:
```
host {
  GET {
    path = "google.com"
  }
}
```

Here's how it looks in Results.json:
```
"GET google.com": {
      "runner": {},
      "result": "<HTML><HEAD><meta http-equiv=\"content-type\" content=\"text/html;charset=utf-8\">\n<TITLE>301 Moved</TITLE></HEAD><BODY>\n<H1>301 Moved</H1>\nThe document has moved\n<A HREF=\"http://www.google.com/\">here</A>.\r\n</BODY></HTML>\r",
      "error": "",
      "status": "success"
    },
