### PR TITLE
Allow Running with no Flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -254,6 +254,10 @@ func setTime(cfg agent.Config, now time.Time, since time.Duration) agent.Config 
 }
 
 func noSubcommand(args []string) error {
+	if len(args) <= 1 {
+		return nil
+	}
+
 	mustBeFlag := args[1]
 	checker := '-'
 	firstChar := []rune(mustBeFlag)[0]


### PR DESCRIPTION
PR #155 addressed a bug when the first argument passed to hcdiag was not a flag. However, it also required at least flag to be present, or else it would panic. This PR addresses that limitation, so that hcdiag can be executed without specifying any flags.