### PR TITLE
Initial Support for Product Auto-Detection

### DIFF
--- a/changelog/147.txt
+++ b/changelog/147.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-op: rename seeker to Op.
-`
+op: Rename seeker to Op.
+```

--- a/changelog/149.txt
+++ b/changelog/149.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
 op: Store Runners on Products and change Runners interface to return an Op.
-`
+```

--- a/changelog/152.txt
+++ b/changelog/152.txt
@@ -1,0 +1,5 @@
+```release-note:breaking
+cli: The default CLI behavior when no product flags are passed in is now to auto-detect installed products and check each one.
+Previously, the behavior was to run only host diagnostics. If you want to still get just host diagnostics, use the flag
+`autodetect=false`.
+```

--- a/tests/integration/functional_test.go
+++ b/tests/integration/functional_test.go
@@ -58,7 +58,7 @@ func TestFunctional(t *testing.T) {
 				skip     bool     // skip the sub-test or not
 			}{
 				"host": {
-					flags:    []string{},
+					flags:    []string{"autodetect=false"},
 					outFiles: []string{},
 					skip:     false,
 				},

--- a/tests/integration/functional_test.go
+++ b/tests/integration/functional_test.go
@@ -58,7 +58,7 @@ func TestFunctional(t *testing.T) {
 				skip     bool     // skip the sub-test or not
 			}{
 				"host": {
-					flags:    []string{"autodetect=false"},
+					flags:    []string{"-autodetect=false"},
 					outFiles: []string{},
 					skip:     false,
 				},


### PR DESCRIPTION
This PR adds support for product auto-detection. The hope is to make it simpler for users to get diagnostics on all installed products by simply running the `hcdiag` command. This is similar to the previous `all` flag, but with some basic checks in place to validate which products' CLIs are actually installed first.