### PR TITLE
Split runners and ops

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -114,8 +114,8 @@ func (a *Agent) Run() []error {
 	// Store products
 	a.products = p
 
-	// Sum up all ops from products
-	a.NumOps = product.CountOps(a.products)
+	// Sum up all runners from products
+	a.NumOps = product.CountRunners(a.products)
 
 	// Run products
 	a.l.Info("Gathering diagnostics")

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -151,7 +151,7 @@ func TestAgent_RecordManifest(t *testing.T) {
 		p := make(map[string]*product.Product)
 		p[testProduct] = product.NewHost(hclog.Default(), pCfg)
 		a.products = p
-		assert.NotEmptyf(t, a.products[testProduct].Ops, "test setup failure, no ops available")
+		assert.NotEmptyf(t, a.products[testProduct].Runners, "test setup failure, no ops available")
 
 		// Record and check
 		a.RecordManifest()

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -146,12 +146,12 @@ func TestAgent_RecordManifest(t *testing.T) {
 	t.Run("adds to ManifestOps when ops exist", func(t *testing.T) {
 		// Setup
 		testProduct := "host"
+		testResults := map[string]op.Op{
+			"": {},
+		}
 		a := NewAgent(Config{}, hclog.Default())
-		pCfg := product.Config{OS: "auto"}
-		p := make(map[string]*product.Product)
-		p[testProduct] = product.NewHost(hclog.Default(), pCfg)
-		a.products = p
-		assert.NotEmptyf(t, a.products[testProduct].Runners, "test setup failure, no ops available")
+		a.results[testProduct] = testResults
+		assert.NotEmptyf(t, a.results[testProduct], "test setup failure, no ops available")
 
 		// Record and check
 		a.RecordManifest()

--- a/op/commander.go
+++ b/op/commander.go
@@ -36,12 +36,11 @@ func (c Commander) params() map[string]string {
 	}
 }
 
-func (c Commander) genOp(result interface{}, status Status, err error) Op {
+func (c Commander) op(result interface{}, status Status, err error) Op {
 	return Op{
 		Identifier: c.ID(),
 		Result:     result,
 		Error:      err,
-		ErrString:  err.Error(),
 		Status:     status,
 		Params:     util.RunnerParams(c),
 	}
@@ -61,7 +60,7 @@ func (c Commander) Run() Op {
 	bts, err := exec.Command(cmd, args...).CombinedOutput()
 	if err != nil {
 		err1 := CommandExecError{command: c.command, format: c.format, err: err}
-		return c.genOp(string(bts), Unknown, err1)
+		return c.op(string(bts), Unknown, err1)
 	}
 
 	// Parse result
@@ -73,14 +72,14 @@ func (c Commander) Run() Op {
 	case c.format == "json":
 		if err := json.Unmarshal(bts, &result); err != nil {
 			// Return the command's response even if we can't parse it as json
-			return c.genOp(string(bts), Unknown, UnmarshalError{command: c.command, err: err})
+			return c.op(string(bts), Unknown, UnmarshalError{command: c.command, err: err})
 		}
 
 	default:
-		return c.genOp(result, Fail, FormatUnknownError{command: c.command, format: c.format})
+		return c.op(result, Fail, FormatUnknownError{command: c.command, format: c.format})
 	}
 
-	return c.genOp(result, Success, nil)
+	return c.op(result, Success, nil)
 }
 
 type CommandExecError struct {

--- a/op/commander.go
+++ b/op/commander.go
@@ -7,28 +7,49 @@ import (
 	"strings"
 )
 
+var _ Runner = Commander{}
+
 // Commander runs shell commands.
 type Commander struct {
-	Command string `json:"command"`
+	command string
 	format  string
 }
 
 // NewCommander provides a Op for running shell commands.
-func NewCommander(command string, format string) *Op {
-	return &Op{
-		Identifier: command,
-		Runner: Commander{
-			Command: command,
-			format:  format,
-		},
+func NewCommander(command string, format string) *Commander {
+	return &Commander{
+		command: command,
+		format:  format,
+	}
+}
+
+func (c Commander) ID() string {
+	return c.command
+}
+
+func (c Commander) params() map[string]string {
+	return map[string]string{
+		"command": c.command,
+		"format":  c.format,
+	}
+}
+
+func (c Commander) genOp(result interface{}, status Status, err error) Op {
+	return Op{
+		Identifier: c.ID(),
+		Result:     result,
+		Error:      err,
+		ErrString:  err.Error(),
+		Status:     status,
+		Params:     c.params(),
 	}
 }
 
 // Run executes the Command
-func (c Commander) Run() (interface{}, Status, error) {
+func (c Commander) Run() Op {
 	var result interface{}
 
-	bits := strings.Split(c.Command, " ")
+	bits := strings.Split(c.command, " ")
 	cmd := bits[0]
 	args := bits[1:]
 
@@ -37,7 +58,8 @@ func (c Commander) Run() (interface{}, Status, error) {
 	// Execute command
 	bts, err := exec.Command(cmd, args...).CombinedOutput()
 	if err != nil {
-		return string(bts), Unknown, CommandExecError{command: c.Command, format: c.format, err: err}
+		err1 := CommandExecError{command: c.command, format: c.format, err: err}
+		return c.genOp(string(bts), Unknown, err1)
 	}
 
 	// Parse result
@@ -49,14 +71,14 @@ func (c Commander) Run() (interface{}, Status, error) {
 	case c.format == "json":
 		if err := json.Unmarshal(bts, &result); err != nil {
 			// Return the command's response even if we can't parse it as json
-			return string(bts), Unknown, UnmarshalError{command: c.Command, err: err}
+			return c.genOp(string(bts), Unknown, UnmarshalError{command: c.command, err: err})
 		}
 
 	default:
-		return result, Fail, FormatUnknownError{command: c.Command, format: c.format}
+		return c.genOp(result, Fail, FormatUnknownError{command: c.command, format: c.format})
 	}
 
-	return result, Success, nil
+	return c.genOp(result, Success, nil)
 }
 
 type CommandExecError struct {

--- a/op/commander.go
+++ b/op/commander.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+
+	"github.com/hashicorp/hcdiag/util"
 )
 
 var _ Runner = Commander{}
@@ -41,7 +43,7 @@ func (c Commander) genOp(result interface{}, status Status, err error) Op {
 		Error:      err,
 		ErrString:  err.Error(),
 		Status:     status,
-		Params:     c.params(),
+		Params:     util.RunnerParams(c),
 	}
 }
 

--- a/op/commander_test.go
+++ b/op/commander_test.go
@@ -10,15 +10,14 @@ import (
 )
 
 func TestNewCommander(t *testing.T) {
+	testCmd := "echo hello"
+	testFmt := "string"
 	expect := &Commander{
-		command: "echo hello",
-		format:  "string",
+		command: testCmd,
+		format:  testFmt,
 	}
-	actual := NewCommander("echo hello", "string")
-	// TODO: proper comparison, my IDE doesn't like this: "avoid using reflect.DeepEqual with errors"
-	if !reflect.DeepEqual(&expect, actual) {
-		t.Errorf("expected (%#v) does not match actual (%#v)", expect, actual)
-	}
+	actual := NewCommander(testCmd, testFmt)
+	assert.Equal(t, expect, actual)
 }
 
 func TestCommander_Run(t *testing.T) {

--- a/op/commander_test.go
+++ b/op/commander_test.go
@@ -10,12 +10,9 @@ import (
 )
 
 func TestNewCommander(t *testing.T) {
-	expect := Op{
-		Identifier: "echo hello",
-		Runner: Commander{
-			Command: "echo hello",
-			format:  "string",
-		},
+	expect := &Commander{
+		command: "echo hello",
+		format:  "string",
 	}
 	actual := NewCommander("echo hello", "string")
 	// TODO: proper comparison, my IDE doesn't like this: "avoid using reflect.DeepEqual with errors"
@@ -52,10 +49,10 @@ func TestCommander_Run(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.desc, func(t *testing.T) {
 			c := NewCommander(tc.command, tc.format)
-			result, status, err := c.Runner.Run()
-			assert.NoError(t, err)
-			assert.Equal(t, Success, status)
-			assert.Equal(t, tc.expect, result)
+			o := c.Run()
+			assert.NoError(t, o.Error)
+			assert.Equal(t, Success, o.Status)
+			assert.Equal(t, tc.expect, o.Result)
 		})
 	}
 }
@@ -86,12 +83,12 @@ func TestCommander_RunError(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.desc, func(t *testing.T) {
 			c := NewCommander(tc.command, tc.format)
-			result, status, err := c.Runner.Run()
-			assert.Error(t, err)
-			hclog.L().Trace("commander.Run() errored", "error", err, "error type", reflect.TypeOf(err))
-			assert.Equal(t, tc.status, status)
+			o := c.Run()
+			assert.Error(t, o.Error)
+			hclog.L().Trace("commander.Run() errored", "error", o.Error, "error type", reflect.TypeOf(o.Error))
+			assert.Equal(t, tc.status, o.Status)
 			if tc.expect != nil {
-				assert.Equal(t, tc.expect, result)
+				assert.Equal(t, tc.expect, o.Result)
 			}
 		})
 	}

--- a/op/copier.go
+++ b/op/copier.go
@@ -41,7 +41,7 @@ func (c Copier) Run() Op {
 	// Ensure destination directory exists
 	err := os.MkdirAll(c.DestDir, 0755)
 	if err != nil {
-		return c.op(nil, Fail, MakeDirError{
+		return New(c, nil, Fail, MakeDirError{
 			path: c.DestDir,
 			err:  err,
 		})
@@ -50,7 +50,7 @@ func (c Copier) Run() Op {
 	// Find all the files
 	files, err := util.FilterWalk(c.SourceDir, c.Filter, c.Since, c.Until)
 	if err != nil {
-		return c.op(nil, Fail, FindFilesError{
+		return New(c, nil, Fail, FindFilesError{
 			path: c.SourceDir,
 			err:  err,
 		})
@@ -60,7 +60,7 @@ func (c Copier) Run() Op {
 	for _, s := range files {
 		err = util.CopyDir(c.DestDir, s)
 		if err != nil {
-			return c.op(nil, Fail, CopyFilesError{
+			return New(c, nil, Fail, CopyFilesError{
 				dest:  c.DestDir,
 				files: files,
 				err:   err,
@@ -68,17 +68,7 @@ func (c Copier) Run() Op {
 		}
 	}
 
-	return c.op(files, Success, nil)
-}
-
-func (c Copier) op(result interface{}, status Status, err error) Op {
-	return Op{
-		Identifier: c.ID(),
-		Result:     result,
-		Error:      err,
-		Status:     status,
-		Params:     util.RunnerParams(c),
-	}
+	return New(c, files, Success, nil)
 }
 
 type MakeDirError struct {

--- a/op/copier.go
+++ b/op/copier.go
@@ -75,7 +75,6 @@ func (c Copier) op(result interface{}, status Status, err error) Op {
 	return Op{
 		Identifier: c.ID(),
 		Result:     result,
-		ErrString:  err.Error(),
 		Error:      err,
 		Status:     status,
 		Params:     util.RunnerParams(c),

--- a/op/copier.go
+++ b/op/copier.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/hcdiag/util"
 )
 
+var _ Runner = Copier{}
+
 // Copier copies files to temp dir based on a filter.
 type Copier struct {
 	SourceDir string    `json:"source_directory"`
@@ -18,54 +20,66 @@ type Copier struct {
 	Until     time.Time `json:"until"`
 }
 
-// NewCopier provides a Op for copying files to temp dir based on a filter.
-func NewCopier(path, destDir string, since, until time.Time) *Op {
+// NewCopier provides a Runner for copying files to temp dir based on a filter.
+func NewCopier(path, destDir string, since, until time.Time) *Copier {
 	sourceDir, filter := util.SplitFilepath(path)
-	return &Op{
-		Identifier: "copy " + filepath.Join(sourceDir, filter),
-		Runner: Copier{
-			SourceDir: sourceDir,
-			Filter:    filter,
-			DestDir:   destDir,
-			Since:     since,
-			Until:     until,
-		},
+	return &Copier{
+		SourceDir: sourceDir,
+		Filter:    filter,
+		DestDir:   destDir,
+		Since:     since,
+		Until:     until,
 	}
 }
 
+func (c Copier) ID() string {
+	return "copy " + filepath.Join(c.SourceDir, c.Filter)
+}
+
 // Run satisfies the Runner interface and copies the filtered source files to the destination.
-func (c Copier) Run() (interface{}, Status, error) {
+func (c Copier) Run() Op {
 	// Ensure destination directory exists
 	err := os.MkdirAll(c.DestDir, 0755)
 	if err != nil {
-		return nil, Fail, &MakeDirError{
+		return c.op(nil, Fail, MakeDirError{
 			path: c.DestDir,
 			err:  err,
-		}
+		})
 	}
 
 	// Find all the files
 	files, err := util.FilterWalk(c.SourceDir, c.Filter, c.Since, c.Until)
 	if err != nil {
-		return nil, Fail, &FindFilesError{
+		return c.op(nil, Fail, FindFilesError{
 			path: c.SourceDir,
 			err:  err,
-		}
+		})
 	}
 
 	// Copy the files
 	for _, s := range files {
 		err = util.CopyDir(c.DestDir, s)
 		if err != nil {
-			return nil, Fail, &CopyFilesError{
+			return c.op(nil, Fail, CopyFilesError{
 				dest:  c.DestDir,
 				files: files,
 				err:   err,
-			}
+			})
 		}
 	}
 
-	return files, Success, nil
+	return c.op(files, Success, nil)
+}
+
+func (c Copier) op(result interface{}, status Status, err error) Op {
+	return Op{
+		Identifier: c.ID(),
+		Result:     result,
+		ErrString:  err.Error(),
+		Error:      err,
+		Status:     status,
+		Params:     util.RunnerParams(c),
+	}
 }
 
 type MakeDirError struct {

--- a/op/copier_test.go
+++ b/op/copier_test.go
@@ -11,15 +11,12 @@ func TestNewCopier(t *testing.T) {
 	dest := "/testing/dest"
 	since := time.Time{}
 	until := time.Now()
-	expect := Op{
-		Identifier: "copy /testing/src",
-		Runner: Copier{
-			SourceDir: "/testing/",
-			Filter:    "src",
-			DestDir:   dest,
-			Since:     since,
-			Until:     until,
-		},
+	expect := &Copier{
+		SourceDir: "/testing/",
+		Filter:    "src",
+		DestDir:   dest,
+		Since:     since,
+		Until:     until,
 	}
 	copier := NewCopier(src, dest, since, until)
 

--- a/op/copier_test.go
+++ b/op/copier_test.go
@@ -1,9 +1,10 @@
 package op
 
 import (
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewCopier(t *testing.T) {
@@ -19,8 +20,5 @@ func TestNewCopier(t *testing.T) {
 		Until:     until,
 	}
 	copier := NewCopier(src, dest, since, until)
-
-	if !reflect.DeepEqual(&expect, copier) {
-		t.Errorf("unexpected copier field, expected=%#v, actual=%#v", expect, copier)
-	}
+	assert.Equal(t, expect, copier)
 }

--- a/op/host/disk.go
+++ b/op/host/disk.go
@@ -30,7 +30,6 @@ func (d Disk) Run() op.Op {
 		return op.Op{
 			Identifier: d.ID(),
 			Result:     diskInfo,
-			ErrString:  err1.Error(),
 			Error:      err1,
 			Status:     op.Unknown,
 		}

--- a/op/host/disk.go
+++ b/op/host/disk.go
@@ -13,20 +13,32 @@ var _ op.Runner = Disk{}
 
 type Disk struct{}
 
-func NewDisk() *op.Op {
-	return &op.Op{
-		Identifier: "disks",
-		Runner:     Disk{},
-	}
+func NewDisk() *Disk {
+	return &Disk{}
 }
 
-func (dp Disk) Run() (interface{}, op.Status, error) {
+func (d Disk) ID() string {
+	return "disks"
+}
+
+func (d Disk) Run() op.Op {
 	// third party
 	diskInfo, err := disk.Partitions(true)
 	if err != nil {
 		hclog.L().Trace("op/host.Disk.Run()", "error", err)
-		return diskInfo, op.Unknown, fmt.Errorf("error getting disk information err=%w", err)
+		err1 := fmt.Errorf("error getting disk information err=%w", err)
+		return op.Op{
+			Identifier: d.ID(),
+			Result:     diskInfo,
+			ErrString:  err1.Error(),
+			Error:      err1,
+			Status:     op.Unknown,
+		}
 	}
 
-	return diskInfo, op.Success, nil
+	return op.Op{
+		Identifier: d.ID(),
+		Result:     diskInfo,
+		Status:     op.Success,
+	}
 }

--- a/op/host/disk.go
+++ b/op/host/disk.go
@@ -27,17 +27,8 @@ func (d Disk) Run() op.Op {
 	if err != nil {
 		hclog.L().Trace("op/host.Disk.Run()", "error", err)
 		err1 := fmt.Errorf("error getting disk information err=%w", err)
-		return op.Op{
-			Identifier: d.ID(),
-			Result:     diskInfo,
-			Error:      err1,
-			Status:     op.Unknown,
-		}
+		return op.New(d, diskInfo, op.Unknown, err1)
 	}
 
-	return op.Op{
-		Identifier: d.ID(),
-		Result:     diskInfo,
-		Status:     op.Success,
-	}
+	return op.New(d, diskInfo, op.Success, nil)
 }

--- a/op/host/etc_hosts.go
+++ b/op/host/etc_hosts.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/hashicorp/hcdiag/util"
-
 	"github.com/hashicorp/hcdiag/op"
 )
 
@@ -30,21 +28,11 @@ func (r EtcHosts) Run() op.Op {
 	if r.os == "windows" {
 		// TODO(mkcp): This should be op.Status("skip") once we implement it
 		err := fmt.Errorf(" EtcHosts.Run() not available on os, os=%s", r.os)
-		return r.op(nil, op.Success, err)
+		return op.New(r, nil, op.Success, err)
 	}
 	s := op.NewSheller("cat /etc/hosts").Run()
 	if s.Error != nil {
-		return r.op(s.Result, op.Fail, s.Error)
+		return op.New(r, s.Result, op.Fail, s.Error)
 	}
-	return r.op(s.Result, op.Success, nil)
-}
-
-func (r EtcHosts) op(result interface{}, status op.Status, err error) op.Op {
-	return op.Op{
-		Identifier: r.ID(),
-		Result:     result,
-		Error:      err,
-		Status:     status,
-		Params:     util.RunnerParams(r),
-	}
+	return op.New(r, s.Result, op.Success, nil)
 }

--- a/op/host/etc_hosts.go
+++ b/op/host/etc_hosts.go
@@ -44,7 +44,6 @@ func (r EtcHosts) op(result interface{}, status op.Status, err error) op.Op {
 		Identifier: r.ID(),
 		Result:     result,
 		Error:      err,
-		ErrString:  err.Error(),
 		Status:     status,
 		Params:     util.RunnerParams(r),
 	}

--- a/op/host/fstab.go
+++ b/op/host/fstab.go
@@ -45,7 +45,6 @@ func (r FSTab) op(result interface{}, status op.Status, err error) op.Op {
 		Identifier: r.ID(),
 		Result:     result,
 		Error:      err,
-		ErrString:  err.Error(),
 		Status:     status,
 		Params:     util.RunnerParams(r),
 	}

--- a/op/host/fstab.go
+++ b/op/host/fstab.go
@@ -3,8 +3,6 @@ package host
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcdiag/util"
-
 	"github.com/hashicorp/hcdiag/op"
 )
 
@@ -30,22 +28,12 @@ func (r FSTab) Run() op.Op {
 	// Only Linux is supported currently; Windows is unsupported, and Darwin doesn't use /etc/fstab by default.
 	if r.os != "linux" {
 		// TODO(nwchandler): This should be op.Status("skip") once we implement it
-		return r.op(nil, op.Success, fmt.Errorf("FSTab.Run() not available on os, os=%s", r.os))
+		return op.New(r, nil, op.Success, fmt.Errorf("FSTab.Run() not available on os, os=%s", r.os))
 	}
 	o := r.sheller.Run()
 	if o.Error != nil {
-		return r.op(o.Result, op.Fail, o.Error)
+		return op.New(r, o.Result, op.Fail, o.Error)
 	}
 
-	return r.op(o.Result, op.Success, nil)
-}
-
-func (r FSTab) op(result interface{}, status op.Status, err error) op.Op {
-	return op.Op{
-		Identifier: r.ID(),
-		Result:     result,
-		Error:      err,
-		Status:     status,
-		Params:     util.RunnerParams(r),
-	}
+	return op.New(r, o.Result, op.Success, nil)
 }

--- a/op/host/get.go
+++ b/op/host/get.go
@@ -3,8 +3,6 @@ package host
 import (
 	"strings"
 
-	"github.com/hashicorp/hcdiag/util"
-
 	"github.com/hashicorp/hcdiag/op"
 )
 
@@ -27,11 +25,6 @@ func (g Get) Run() op.Op {
 	// NOTE(mkcp): We will get JSON back from a lot of requests, so this can be improved
 	format := "string"
 	o := op.NewCommander(cmd, format).Run()
-	return op.Op{
-		Identifier: g.ID(),
-		Result:     o.Result,
-		Error:      o.Error,
-		Status:     o.Status,
-		Params:     util.RunnerParams(g),
-	}
+	return op.New(g, o.Result, o.Status, o.Error)
+
 }

--- a/op/host/get.go
+++ b/op/host/get.go
@@ -3,6 +3,8 @@ package host
 import (
 	"strings"
 
+	"github.com/hashicorp/hcdiag/util"
+
 	"github.com/hashicorp/hcdiag/op"
 )
 
@@ -12,18 +14,25 @@ type Get struct {
 	path string
 }
 
-func NewGetter(path string) *op.Op {
-	return &op.Op{
-		Identifier: "GET" + " " + path,
-		Runner: Get{
-			path: path,
-		},
-	}
+func NewGetter(path string) *Get {
+	return &Get{path}
 }
 
-func (g Get) Run() (interface{}, op.Status, error) {
+func (g Get) ID() string {
+	return "GET" + " " + g.path
+}
+
+func (g Get) Run() op.Op {
 	cmd := strings.Join([]string{"curl -s", g.path}, " ")
 	// NOTE(mkcp): We will get JSON back from a lot of requests, so this can be improved
 	format := "string"
-	return op.NewCommander(cmd, format).Runner.Run()
+	o := op.NewCommander(cmd, format).Run()
+	return op.Op{
+		Identifier: g.ID(),
+		Result:     o.Result,
+		Error:      o.Error,
+		ErrString:  o.Error.Error(),
+		Status:     o.Status,
+		Params:     util.RunnerParams(g),
+	}
 }

--- a/op/host/get.go
+++ b/op/host/get.go
@@ -31,7 +31,6 @@ func (g Get) Run() op.Op {
 		Identifier: g.ID(),
 		Result:     o.Result,
 		Error:      o.Error,
-		ErrString:  o.Error.Error(),
 		Status:     o.Status,
 		Params:     util.RunnerParams(g),
 	}

--- a/op/host/info.go
+++ b/op/host/info.go
@@ -19,16 +19,8 @@ func (i Info) Run() op.Op {
 	hostInfo, err := host.Info()
 	if err != nil {
 		hclog.L().Trace("op/host.Info.Run()", "error", err)
-		return i.op(hostInfo, op.Fail, err)
+		return op.New(i, hostInfo, op.Fail, err)
 	}
 
-	return i.op(hostInfo, op.Success, nil)
-}
-func (i Info) op(result interface{}, status op.Status, err error) op.Op {
-	return op.Op{
-		Identifier: i.ID(),
-		Result:     result,
-		Error:      err,
-		Status:     status,
-	}
+	return op.New(i, hostInfo, op.Success, nil)
 }

--- a/op/host/info.go
+++ b/op/host/info.go
@@ -29,7 +29,6 @@ func (i Info) op(result interface{}, status op.Status, err error) op.Op {
 		Identifier: i.ID(),
 		Result:     result,
 		Error:      err,
-		ErrString:  err.Error(),
 		Status:     status,
 	}
 }

--- a/op/host/info.go
+++ b/op/host/info.go
@@ -8,22 +8,28 @@ import (
 
 var _ op.Runner = Info{}
 
-func NewInfo() *op.Op {
-	return &op.Op{
-		Identifier: "info",
-		Runner:     Info{},
-	}
-}
-
 type Info struct{}
 
-func (i Info) Run() (interface{}, op.Status, error) {
+func (i Info) ID() string {
+	return "info"
+}
+
+func (i Info) Run() op.Op {
 	// third party
 	hostInfo, err := host.Info()
 	if err != nil {
 		hclog.L().Trace("op/host.Info.Run()", "error", err)
-		return hostInfo, op.Fail, err
+		return i.op(hostInfo, op.Fail, err)
 	}
 
-	return hostInfo, op.Success, nil
+	return i.op(hostInfo, op.Success, nil)
+}
+func (i Info) op(result interface{}, status op.Status, err error) op.Op {
+	return op.Op{
+		Identifier: i.ID(),
+		Result:     result,
+		Error:      err,
+		ErrString:  err.Error(),
+		Status:     status,
+	}
 }

--- a/op/host/iptables.go
+++ b/op/host/iptables.go
@@ -52,7 +52,6 @@ func (r IPTables) op(result interface{}, status op.Status, err error) op.Op {
 		Identifier: r.ID(),
 		Result:     result,
 		Error:      err,
-		ErrString:  err.Error(),
 		Status:     status,
 		Params:     util.RunnerParams(r),
 	}

--- a/op/host/memory.go
+++ b/op/host/memory.go
@@ -31,7 +31,6 @@ func (m Memory) op(result interface{}, status op.Status, err error) op.Op {
 		Identifier: m.ID(),
 		Result:     result,
 		Error:      err,
-		ErrString:  err.Error(),
 		Status:     status,
 		Params:     util.RunnerParams(m),
 	}

--- a/op/host/memory.go
+++ b/op/host/memory.go
@@ -3,7 +3,6 @@ package host
 import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcdiag/op"
-	"github.com/hashicorp/hcdiag/util"
 	"github.com/shirou/gopsutil/v3/mem"
 )
 
@@ -20,18 +19,8 @@ func (m Memory) Run() op.Op {
 	memoryInfo, err := mem.VirtualMemory()
 	if err != nil {
 		hclog.L().Trace("op/host.Memory.Run()", "error", err)
-		return m.op(memoryInfo, op.Fail, err)
+		return op.New(m, memoryInfo, op.Fail, err)
 	}
 
-	return m.op(memoryInfo, op.Success, nil)
-}
-
-func (m Memory) op(result interface{}, status op.Status, err error) op.Op {
-	return op.Op{
-		Identifier: m.ID(),
-		Result:     result,
-		Error:      err,
-		Status:     status,
-		Params:     util.RunnerParams(m),
-	}
+	return op.New(m, memoryInfo, op.Success, nil)
 }

--- a/op/host/network.go
+++ b/op/host/network.go
@@ -30,7 +30,6 @@ func (n Network) op(result interface{}, status op.Status, err error) op.Op {
 		Identifier: n.ID(),
 		Result:     result,
 		Error:      err,
-		ErrString:  err.Error(),
 		Status:     status,
 		Params:     util.RunnerParams(n),
 	}

--- a/op/host/network.go
+++ b/op/host/network.go
@@ -3,23 +3,35 @@ package host
 import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcdiag/op"
+	"github.com/hashicorp/hcdiag/util"
 	"github.com/shirou/gopsutil/v3/net"
 )
 
 var _ op.Runner = &Network{}
 
-func NewNetwork() *op.Op {
-	return &op.Op{Identifier: "network", Runner: Network{}}
-}
-
 type Network struct{}
 
-func (n Network) Run() (interface{}, op.Status, error) {
+func (n Network) ID() string {
+	return "network"
+}
+
+func (n Network) Run() op.Op {
 	netInterfaces, err := net.Interfaces()
 	if err != nil {
 		hclog.L().Trace("op/host.Network.Run()", "error", err)
-		return nil, op.Fail, err
+		return n.op(nil, op.Fail, err)
 	}
 
-	return netInterfaces, op.Success, nil
+	return n.op(netInterfaces, op.Success, nil)
+}
+
+func (n Network) op(result interface{}, status op.Status, err error) op.Op {
+	return op.Op{
+		Identifier: n.ID(),
+		Result:     result,
+		Error:      err,
+		ErrString:  err.Error(),
+		Status:     status,
+		Params:     util.RunnerParams(n),
+	}
 }

--- a/op/host/network.go
+++ b/op/host/network.go
@@ -3,7 +3,6 @@ package host
 import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcdiag/op"
-	"github.com/hashicorp/hcdiag/util"
 	"github.com/shirou/gopsutil/v3/net"
 )
 
@@ -19,18 +18,8 @@ func (n Network) Run() op.Op {
 	netInterfaces, err := net.Interfaces()
 	if err != nil {
 		hclog.L().Trace("op/host.Network.Run()", "error", err)
-		return n.op(nil, op.Fail, err)
+		return op.New(n, nil, op.Fail, err)
 	}
 
-	return n.op(netInterfaces, op.Success, nil)
-}
-
-func (n Network) op(result interface{}, status op.Status, err error) op.Op {
-	return op.Op{
-		Identifier: n.ID(),
-		Result:     result,
-		Error:      err,
-		Status:     status,
-		Params:     util.RunnerParams(n),
-	}
+	return op.New(n, netInterfaces, op.Success, nil)
 }

--- a/op/host/os.go
+++ b/op/host/os.go
@@ -2,33 +2,43 @@ package host
 
 import (
 	"github.com/hashicorp/hcdiag/op"
+	"github.com/hashicorp/hcdiag/util"
 )
 
 var _ op.Runner = OS{}
 
-func NewOS(os string) *op.Op {
+func NewOS(os string) *OS {
 	osCmd := "uname -v"
 	if os == "windows" {
 		osCmd = "systeminfo"
 	}
 
-	return &op.Op{
-		Identifier: osCmd,
-		Runner: OS{
-			OS:      os,
-			command: osCmd,
-		},
+	return &OS{
+		os:      os,
+		command: osCmd,
 	}
 }
 
+func (o OS) ID() string {
+	return o.command
+}
+
 type OS struct {
-	OS      string `json:"os"`
+	os      string
 	command string
 }
 
 // Run calls the given OS utility to get information on the operating system
-func (o OS) Run() (interface{}, op.Status, error) {
+func (o OS) Run() op.Op {
 	// NOTE(mkcp): This op can be made consistent between multiple operating systems if we parse the output of
 	//   systeminfo to match uname's scope of concerns.
-	return op.NewCommander(o.command, "string").Runner.Run()
+	c := op.NewCommander(o.command, "string").Run()
+	return op.Op{
+		Identifier: o.ID(),
+		Result:     c.Result,
+		Error:      c.Error,
+		ErrString:  c.ErrString,
+		Status:     c.Status,
+		Params:     util.RunnerParams(o),
+	}
 }

--- a/op/host/os.go
+++ b/op/host/os.go
@@ -2,7 +2,6 @@ package host
 
 import (
 	"github.com/hashicorp/hcdiag/op"
-	"github.com/hashicorp/hcdiag/util"
 )
 
 var _ op.Runner = OS{}
@@ -33,12 +32,5 @@ func (o OS) Run() op.Op {
 	// NOTE(mkcp): This op can be made consistent between multiple operating systems if we parse the output of
 	//   systeminfo to match uname's scope of concerns.
 	c := op.NewCommander(o.command, "string").Run()
-	return op.Op{
-		Identifier: o.ID(),
-		Result:     c.Result,
-		Error:      c.Error,
-		ErrString:  c.ErrString,
-		Status:     c.Status,
-		Params:     util.RunnerParams(o),
-	}
+	return op.New(o, c.Result, c.Status, c.Error)
 }

--- a/op/host/proc_file.go
+++ b/op/host/proc_file.go
@@ -3,8 +3,6 @@ package host
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcdiag/util"
-
 	"github.com/hashicorp/hcdiag/op"
 )
 
@@ -32,25 +30,15 @@ func (p ProcFile) ID() string {
 func (p ProcFile) Run() op.Op {
 	if p.os != "linux" {
 		// TODO(mkcp): Replace status with op.Skip when we implement it
-		return p.op(nil, op.Success, fmt.Errorf("os not linux, skipping, os=%s", p.os))
+		return op.New(p, nil, op.Success, fmt.Errorf("os not linux, skipping, os=%s", p.os))
 	}
 	m := make(map[string]interface{})
 	for _, c := range p.commands {
 		sheller := op.NewSheller(c).Run()
 		m[c] = sheller.Result
 		if sheller.Error != nil {
-			return p.op(m, op.Fail, sheller.Error)
+			return op.New(p, m, op.Fail, sheller.Error)
 		}
 	}
-	return p.op(m, op.Success, nil)
-}
-
-func (p ProcFile) op(result interface{}, status op.Status, err error) op.Op {
-	return op.Op{
-		Identifier: p.ID(),
-		Result:     result,
-		Error:      err,
-		Status:     status,
-		Params:     util.RunnerParams(p),
-	}
+	return op.New(p, m, op.Success, nil)
 }

--- a/op/host/proc_file.go
+++ b/op/host/proc_file.go
@@ -50,7 +50,6 @@ func (p ProcFile) op(result interface{}, status op.Status, err error) op.Op {
 		Identifier: p.ID(),
 		Result:     result,
 		Error:      err,
-		ErrString:  err.Error(),
 		Status:     status,
 		Params:     util.RunnerParams(p),
 	}

--- a/op/host/proc_file.go
+++ b/op/host/proc_file.go
@@ -24,9 +24,11 @@ func NewProcFile(os string) *ProcFile {
 		},
 	}
 }
+
 func (p ProcFile) ID() string {
 	return "/proc/ files"
 }
+
 func (p ProcFile) Run() op.Op {
 	if p.os != "linux" {
 		// TODO(mkcp): Replace status with op.Skip when we implement it

--- a/op/host/processes.go
+++ b/op/host/processes.go
@@ -18,7 +18,7 @@ func (p Process) Run() op.Op {
 	processes, err := ps.Processes()
 	if err != nil {
 		hclog.L().Trace("op/host.Process.Run()", "error", err)
-		return p.op(processes, op.Fail, err)
+		return op.New(p, processes, op.Fail, err)
 	}
 
 	processInfo := make([]string, 0)
@@ -27,14 +27,5 @@ func (p Process) Run() op.Op {
 		processInfo = append(processInfo, process.Executable())
 	}
 
-	return p.op(processInfo, op.Success, nil)
-}
-
-func (p Process) op(result interface{}, status op.Status, err error) op.Op {
-	return op.Op{
-		Identifier: p.ID(),
-		Result:     result,
-		Error:      err,
-		Status:     status,
-	}
+	return op.New(p, processInfo, op.Success, nil)
 }

--- a/op/host/processes.go
+++ b/op/host/processes.go
@@ -35,7 +35,6 @@ func (p Process) op(result interface{}, status op.Status, err error) op.Op {
 		Identifier: p.ID(),
 		Result:     result,
 		Error:      err,
-		ErrString:  err.Error(),
 		Status:     status,
 	}
 }

--- a/op/httper.go
+++ b/op/httper.go
@@ -10,21 +10,33 @@ type HTTPer struct {
 	Client *client.APIClient `json:"client"`
 }
 
-func NewHTTPer(client *client.APIClient, path string) *Op {
-	return &Op{
-		Identifier: "GET" + " " + path,
-		Runner: HTTPer{
-			Client: client,
-			Path:   path,
-		},
+func NewHTTPer(client *client.APIClient, path string) *HTTPer {
+	return &HTTPer{
+		Client: client,
+		Path:   path,
 	}
 }
 
+func (h HTTPer) ID() string {
+	return "GET" + " " + h.Path
+}
+
 // Run executes a GET request to the Path using the Client
-func (h HTTPer) Run() (interface{}, Status, error) {
+func (h HTTPer) Run() Op {
 	result, err := h.Client.Get(h.Path)
 	if err != nil {
-		return result, Unknown, err
+		return h.op(result, Unknown, err)
 	}
-	return result, Success, nil
+	return h.op(result, Success, nil)
+}
+
+func (h HTTPer) op(result interface{}, status Status, err error) Op {
+	return Op{
+		Identifier: h.ID(),
+		Result:     result,
+		Error:      err,
+		ErrString:  err.Error(),
+		Status:     status,
+		Params:     map[string]interface{}{"path": h.Path},
+	}
 }

--- a/op/httper.go
+++ b/op/httper.go
@@ -2,6 +2,7 @@ package op
 
 import (
 	"github.com/hashicorp/hcdiag/client"
+	"github.com/hashicorp/hcdiag/util"
 )
 
 // HTTPer hits APIs.
@@ -35,8 +36,7 @@ func (h HTTPer) op(result interface{}, status Status, err error) Op {
 		Identifier: h.ID(),
 		Result:     result,
 		Error:      err,
-		ErrString:  err.Error(),
 		Status:     status,
-		Params:     map[string]interface{}{"path": h.Path},
+		Params:     util.RunnerParams(h),
 	}
 }

--- a/op/httper.go
+++ b/op/httper.go
@@ -2,7 +2,6 @@ package op
 
 import (
 	"github.com/hashicorp/hcdiag/client"
-	"github.com/hashicorp/hcdiag/util"
 )
 
 // HTTPer hits APIs.
@@ -26,17 +25,7 @@ func (h HTTPer) ID() string {
 func (h HTTPer) Run() Op {
 	result, err := h.Client.Get(h.Path)
 	if err != nil {
-		return h.op(result, Unknown, err)
+		return New(h, result, Unknown, err)
 	}
-	return h.op(result, Success, nil)
-}
-
-func (h HTTPer) op(result interface{}, status Status, err error) Op {
-	return Op{
-		Identifier: h.ID(),
-		Result:     result,
-		Error:      err,
-		Status:     status,
-		Params:     util.RunnerParams(h),
-	}
+	return New(h, result, Success, nil)
 }

--- a/op/log/docker.go
+++ b/op/log/docker.go
@@ -66,7 +66,6 @@ func (d Docker) op(result interface{}, status op.Status, err error) op.Op {
 		Identifier: d.ID(),
 		Result:     result,
 		Error:      err,
-		ErrString:  err.Error(),
 		Status:     status,
 		Params:     util.RunnerParams(d),
 	}

--- a/op/log/docker.go
+++ b/op/log/docker.go
@@ -4,20 +4,19 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/hcdiag/util"
+
 	"github.com/hashicorp/hcdiag/op"
 )
 
 var _ op.Runner = Docker{}
 
 // NewDocker returns a op with an identifier and fully configured docker runner
-func NewDocker(container, destDir string, since time.Time) *op.Op {
-	return &op.Op{
-		Identifier: "log/docker " + container,
-		Runner: &Docker{
-			Container: container,
-			DestDir:   destDir,
-			Since:     since,
-		},
+func NewDocker(container, destDir string, since time.Time) *Docker {
+	return &Docker{
+		Container: container,
+		DestDir:   destDir,
+		Since:     since,
 	}
 }
 
@@ -31,31 +30,46 @@ type Docker struct {
 	Since time.Time
 }
 
+func (d Docker) ID() string {
+	return "log/docker " + d.Container
+}
+
 // Run executes the runner
-func (d Docker) Run() (interface{}, op.Status, error) {
+func (d Docker) Run() op.Op {
 	// Check that docker exists
-	checkResult, _, err := op.NewSheller("docker version").Runner.Run()
-	if err != nil {
-		return checkResult, op.Fail, DockerNotFoundError{
+	o := op.NewSheller("docker version").Run()
+	if o.Error != nil {
+		return d.op(o.Result, op.Fail, DockerNotFoundError{
 			container: d.Container,
-			err:       err,
-		}
+			err:       o.Error,
+		})
 	}
 
 	// Retrieve logs
 	cmd := DockerLogCmd(d.Container, d.DestDir, d.Since)
-	logResult, status, err := op.NewSheller(cmd).Runner.Run()
+	o = op.NewSheller(cmd).Run()
 	// NOTE(mkcp): If the container does not exist, docker will exit non-zero and it'll surface as a ShellExecError.
 	//  The result actionably states that the container wasn't found. In the future we may want to scrub the result
 	//  and only return an actionable error message
-	if err != nil {
-		return logResult, status, err
+	if o.Error != nil {
+		return d.op(o.Result, o.Status, o.Error)
 	}
-	if logResult == "" {
-		return logResult, op.Unknown, DockerNoLogsError{container: d.Container}
+	if o.Result == "" {
+		return d.op(o.Result, op.Unknown, DockerNoLogsError{container: d.Container})
 	}
 
-	return logResult, op.Success, nil
+	return d.op(o.Result, op.Success, nil)
+}
+
+func (d Docker) op(result interface{}, status op.Status, err error) op.Op {
+	return op.Op{
+		Identifier: d.ID(),
+		Result:     result,
+		Error:      err,
+		ErrString:  err.Error(),
+		Status:     status,
+		Params:     util.RunnerParams(d),
+	}
 }
 
 func DockerLogCmd(container, destDir string, since time.Time) string {

--- a/op/log/journald.go
+++ b/op/log/journald.go
@@ -78,7 +78,6 @@ func (j Journald) op(result interface{}, status op.Status, err error) op.Op {
 		Identifier: j.ID(),
 		Result:     result,
 		Error:      err,
-		ErrString:  err.Error(),
 		Status:     status,
 		Params:     util.RunnerParams(j),
 	}

--- a/op/log/journald.go
+++ b/op/log/journald.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/hcdiag/util"
+
 	"github.com/hashicorp/hcdiag/op"
 
 	"github.com/hashicorp/go-hclog"
@@ -21,53 +23,65 @@ type Journald struct {
 	until   time.Time
 }
 
-// NewJournald sets the defaults for the journald runner and returns a op
-func NewJournald(service, destDir string, since, until time.Time) *op.Op {
-	return &op.Op{
-		Identifier: "journald",
-		Runner: Journald{
-			service: service,
-			destDir: destDir,
-			since:   since,
-			until:   until,
-		},
+// NewJournald sets the defaults for the journald runner
+func NewJournald(service, destDir string, since, until time.Time) *Journald {
+	return &Journald{
+		service: service,
+		destDir: destDir,
+		since:   since,
+		until:   until,
 	}
+}
+
+func (j Journald) ID() string {
+	return "journald"
 }
 
 // Run attempts to pull logs from journald via shell command, e.g.:
 // journalctl -x -u {name} --since '3 days ago' --no-pager > {destDir}/journald-{name}.log
-func (j Journald) Run() (interface{}, op.Status, error) {
+func (j Journald) Run() op.Op {
 	// Check if systemd has a unit with the provided name
-	cmd := fmt.Sprintf("systemctl is-enabled %s", j.service) // TODO(gulducat): another command?
-	out, err := op.NewCommander(cmd, "string").Run()
-	if err != nil {
-		hclog.L().Debug("skipping journald", "service", j.service, "output", out, "error", err)
-		return nil, op.Fail, JournaldServiceNotEnabled{
+	cmd := fmt.Sprintf("systemctl is-enabled %s", j.service)
+	o := op.NewCommander(cmd, "string").Run()
+	if o.Error != nil {
+		hclog.L().Debug("skipping journald", "service", j.service, "output", o.Result, "error", o.Error)
+		return j.op(o.Result, op.Fail, JournaldServiceNotEnabled{
 			service: j.service,
 			command: cmd,
-			result:  fmt.Sprintf("%s", out),
-			err:     err,
-		}
+			result:  fmt.Sprintf("%s", o.Result),
+			err:     o.Error,
+		})
 	}
 
 	// check if user is able to read messages
 	cmd = fmt.Sprintf("journalctl -n0 -u %s 2>&1 | grep -A10 'not seeing messages from other users'", j.service)
-	out, err = op.NewSheller(cmd).Run()
+	o = op.NewSheller(cmd).Run()
 	// permissions error detected
-	if err == nil {
-		return nil, op.Fail, JournaldPermissionError{
+	if o.Error == nil {
+		return j.op(o.Result, op.Fail, JournaldPermissionError{
 			service: j.service,
 			command: cmd,
-			result:  fmt.Sprintf("%s", out),
-			err:     err,
-		}
+			result:  fmt.Sprintf("%s", o.Result),
+			err:     o.Error,
+		})
 	}
 
 	cmd = j.LogsCmd()
 	s := op.NewSheller(cmd)
-	s.Identifier = "journald"
+	o = s.Run()
 
-	return s.Runner.Run()
+	return j.op(o.Result, o.Status, o.Error)
+}
+
+func (j Journald) op(result interface{}, status op.Status, err error) op.Op {
+	return op.Op{
+		Identifier: j.ID(),
+		Result:     result,
+		Error:      err,
+		ErrString:  err.Error(),
+		Status:     status,
+		Params:     util.RunnerParams(j),
+	}
 }
 
 // LogsCmd arranges the params into a runnable command string.

--- a/op/log/journald_test.go
+++ b/op/log/journald_test.go
@@ -51,7 +51,7 @@ func TestJournalctlGetLogsCmd(t *testing.T) {
 	}
 
 	for _, tc := range testTable {
-		j := NewJournald(tc.name, tc.destDir, tc.since, tc.until).Runner.(Journald)
+		j := NewJournald(tc.name, tc.destDir, tc.since, tc.until)
 		result := j.LogsCmd()
 		assert.Equal(t, tc.expect, result)
 	}

--- a/op/op.go
+++ b/op/op.go
@@ -91,7 +91,7 @@ func Select(selects []string, runners []Runner) ([]Runner, error) {
 }
 
 // StatusCounts takes a slice of op references and returns a map containing sums of each Status
-func StatusCounts(ops []Op) (map[Status]int, error) {
+func StatusCounts(ops map[string]Op) (map[Status]int, error) {
 	statuses := make(map[Status]int)
 	for _, op := range ops {
 		if op.Status == "" {

--- a/op/op.go
+++ b/op/op.go
@@ -3,6 +3,8 @@ package op
 import (
 	"fmt"
 	"path/filepath"
+
+	"github.com/hashicorp/hcdiag/util"
 )
 
 // Status describes the result of a Runner's Run
@@ -27,6 +29,23 @@ type Op struct {
 	Error      error                  `json:"-"`
 	Status     Status                 `json:"status"`
 	Params     map[string]interface{} `json:"params"`
+}
+
+// New takes a runner its results, serializing it into an immutable Op struct.
+func New(runner Runner, result interface{}, status Status, err error) Op {
+	// We store the error directly to make JSON serialization easier
+	var message string
+	if err != nil {
+		message = err.Error()
+	}
+	return Op{
+		Identifier: runner.ID(),
+		Result:     result,
+		Error:      err,
+		ErrString:  message,
+		Status:     status,
+		Params:     util.RunnerParams(runner),
+	}
 }
 
 // Runner runs things to get information.

--- a/op/op.go
+++ b/op/op.go
@@ -21,12 +21,12 @@ const (
 
 // Op seeks information via its Runner then stores the results.
 type Op struct {
-	Identifier string            `json:"-"`
-	Result     interface{}       `json:"result"`
-	ErrString  string            `json:"error"` // this simplifies json marshaling
-	Error      error             `json:"-"`
-	Status     Status            `json:"status"`
-	Params     map[string]string `json:"params"`
+	Identifier string                 `json:"-"`
+	Result     interface{}            `json:"result"`
+	ErrString  string                 `json:"error"` // this simplifies json marshaling
+	Error      error                  `json:"-"`
+	Status     Status                 `json:"status"`
+	Params     map[string]interface{} `json:"params"`
 }
 
 // Runner runs things to get information.
@@ -91,7 +91,7 @@ func Select(selects []string, runners []Runner) ([]Runner, error) {
 }
 
 // StatusCounts takes a slice of op references and returns a map containing sums of each Status
-func StatusCounts(ops []*Op) (map[Status]int, error) {
+func StatusCounts(ops []Op) (map[Status]int, error) {
 	statuses := make(map[Status]int)
 	for _, op := range ops {
 		if op.Status == "" {

--- a/op/op.go
+++ b/op/op.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 )
 
-// Status describes the result of a op run
+// Status describes the result of a Runner's Run
 type Status string
 
 const (
@@ -21,31 +21,18 @@ const (
 
 // Op seeks information via its Runner then stores the results.
 type Op struct {
-	Runner     Runner      `json:"runner"`
-	Identifier string      `json:"-"`
-	Result     interface{} `json:"result"`
-	ErrString  string      `json:"error"` // this simplifies json marshaling
-	Error      error       `json:"-"`
-	Status     Status      `json:"status"`
+	Identifier string            `json:"-"`
+	Result     interface{}       `json:"result"`
+	ErrString  string            `json:"error"` // this simplifies json marshaling
+	Error      error             `json:"-"`
+	Status     Status            `json:"status"`
+	Params     map[string]string `json:"params"`
 }
 
 // Runner runs things to get information.
 type Runner interface {
-	Run() (interface{}, Status, error)
-}
-
-// Run calls a Runner's Run() method and writes the results and any errors on the op struct
-func (s *Op) Run() (interface{}, error) {
-	result, stat, err := s.Runner.Run()
-	s.Result = result
-	s.Error = err
-	s.Status = stat
-
-	if err != nil {
-		s.ErrString = fmt.Sprintf("%s", err)
-		return s.Result, s.Error
-	}
-	return result, err
+	ID() string
+	Run() Op
 }
 
 // Exclude takes a slice of matcher strings and a slice of ops. If any of the op identifiers match the exclude
@@ -53,16 +40,16 @@ func (s *Op) Run() (interface{}, error) {
 // NOTE(mkcp): This is precisely identical to Select() except we flip the match check. Maybe we can perform both rounds
 //  of filtering in one pass one rather than iterating over all the ops several times. Not likely to be a huge speed
 //  increase though... we're not even remotely bottlenecked on op filtering.
-func Exclude(excludes []string, ops []*Op) ([]*Op, error) {
-	newOps := make([]*Op, 0)
-	for _, s := range ops {
+func Exclude(excludes []string, runners []Runner) ([]Runner, error) {
+	newRunners := make([]Runner, 0)
+	for _, r := range runners {
 		// Set our match flag if we get a hit for any of the matchers on this op
 		var match bool
 		var err error
 		for _, matcher := range excludes {
-			match, err = filepath.Match(matcher, s.Identifier)
+			match, err = filepath.Match(matcher, r.ID())
 			if err != nil {
-				return newOps, fmt.Errorf("filter error: '%s' for '%s'", err, matcher)
+				return newRunners, fmt.Errorf("filter error: '%s' for '%s'", err, matcher)
 			}
 			if match {
 				break
@@ -71,36 +58,36 @@ func Exclude(excludes []string, ops []*Op) ([]*Op, error) {
 
 		// Add the op back to our set if we have not matched an exclude
 		if !match {
-			newOps = append(newOps, s)
+			newRunners = append(newRunners, r)
 		}
 	}
-	return newOps, nil
+	return newRunners, nil
 }
 
 // Select takes a slice of matcher strings and a slice of ops. The only ops returned will be those
 // matching the given select strings according to filepath.Match()
-func Select(selects []string, ops []*Op) ([]*Op, error) {
-	newOps := make([]*Op, 0)
-	for _, op := range ops {
+func Select(selects []string, runners []Runner) ([]Runner, error) {
+	newRunners := make([]Runner, 0)
+	for _, r := range runners {
 		// Set our match flag if we get a hit for any of the matchers on this op
 		var match bool
 		var err error
 		for _, matcher := range selects {
-			match, err = filepath.Match(matcher, op.Identifier)
+			match, err = filepath.Match(matcher, r.ID())
 			if err != nil {
-				return newOps, fmt.Errorf("filter error: '%s' for '%s'", err, matcher)
+				return newRunners, fmt.Errorf("filter error: '%s' for '%s'", err, matcher)
 			}
 			if match {
 				break
 			}
 		}
 
-		// Only include the op if we've matched it
+		// Only include the runner if we've matched it
 		if match {
-			newOps = append(newOps, op)
+			newRunners = append(newRunners, r)
 		}
 	}
-	return newOps, nil
+	return newRunners, nil
 }
 
 // StatusCounts takes a slice of op references and returns a map containing sums of each Status

--- a/op/op_test.go
+++ b/op/op_test.go
@@ -58,7 +58,6 @@ func TestRunner_Run(t *testing.T) {
 	}
 }
 
-// FIXME(mkcp): This needs to be recreated with Runners
 func TestExclude(t *testing.T) {
 	testTable := []struct {
 		desc     string
@@ -123,7 +122,6 @@ func TestExclude(t *testing.T) {
 	}
 }
 
-// FIXME(mkcp): This needs to be recreated with Runners
 func TestSelect(t *testing.T) {
 	testTable := []struct {
 		desc     string
@@ -201,12 +199,12 @@ func TestSelect(t *testing.T) {
 func Test_StatusCounts(t *testing.T) {
 	testTable := []struct {
 		desc   string
-		ops    []*Op
+		ops    []Op
 		expect map[Status]int
 	}{
 		{
 			desc: "Statuses sums statuses",
-			ops: []*Op{
+			ops: []Op{
 				{Status: Success},
 				{Status: Unknown},
 				{Status: Success},
@@ -221,7 +219,7 @@ func Test_StatusCounts(t *testing.T) {
 		},
 		{
 			desc: "returns an error if a op doesn't have a status",
-			ops: []*Op{
+			ops: []Op{
 				{Status: Unknown},
 				{Status: Success},
 				{Status: ""},

--- a/op/op_test.go
+++ b/op/op_test.go
@@ -199,17 +199,17 @@ func TestSelect(t *testing.T) {
 func Test_StatusCounts(t *testing.T) {
 	testTable := []struct {
 		desc   string
-		ops    []Op
+		ops    map[string]Op
 		expect map[Status]int
 	}{
 		{
 			desc: "Statuses sums statuses",
-			ops: []Op{
-				{Status: Success},
-				{Status: Unknown},
-				{Status: Success},
-				{Status: Fail},
-				{Status: Success},
+			ops: map[string]Op{
+				"1": {Status: Success},
+				"2": {Status: Unknown},
+				"3": {Status: Success},
+				"4": {Status: Fail},
+				"5": {Status: Success},
 			},
 			expect: map[Status]int{
 				Success: 3,
@@ -219,13 +219,13 @@ func Test_StatusCounts(t *testing.T) {
 		},
 		{
 			desc: "returns an error if a op doesn't have a status",
-			ops: []Op{
-				{Status: Unknown},
-				{Status: Success},
-				{Status: ""},
-				{Status: Success},
-				{Status: Fail},
-				{Status: Success},
+			ops: map[string]Op{
+				"1": {Status: Unknown},
+				"2": {Status: Success},
+				"3": {Status: ""},
+				"4": {Status: Success},
+				"5": {Status: Fail},
+				"6": {Status: Success},
 			},
 			expect: nil,
 		},

--- a/op/op_test.go
+++ b/op/op_test.go
@@ -9,176 +9,191 @@ import (
 )
 
 var (
-	mockResult = "get mock'd"
-	errFake    = errors.New("uh oh a fake error")
-	testStatus = Status("test")
+	mockID            = "mock"
+	mockResult        = "get mock'd"
+	errFake           = errors.New("uh oh a fake error")
+	testStatus        = Status("test")
+	_          Runner = MockRunner{}
 )
 
-type MockRunner struct{}
-
-func (r MockRunner) Run() (interface{}, Status, error) {
-	return mockResult, testStatus, errFake
+type MockRunner struct {
+	id string
 }
 
-func TestOp_Run(t *testing.T) {
-	r := MockRunner{}
-	s := Op{Identifier: "mock", Runner: r}
+func NewMockRunner(id string) *MockRunner {
+	return &MockRunner{id}
+}
 
-	result, err := s.Run()
+func (r MockRunner) ID() string {
+	return r.id
+}
+
+func (r MockRunner) Run() Op {
+	return Op{
+		Identifier: r.ID(),
+		Result:     mockResult,
+		ErrString:  errFake.Error(),
+		Error:      errFake,
+		Status:     testStatus,
+	}
+}
+
+func TestRunner_Run(t *testing.T) {
+	r := NewMockRunner(mockID)
+	o := r.Run()
 
 	// assert that return values are also being stored as struct fields
-	if s.Result != result {
-		t.Errorf("returned result (%s) does not match Op Result field (%s)", result, s.Result)
+	if o.Identifier != mockID {
+		t.Errorf("returned result (%s) does not match Op Result field (%s)", mockID, o.Identifier)
 	}
-	if s.Error != err {
-		t.Errorf("returned err (%s) does not match Op Error field (%s)", err, s.Error)
+	if o.Result != mockResult {
+		t.Errorf("returned result (%s) does not match Op Result field (%s)", mockResult, o.Result)
 	}
-	errStr := fmt.Sprintf("%s", err)
-	if s.ErrString != errStr {
-		t.Errorf("Op ErrString (%s) not formatted as expected (%s)", s.ErrString, errStr)
+	if o.Error != errFake {
+		t.Errorf("returned err (%s) does not match Op Error field (%s)", errFake, o.Error)
 	}
-
-	// assert that values are what we expect from MockRunner.Run()
-	if err != errFake {
-		t.Errorf("err should be '%s', got: '%s'", errFake, err)
+	errStr := fmt.Sprintf("%s", o.Error)
+	if o.ErrString != errStr {
+		t.Errorf("Op ErrString (%s) not formatted as expected (%s)", o.ErrString, errStr)
 	}
-	if result != mockResult {
-		t.Errorf("resp should be '%s'; got '%s'", mockResult, result)
-	}
-
 }
 
+// FIXME(mkcp): This needs to be recreated with Runners
 func TestExclude(t *testing.T) {
 	testTable := []struct {
 		desc     string
 		matchers []string
-		ops      []*Op
+		runners  []Runner
 		expect   int
 	}{
 		{
 			desc:     "Can exclude none",
 			matchers: []string{"hello"},
-			ops: []*Op{
-				{Identifier: "nope"},
-				{Identifier: "nah"},
-				{Identifier: "sry"},
+			runners: []Runner{
+				NewMockRunner("nope"),
+				NewMockRunner("nah"),
+				NewMockRunner("sry"),
 			},
 			expect: 3,
 		},
 		{
 			desc:     "Can exclude one",
 			matchers: []string{"hi"},
-			ops:      []*Op{{Identifier: "hi"}},
-			expect:   0,
+			runners: []Runner{
+				NewMockRunner("hi"),
+			},
+			expect: 0,
 		},
 		{
 			desc:     "Can exclude two",
 			matchers: []string{"hi", "sup"},
-			ops: []*Op{
-				{Identifier: "hi"},
-				{Identifier: "sup"},
+			runners: []Runner{
+				NewMockRunner("hi"),
+				NewMockRunner("sup"),
 			},
 			expect: 0,
 		},
 		{
 			desc:     "Can exclude many and and ignore one",
 			matchers: []string{"exclude1", "exclude2", "exclude3"},
-			ops: []*Op{
-				{Identifier: "exclude1"},
-				{Identifier: "exclude2"},
-				{Identifier: "exclude3"},
-				{Identifier: "keep"},
+			runners: []Runner{
+				NewMockRunner("exclude1"),
+				NewMockRunner("exclude2"),
+				NewMockRunner("exclude3"),
+				NewMockRunner("keep"),
 			},
 			expect: 1,
 		},
 		{
 			desc:     "Can exclude glob *",
 			matchers: []string{"exclude*"},
-			ops: []*Op{
-				{Identifier: "exclude1"},
-				{Identifier: "exclude2"},
-				{Identifier: "keep"},
+			runners: []Runner{
+				NewMockRunner("exclude1"),
+				NewMockRunner("exclude2"),
+				NewMockRunner("keep"),
 			},
 			expect: 1,
 		},
 	}
 
 	for _, tc := range testTable {
-		res, err := Exclude(tc.matchers, tc.ops)
+		res, err := Exclude(tc.matchers, tc.runners)
 		assert.Nil(t, err)
 		assert.Len(t, res, tc.expect, tc.desc)
 	}
 }
 
+// FIXME(mkcp): This needs to be recreated with Runners
 func TestSelect(t *testing.T) {
 	testTable := []struct {
 		desc     string
 		matchers []string
-		ops      []*Op
+		runners  []Runner
 		expect   int
 	}{
 		{
 			desc:     "Can select none",
 			matchers: []string{"hello"},
-			ops: []*Op{
-				{Identifier: "nope"},
-				{Identifier: "nah"},
-				{Identifier: "sry"},
+			runners: []Runner{
+				NewMockRunner("nope"),
+				NewMockRunner("nah"),
+				NewMockRunner("sry"),
 			},
 			expect: 0,
 		},
 		{
 			desc:     "Can select one",
 			matchers: []string{"match"},
-			ops: []*Op{
-				{Identifier: "nope"},
-				{Identifier: "nah"},
-				{Identifier: "sry"},
-				{Identifier: "match"}},
+			runners: []Runner{
+				NewMockRunner("nope"),
+				NewMockRunner("nah"),
+				NewMockRunner("sry"),
+				NewMockRunner("match"),
+			},
 			expect: 1,
 		},
 		{
 			desc:     "Can select two",
 			matchers: []string{"match1", "match2"},
-			ops: []*Op{
-				{Identifier: "nope"},
-				{Identifier: "nah"},
-				{Identifier: "sry"},
-				{Identifier: "match1"},
-				{Identifier: "match2"},
+			runners: []Runner{
+				NewMockRunner("nope"),
+				NewMockRunner("nah"),
+				NewMockRunner("sry"),
+				NewMockRunner("match1"),
+				NewMockRunner("match2"),
 			},
 			expect: 2,
 		},
 		{
 			desc:     "Can select many regardless of order",
 			matchers: []string{"select1", "select2", "select3"},
-			ops: []*Op{
-				{Identifier: "skip1"},
-				{Identifier: "select2"},
-				{Identifier: "skip2"},
-				{Identifier: "skip3"},
-				{Identifier: "select3"},
-				{Identifier: "select1"},
+			runners: []Runner{
+				NewMockRunner("skip1"),
+				NewMockRunner("select2"),
+				NewMockRunner("skip2"),
+				NewMockRunner("skip3"),
+				NewMockRunner("select3"),
+				NewMockRunner("select1"),
 			},
 			expect: 3,
 		},
 		{
 			desc:     "Can select glob *",
 			matchers: []string{"select*"},
-			ops: []*Op{
-				{Identifier: "skip1"},
-				{Identifier: "select2"},
-				{Identifier: "skip2"},
-				{Identifier: "skip3"},
-				{Identifier: "select3"},
-				{Identifier: "select1"},
+			runners: []Runner{
+				NewMockRunner("skip1"),
+				NewMockRunner("select2"),
+				NewMockRunner("skip2"),
+				NewMockRunner("skip3"),
+				NewMockRunner("select3"),
+				NewMockRunner("select1"),
 			},
 			expect: 3,
 		},
 	}
 
 	for _, tc := range testTable {
-		res, err := Select(tc.matchers, tc.ops)
+		res, err := Select(tc.matchers, tc.runners)
 		assert.Nil(t, err)
 		assert.Len(t, res, tc.expect, tc.desc)
 	}

--- a/op/sheller.go
+++ b/op/sheller.go
@@ -17,16 +17,15 @@ type Sheller struct {
 // NewSheller provides a Op for running shell commands.
 func NewSheller(command string) *Sheller {
 	return &Sheller{
-		id:      command,
 		command: command,
 	}
 }
 
-func (s *Sheller) ID() string {
-	return s.id
+func (s Sheller) ID() string {
+	return s.command
 }
 
-func (s *Sheller) params() map[string]string {
+func (s Sheller) params() map[string]string {
 	return map[string]string{
 		"command": s.command,
 		"shell":   s.shell,
@@ -34,16 +33,16 @@ func (s *Sheller) params() map[string]string {
 }
 
 // Run ensures a shell exists and optimistically executes the given Command string
-func (s *Sheller) Run() Op {
+func (s Sheller) Run() Op {
 	// Read the shell from the environment
 	shell, err := util.GetShell()
 	if err != nil {
 		return Op{
-			Identifier: s.id,
+			Identifier: s.ID(),
 			Error:      err,
 			ErrString:  err.Error(),
 			Status:     Fail,
-			Params:     nil,
+			Params:     util.RunnerParams(s),
 		}
 	}
 	s.shell = shell
@@ -64,7 +63,7 @@ func (s *Sheller) Run() Op {
 			Error:      err1,
 			ErrString:  err1.Error(),
 			Status:     Unknown,
-			Params:     s.params(),
+			Params:     util.RunnerParams(s),
 		}
 	}
 
@@ -72,7 +71,7 @@ func (s *Sheller) Run() Op {
 		Identifier: s.id,
 		Result:     string(bts),
 		Status:     Success,
-		Params:     s.params(),
+		Params:     util.RunnerParams(s),
 	}
 }
 

--- a/op/sheller.go
+++ b/op/sheller.go
@@ -40,7 +40,6 @@ func (s Sheller) Run() Op {
 		return Op{
 			Identifier: s.ID(),
 			Error:      err,
-			ErrString:  err.Error(),
 			Status:     Fail,
 			Params:     util.RunnerParams(s),
 		}

--- a/op/sheller.go
+++ b/op/sheller.go
@@ -37,12 +37,7 @@ func (s Sheller) Run() Op {
 	// Read the shell from the environment
 	shell, err := util.GetShell()
 	if err != nil {
-		return Op{
-			Identifier: s.ID(),
-			Error:      err,
-			Status:     Fail,
-			Params:     util.RunnerParams(s),
-		}
+		return New(s, nil, Fail, err)
 	}
 	s.shell = shell
 
@@ -56,22 +51,10 @@ func (s Sheller) Run() Op {
 			command: s.command,
 			err:     err,
 		}
-		return Op{
-			Identifier: s.id,
-			Result:     string(bts),
-			Error:      err1,
-			ErrString:  err1.Error(),
-			Status:     Unknown,
-			Params:     util.RunnerParams(s),
-		}
+		return New(s, string(bts), Unknown, err1)
 	}
 
-	return Op{
-		Identifier: s.id,
-		Result:     string(bts),
-		Status:     Success,
-		Params:     util.RunnerParams(s),
-	}
+	return New(s, string(bts), Success, nil)
 }
 
 type ShellExecError struct {

--- a/op/sheller_test.go
+++ b/op/sheller_test.go
@@ -21,11 +21,9 @@ func TestSheller(t *testing.T) {
 	// features pipe "|" and file redirection ">"
 	c := NewSheller("echo hiii | grep hi > cooltestfile")
 	defer os.Remove("cooltestfile")
-	out, err := c.Run()
-	sheller := c.Runner.(*Sheller)
-	assert.Equal(t, sheller.Shell, "/bin/sh")
-	assert.Equal(t, "", out)
-	assert.NoError(t, err)
+	o := c.Run()
+	assert.Equal(t, "", o.Result)
+	assert.NoError(t, o.Error)
 
 	bts, err := ioutil.ReadFile("cooltestfile")
 	assert.Equal(t, "hiii\n", string(bts))

--- a/product/consul.go
+++ b/product/consul.go
@@ -28,10 +28,10 @@ func NewConsul(logger hclog.Logger, cfg Config) (*Product, error) {
 		return nil, err
 	}
 	return &Product{
-		l:      logger.Named("product"),
-		Name:   Consul,
-		Ops:    ops,
-		Config: cfg,
+		l:       logger.Named("product"),
+		Name:    Consul,
+		Runners: ops,
+		Config:  cfg,
 	}, nil
 }
 

--- a/product/host.go
+++ b/product/host.go
@@ -12,10 +12,10 @@ import (
 // NewHost takes a product config and creates a Product containing all of the host's ops.
 func NewHost(logger hclog.Logger, cfg Config) *Product {
 	return &Product{
-		l:      logger.Named("product"),
-		Name:   Host,
-		Ops:    HostOps(cfg.OS),
-		Config: cfg,
+		l:       logger.Named("product"),
+		Name:    Host,
+		Runners: HostOps(cfg.OS),
+		Config:  cfg,
 	}
 }
 

--- a/product/host.go
+++ b/product/host.go
@@ -14,23 +14,23 @@ func NewHost(logger hclog.Logger, cfg Config) *Product {
 	return &Product{
 		l:       logger.Named("product"),
 		Name:    Host,
-		Runners: HostOps(cfg.OS),
+		Runners: HostRunners(cfg.OS),
 		Config:  cfg,
 	}
 }
 
-// HostOps checks the operating system and passes it into the operations, returning a list of ops to run.
-func HostOps(os string) []*op.Op {
+// HostRunners checks the operating system and passes it into the operations, returning a list of ops to run.
+func HostRunners(os string) []op.Runner {
 	if os == "auto" {
 		os = runtime.GOOS
 	}
-	return []*op.Op{
+	return []op.Runner{
 		host.NewOS(os),
 		host.NewDisk(),
-		host.NewInfo(),
-		host.NewMemory(),
-		host.NewProcess(),
-		host.NewNetwork(),
+		host.Info{},
+		host.Memory{},
+		host.Process{},
+		host.Network{},
 		host.NewEtcHosts(),
 		host.NewIPTables(),
 		host.NewProcFile(os),

--- a/product/nomad.go
+++ b/product/nomad.go
@@ -42,10 +42,10 @@ func NewNomad(logger hclog.Logger, cfg Config) (*Product, error) {
 	}
 
 	return &Product{
-		l:      logger.Named("product"),
-		Name:   Nomad,
-		Ops:    ops,
-		Config: cfg,
+		l:       logger.Named("product"),
+		Name:    Nomad,
+		Runners: ops,
+		Config:  cfg,
 	}, nil
 }
 

--- a/product/nomad.go
+++ b/product/nomad.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 
 	"github.com/hashicorp/hcdiag/client"
-	s "github.com/hashicorp/hcdiag/op"
+	"github.com/hashicorp/hcdiag/op"
 	logs "github.com/hashicorp/hcdiag/op/log"
 )
 
@@ -36,7 +36,7 @@ func NewNomad(logger hclog.Logger, cfg Config) (*Product, error) {
 	if DefaultInterval == cfg.DebugInterval {
 		cfg.DebugInterval = NomadDebugInterval
 	}
-	ops, err := NomadOps(cfg, api)
+	ops, err := NomadRunners(cfg, api)
 	if err != nil {
 		return nil, err
 	}
@@ -49,17 +49,18 @@ func NewNomad(logger hclog.Logger, cfg Config) (*Product, error) {
 	}, nil
 }
 
-// NomadOps seek information about Nomad.
-func NomadOps(cfg Config, api *client.APIClient) ([]*s.Op, error) {
-	ops := []*s.Op{
-		s.NewCommander("nomad version", "string"),
-		s.NewCommander("nomad node status -self -json", "json"),
-		s.NewCommander("nomad agent-info -json", "json"),
-		s.NewCommander(fmt.Sprintf("nomad operator debug -log-level=TRACE -node-id=all -max-nodes=10 -output=%s -duration=%s -interval=%s", cfg.TmpDir, cfg.DebugDuration, cfg.DebugInterval), "string"),
+// FIXME(mkcp): doccment
+// NomadRunners ...
+func NomadRunners(cfg Config, api *client.APIClient) ([]op.Runner, error) {
+	runners := []op.Runner{
+		op.NewCommander("nomad version", "string"),
+		op.NewCommander("nomad node status -self -json", "json"),
+		op.NewCommander("nomad agent-info -json", "json"),
+		op.NewCommander(fmt.Sprintf("nomad operator debug -log-level=TRACE -node-id=all -max-nodes=10 -output=%s -duration=%s -interval=%s", cfg.TmpDir, cfg.DebugDuration, cfg.DebugInterval), "string"),
 
-		s.NewHTTPer(api, "/v1/agent/members?stale=true"),
-		s.NewHTTPer(api, "/v1/operator/autopilot/configuration?stale=true"),
-		s.NewHTTPer(api, "/v1/operator/raft/configuration?stale=true"),
+		op.NewHTTPer(api, "/v1/agent/members?stale=true"),
+		op.NewHTTPer(api, "/v1/operator/autopilot/configuration?stale=true"),
+		op.NewHTTPer(api, "/v1/operator/raft/configuration?stale=true"),
 
 		logs.NewDocker("nomad", cfg.TmpDir, cfg.Since),
 		logs.NewJournald("nomad", cfg.TmpDir, cfg.Since, cfg.Until),
@@ -68,9 +69,9 @@ func NomadOps(cfg Config, api *client.APIClient) ([]*s.Op, error) {
 	// try to detect log location to copy
 	if logPath, err := client.GetNomadLogPath(api); err == nil {
 		dest := filepath.Join(cfg.TmpDir, "logs", "nomad")
-		logCopier := s.NewCopier(logPath, dest, cfg.Since, cfg.Until)
-		ops = append([]*s.Op{logCopier}, ops...)
+		logCopier := op.NewCopier(logPath, dest, cfg.Since, cfg.Until)
+		runners = append([]op.Runner{logCopier}, runners...)
 	}
 
-	return ops, nil
+	return runners, nil
 }

--- a/product/product.go
+++ b/product/product.go
@@ -54,8 +54,8 @@ func (p *Product) Run() map[string]op.Op {
 		if o.Error != nil {
 			p.l.Warn("result",
 				"op", r.ID(),
-				"result", fmt.Sprintf("%s", result),
-				"error", err,
+				"result", fmt.Sprintf("%s", o.Result),
+				"error", o.Error,
 			)
 		}
 	}
@@ -65,7 +65,7 @@ func (p *Product) Run() map[string]op.Op {
 // Filter applies our slices of exclude and select op.Identifier matchers to the set of the product's ops
 func (p *Product) Filter() error {
 	if p.Runners == nil {
-		p.Runners = []*op.Op{}
+		p.Runners = []op.Runner{}
 	}
 	var err error
 	// The presence of Selects takes precedence over Excludes
@@ -83,13 +83,13 @@ func (p *Product) Filter() error {
 
 // CommanderHealthCheck employs the CLI to check if the client and then the agent are available.
 func CommanderHealthCheck(client, agent string) error {
-	isClientAvailable := op.NewCommander(client, "string")
-	if result, err := isClientAvailable.Run(); err != nil {
-		return fmt.Errorf("client not available, healthcheck=%v, result=%v, error=%v", client, result, err)
+	checkClient := op.NewCommander(client, "string").Run()
+	if checkClient.Error != nil {
+		return fmt.Errorf("client not available, healthcheck=%v, result=%v, error=%v", client, checkClient.Result, checkClient.Error)
 	}
-	isAgentAvailable := op.NewCommander(agent, "string")
-	if result, err := isAgentAvailable.Run(); err != nil {
-		return fmt.Errorf("agent not available, healthcheck=%v, result=%v, error=%v", agent, result, err)
+	checkAgent := op.NewCommander(agent, "string").Run()
+	if checkAgent.Error != nil {
+		return fmt.Errorf("agent not available, healthcheck=%v, result=%v, error=%v", agent, checkAgent.Result, checkAgent.Error)
 	}
 	return nil
 }

--- a/product/product.go
+++ b/product/product.go
@@ -34,7 +34,7 @@ type Config struct {
 type Product struct {
 	l        hclog.Logger
 	Name     string
-	Ops      []*op.Op
+	Runners  []op.Runner
 	Excludes []string
 	Selects  []string
 	Config   Config
@@ -44,16 +44,16 @@ type Product struct {
 func (p *Product) Run() map[string]op.Op {
 	p.l.Info("Running operations for", "product", p.Name)
 	results := make(map[string]op.Op)
-	for _, s := range p.Ops {
-		p.l.Info("running operation", "product", p.Name, "op", s.Identifier)
-		result, err := s.Run()
+	for _, r := range p.Runners {
+		p.l.Info("running operation", "product", p.Name, "op", r.ID())
+		o := r.Run()
 		// NOTE(mkcp): There's nothing stopping Run() from being called multiple times, so we'll copy the op off the product once it's done.
 		// TODO(mkcp): It would be nice if we got an immutable op result type back from op runs instead.
-		results[s.Identifier] = *s
+		results[r.ID()] = o
 		// Note op errors to users and keep going.
-		if err != nil {
+		if o.Error != nil {
 			p.l.Warn("result",
-				"op", s.Identifier,
+				"op", r.ID(),
 				"result", fmt.Sprintf("%s", result),
 				"error", err,
 			)
@@ -64,19 +64,19 @@ func (p *Product) Run() map[string]op.Op {
 
 // Filter applies our slices of exclude and select op.Identifier matchers to the set of the product's ops
 func (p *Product) Filter() error {
-	if p.Ops == nil {
-		p.Ops = []*op.Op{}
+	if p.Runners == nil {
+		p.Runners = []*op.Op{}
 	}
 	var err error
 	// The presence of Selects takes precedence over Excludes
 	if p.Selects != nil && 0 < len(p.Selects) {
-		p.Ops, err = op.Select(p.Selects, p.Ops)
+		p.Runners, err = op.Select(p.Selects, p.Runners)
 		// Skip any Excludes
 		return err
 	}
 	// No Selects, we can apply Excludes
 	if p.Excludes != nil {
-		p.Ops, err = op.Exclude(p.Excludes, p.Ops)
+		p.Runners, err = op.Exclude(p.Excludes, p.Runners)
 	}
 	return err
 }
@@ -97,7 +97,7 @@ func CommanderHealthCheck(client, agent string) error {
 func CountOps(products map[string]*Product) int {
 	var count int
 	for _, product := range products {
-		count += len(product.Ops)
+		count += len(product.Runners)
 	}
 	return count
 }

--- a/product/product.go
+++ b/product/product.go
@@ -94,7 +94,8 @@ func CommanderHealthCheck(client, agent string) error {
 	return nil
 }
 
-func CountOps(products map[string]*Product) int {
+// CountRunners takes a map of product references and returns a count of all the runners
+func CountRunners(products map[string]*Product) int {
 	var count int
 	for _, product := range products {
 		count += len(product.Runners)

--- a/product/product_test.go
+++ b/product/product_test.go
@@ -16,14 +16,14 @@ func TestFilters(t *testing.T) {
 		{
 			desc: "Handles empty ops and empty filters",
 			product: &Product{
-				Ops: []*op.Op{},
+				Runners: []*op.Op{},
 			},
 			expect: []*op.Op{},
 		},
 		{
 			desc: "Handles empty ops with non-empty filters",
 			product: &Product{
-				Ops:      []*op.Op{},
+				Runners:  []*op.Op{},
 				Excludes: []string{"hello"},
 			},
 			expect: []*op.Op{},
@@ -31,7 +31,7 @@ func TestFilters(t *testing.T) {
 		{
 			desc: "Handles nil filters",
 			product: &Product{
-				Ops: []*op.Op{{Identifier: "still here"}},
+				Runners: []*op.Op{{Identifier: "still here"}},
 			},
 			expect: []*op.Op{{Identifier: "still here"}},
 		},
@@ -45,7 +45,7 @@ func TestFilters(t *testing.T) {
 		{
 			desc: "Handles empty filters",
 			product: &Product{
-				Ops: []*op.Op{
+				Runners: []*op.Op{
 					{Identifier: "still here"},
 				},
 				Excludes: []string{},
@@ -56,7 +56,7 @@ func TestFilters(t *testing.T) {
 		{
 			desc: "Applies matching excludes",
 			product: &Product{
-				Ops: []*op.Op{
+				Runners: []*op.Op{
 					{Identifier: "goodbye"},
 				},
 				Excludes: []string{"goodbye"},
@@ -66,7 +66,7 @@ func TestFilters(t *testing.T) {
 		{
 			desc: "Does not apply non-matching excludes",
 			product: &Product{
-				Ops:      []*op.Op{{Identifier: "goodbye"}},
+				Runners:  []*op.Op{{Identifier: "goodbye"}},
 				Excludes: []string{"hello"},
 			},
 			expect: []*op.Op{{Identifier: "goodbye"}},
@@ -74,7 +74,7 @@ func TestFilters(t *testing.T) {
 		{
 			desc: "Applies matching Selects",
 			product: &Product{
-				Ops: []*op.Op{
+				Runners: []*op.Op{
 					{Identifier: "goodbye"},
 					{Identifier: "hello"},
 				},
@@ -85,7 +85,7 @@ func TestFilters(t *testing.T) {
 		{
 			desc: "Ignores excludes when Selects are present, and ignores order",
 			product: &Product{
-				Ops: []*op.Op{
+				Runners: []*op.Op{
 					{Identifier: "select3"},
 					{Identifier: "select1"},
 					{Identifier: "goodbye"},
@@ -105,8 +105,8 @@ func TestFilters(t *testing.T) {
 	for _, tc := range testTable {
 		err := tc.product.Filter()
 		assert.Nil(t, err)
-		assert.NotNil(t, tc.product.Ops)
-		assert.Equal(t, tc.expect, tc.product.Ops, tc.desc)
+		assert.NotNil(t, tc.product.Runners)
+		assert.Equal(t, tc.expect, tc.product.Runners, tc.desc)
 	}
 
 }
@@ -120,7 +120,7 @@ func TestFilterErrors(t *testing.T) {
 		{
 			desc: "Select returns error when pattern is malformed",
 			product: &Product{
-				Ops:     []*op.Op{{Identifier: "ignoreme"}},
+				Runners: []*op.Op{{Identifier: "ignoreme"}},
 				Selects: []string{"mal[formed"},
 			},
 			expect: "filter error: 'syntax error in pattern'",
@@ -128,7 +128,7 @@ func TestFilterErrors(t *testing.T) {
 		{
 			desc: "Exclude returns error when pattern is malformed",
 			product: &Product{
-				Ops:      []*op.Op{{Identifier: "ignoreme"}},
+				Runners:  []*op.Op{{Identifier: "ignoreme"}},
 				Excludes: []string{"mal[formed"},
 			},
 			expect: "filter error: 'syntax error in pattern'",

--- a/product/product_test.go
+++ b/product/product_test.go
@@ -7,97 +7,106 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var _ op.Runner = mockRunner{}
+
+type mockRunner struct {
+	id string
+}
+
+func (m mockRunner) ID() string { return m.id }
+func (m mockRunner) Run() op.Op { return op.Op{} }
+
 func TestFilters(t *testing.T) {
 	testTable := []struct {
 		desc    string
 		product *Product
-		expect  []*op.Op
+		expect  []op.Runner
 	}{
 		{
 			desc: "Handles empty ops and empty filters",
 			product: &Product{
-				Runners: []*op.Op{},
+				Runners: []op.Runner{},
 			},
-			expect: []*op.Op{},
+			expect: []op.Runner{},
 		},
 		{
 			desc: "Handles empty ops with non-empty filters",
 			product: &Product{
-				Runners:  []*op.Op{},
+				Runners:  []op.Runner{},
 				Excludes: []string{"hello"},
 			},
-			expect: []*op.Op{},
+			expect: []op.Runner{},
 		},
 		{
 			desc: "Handles nil filters",
 			product: &Product{
-				Runners: []*op.Op{{Identifier: "still here"}},
+				Runners: []op.Runner{mockRunner{id: "still here"}},
 			},
-			expect: []*op.Op{{Identifier: "still here"}},
+			expect: []op.Runner{mockRunner{id: "still here"}},
 		},
 		{
-			desc: "Handles nil ops",
+			desc: "Handles nil runners",
 			product: &Product{
 				Excludes: []string{"nope"},
 			},
-			expect: []*op.Op{},
+			expect: []op.Runner{},
 		},
 		{
 			desc: "Handles empty filters",
 			product: &Product{
-				Runners: []*op.Op{
-					{Identifier: "still here"},
+				Runners: []op.Runner{
+					mockRunner{id: "still here"},
 				},
 				Excludes: []string{},
 				Selects:  []string{},
 			},
-			expect: []*op.Op{{Identifier: "still here"}},
+			expect: []op.Runner{mockRunner{id: "still here"}},
 		},
 		{
 			desc: "Applies matching excludes",
 			product: &Product{
-				Runners: []*op.Op{
-					{Identifier: "goodbye"},
+				Runners: []op.Runner{
+					mockRunner{id: "goodbye"},
 				},
 				Excludes: []string{"goodbye"},
 			},
-			expect: []*op.Op{},
+			expect: []op.Runner{},
 		},
 		{
 			desc: "Does not apply non-matching excludes",
 			product: &Product{
-				Runners:  []*op.Op{{Identifier: "goodbye"}},
+				Runners:  []op.Runner{mockRunner{id: "goodbye"}},
 				Excludes: []string{"hello"},
 			},
-			expect: []*op.Op{{Identifier: "goodbye"}},
+			expect: []op.Runner{mockRunner{id: "goodbye"}},
 		},
 		{
 			desc: "Applies matching Selects",
 			product: &Product{
-				Runners: []*op.Op{
-					{Identifier: "goodbye"},
-					{Identifier: "hello"},
+				Runners: []op.Runner{
+					mockRunner{id: "goodbye"},
+					mockRunner{id: "hello"},
 				},
 				Selects: []string{"hello"},
 			},
-			expect: []*op.Op{{Identifier: "hello"}},
+			expect: []op.Runner{mockRunner{id: "hello"}},
 		},
 		{
 			desc: "Ignores excludes when Selects are present, and ignores order",
 			product: &Product{
-				Runners: []*op.Op{
-					{Identifier: "select3"},
-					{Identifier: "select1"},
-					{Identifier: "goodbye"},
-					{Identifier: "select2"},
+				Runners: []op.Runner{
+					mockRunner{id: "select3"},
+					mockRunner{id: "select1"},
+					mockRunner{id: "goodbye"},
+					mockRunner{id: "select2"},
 				},
 				Excludes: []string{"select2", "select3"},
 				Selects:  []string{"select2", "select1", "select3"},
 			},
-			expect: []*op.Op{
-				{Identifier: "select3"},
-				{Identifier: "select1"},
-				{Identifier: "select2"},
+			expect: []op.Runner{
+				mockRunner{id: "select3"},
+				mockRunner{id: "select1"},
+				mockRunner{id: "select2"},
 			},
 		},
 	}
@@ -120,7 +129,7 @@ func TestFilterErrors(t *testing.T) {
 		{
 			desc: "Select returns error when pattern is malformed",
 			product: &Product{
-				Runners: []*op.Op{{Identifier: "ignoreme"}},
+				Runners: []op.Runner{mockRunner{id: "ignoreme"}},
 				Selects: []string{"mal[formed"},
 			},
 			expect: "filter error: 'syntax error in pattern'",
@@ -128,7 +137,7 @@ func TestFilterErrors(t *testing.T) {
 		{
 			desc: "Exclude returns error when pattern is malformed",
 			product: &Product{
-				Runners:  []*op.Op{{Identifier: "ignoreme"}},
+				Runners:  []op.Runner{mockRunner{id: "ignoreme"}},
 				Excludes: []string{"mal[formed"},
 			},
 			expect: "filter error: 'syntax error in pattern'",

--- a/product/tfe.go
+++ b/product/tfe.go
@@ -3,7 +3,7 @@ package product
 import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcdiag/client"
-	s "github.com/hashicorp/hcdiag/op"
+	"github.com/hashicorp/hcdiag/op"
 )
 
 // NewTFE takes a product config and creates a Product containing all of TFE's ops.
@@ -13,31 +13,32 @@ func NewTFE(logger hclog.Logger, cfg Config) (*Product, error) {
 		return nil, err
 	}
 
-	ops, err := TFEOps(cfg, api)
+	runners, err := TFERunners(cfg, api)
 	if err != nil {
 		return nil, err
 	}
 	return &Product{
 		l:       logger.Named("product"),
 		Name:    TFE,
-		Runners: ops,
+		Runners: runners,
 		Config:  cfg,
 	}, nil
 }
 
-// TFEOps seek information about Terraform Enterprise/Cloud.
-func TFEOps(cfg Config, api *client.APIClient) ([]*s.Op, error) {
-	return []*s.Op{
-		s.NewCommander("replicatedctl support-bundle", "string"),
+// FIXME(mkcp): doccment
+// TFERunners...
+func TFERunners(cfg Config, api *client.APIClient) ([]op.Runner, error) {
+	return []op.Runner{
+		op.NewCommander("replicatedctl support-bundle", "string"),
 
-		s.NewCopier("/var/lib/replicated/support-bundles/replicated-support*.tar.gz", cfg.TmpDir, cfg.Since, cfg.Until),
+		op.NewCopier("/var/lib/replicated/support-bundles/replicated-support*.tar.gz", cfg.TmpDir, cfg.Since, cfg.Until),
 
-		s.NewHTTPer(api, "/api/v2/admin/customization-settings"),
-		s.NewHTTPer(api, "/api/v2/admin/general-settings"),
-		s.NewHTTPer(api, "/api/v2/admin/organizations"),
-		s.NewHTTPer(api, "/api/v2/admin/terraform-versions"),
-		s.NewHTTPer(api, "/api/v2/admin/twilio-settings"),
+		op.NewHTTPer(api, "/api/v2/admin/customization-settings"),
+		op.NewHTTPer(api, "/api/v2/admin/general-settings"),
+		op.NewHTTPer(api, "/api/v2/admin/organizations"),
+		op.NewHTTPer(api, "/api/v2/admin/terraform-versions"),
+		op.NewHTTPer(api, "/api/v2/admin/twilio-settings"),
 		// page size 1 because we only actually care about total workspace count in the `meta` field
-		s.NewHTTPer(api, "/api/v2/admin/workspaces?page[size]=1"),
+		op.NewHTTPer(api, "/api/v2/admin/workspaces?page[size]=1"),
 	}, nil
 }

--- a/product/tfe.go
+++ b/product/tfe.go
@@ -18,10 +18,10 @@ func NewTFE(logger hclog.Logger, cfg Config) (*Product, error) {
 		return nil, err
 	}
 	return &Product{
-		l:      logger.Named("product"),
-		Name:   TFE,
-		Ops:    ops,
-		Config: cfg,
+		l:       logger.Named("product"),
+		Name:    TFE,
+		Runners: ops,
+		Config:  cfg,
 	}, nil
 }
 

--- a/product/vault.go
+++ b/product/vault.go
@@ -29,10 +29,10 @@ func NewVault(logger hclog.Logger, cfg Config) (*Product, error) {
 		return nil, err
 	}
 	return &Product{
-		l:      logger.Named("product"),
-		Name:   Vault,
-		Ops:    ops,
-		Config: cfg,
+		l:       logger.Named("product"),
+		Name:    Vault,
+		Runners: ops,
+		Config:  cfg,
 	}, nil
 }
 

--- a/product/vault.go
+++ b/product/vault.go
@@ -9,7 +9,7 @@ import (
 	logs "github.com/hashicorp/hcdiag/op/log"
 
 	"github.com/hashicorp/hcdiag/client"
-	s "github.com/hashicorp/hcdiag/op"
+	"github.com/hashicorp/hcdiag/op"
 )
 
 const (
@@ -24,27 +24,28 @@ func NewVault(logger hclog.Logger, cfg Config) (*Product, error) {
 		return nil, err
 	}
 
-	ops, err := VaultOps(cfg, api)
+	runners, err := VaultRunners(cfg, api)
 	if err != nil {
 		return nil, err
 	}
 	return &Product{
 		l:       logger.Named("product"),
 		Name:    Vault,
-		Runners: ops,
+		Runners: runners,
 		Config:  cfg,
 	}, nil
 }
 
-// VaultOps generates a list of ops to inspect Vault.
-func VaultOps(cfg Config, api *client.APIClient) ([]*s.Op, error) {
-	ops := []*s.Op{
-		s.NewCommander("vault version", "string"),
-		s.NewCommander("vault status -format=json", "json"),
-		s.NewCommander("vault read sys/health -format=json", "json"),
-		s.NewCommander("vault read sys/seal-status -format=json", "json"),
-		s.NewCommander("vault read sys/host-info -format=json", "json"),
-		s.NewCommander(fmt.Sprintf("vault debug -output=%s/VaultDebug.tar.gz -duration=%s -interval=%s", cfg.TmpDir, cfg.DebugDuration, cfg.DebugInterval), "string"),
+// TODO(mkcp): doccomment
+// VaultRunners ...
+func VaultRunners(cfg Config, api *client.APIClient) ([]op.Runner, error) {
+	runners := []op.Runner{
+		op.NewCommander("vault version", "string"),
+		op.NewCommander("vault status -format=json", "json"),
+		op.NewCommander("vault read sys/health -format=json", "json"),
+		op.NewCommander("vault read sys/seal-status -format=json", "json"),
+		op.NewCommander("vault read sys/host-info -format=json", "json"),
+		op.NewCommander(fmt.Sprintf("vault debug -output=%s/VaultDebug.tar.gz -duration=%s -interval=%s", cfg.TmpDir, cfg.DebugDuration, cfg.DebugInterval), "string"),
 
 		logs.NewDocker("vault", cfg.TmpDir, cfg.Since),
 		logs.NewJournald("vault", cfg.TmpDir, cfg.Since, cfg.Until),
@@ -53,9 +54,9 @@ func VaultOps(cfg Config, api *client.APIClient) ([]*s.Op, error) {
 	// try to detect log location to copy
 	if logPath, err := client.GetVaultAuditLogPath(api); err == nil {
 		dest := filepath.Join(cfg.TmpDir, "logs/vault")
-		logCopier := s.NewCopier(logPath, dest, cfg.Since, cfg.Until)
-		ops = append([]*s.Op{logCopier}, ops...)
+		logCopier := op.NewCopier(logPath, dest, cfg.Since, cfg.Until)
+		runners = append([]op.Runner{logCopier}, runners...)
 	}
 
-	return ops, nil
+	return runners, nil
 }

--- a/util/util.go
+++ b/util/util.go
@@ -251,3 +251,11 @@ func EnsureDirectory(dir string) error {
 
 	return nil
 }
+
+// RunnerParams converts a struct to a map[string]interface{}
+func RunnerParams(r interface{}) map[string]interface{} {
+	var inInterface map[string]interface{}
+	inrec, _ := json.Marshal(&r)
+	_ = json.Unmarshal(inrec, &inInterface)
+	return inInterface
+}


### PR DESCRIPTION
This is a follow up to renaming seekers in which we add some boundaries between Operations To Be Run (`Runner`s now) and the result of these operations `Op`.

A list of changes in this migration:
- Remove Runner field from Ops
- Store Runners on Product instead of Ops
- Change Runner.Run() to return an immutable Op struct copy and implement on all runners
  - Add an op.New() function to help make this easier.
  - Add Params field to Op and serialize Runner params onto it
- Add Runner.ID() method and implement on all runners
- Change New<Runner> functions to return the struct type it’s named after 
- Change Agent and Product reporting to use Ops and Runners where appropriate.