### PR TITLE
Display Summary Report Alphabetically by Product

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -539,11 +539,9 @@ func (a *Agent) WriteSummary(writer io.Writer) error {
 
 	// For deterministic output, we sort the products in alphabetical order. Otherwise, ranging over the map
 	// a.ManifestSeekers directly, we wouldn't know for certain which order the keys - and therefore the rows - would be in.
-	products := make([]string, len(a.ManifestSeekers))
-	i := 0
+	var products []string
 	for k := range a.ManifestSeekers {
-		products[i] = k
-		i++
+		products = append(products, k)
 	}
 	sort.Strings(products)
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -536,8 +537,19 @@ func (a *Agent) WriteSummary(writer io.Writer) error {
 		return err
 	}
 
-	for prod, seekers := range a.ManifestSeekers {
+	// For deterministic output, we sort the products in alphabetical order. Otherwise, ranging over the map
+	// a.ManifestSeekers directly, we wouldn't know for certain which order the keys - and therefore the rows - would be in.
+	products := make([]string, len(a.ManifestSeekers))
+	i := 0
+	for k := range a.ManifestSeekers {
+		products[i] = k
+		i++
+	}
+	sort.Strings(products)
+
+	for _, prod := range products {
 		var success, fail, unknown int
+		seekers := a.ManifestSeekers[prod]
 
 		for _, s := range seekers {
 			switch s.Status {


### PR DESCRIPTION
Report output is now sorted alphabetically by product name, rather than nondeterministically. This should be a better user experience, knowing where a product should appear in the report. And, it should fix sporadic unit test failures, which had been written with an (incorrect) assumption that the order of reports would be deterministic already.