### PR TITLE
Refactor agent.Setup()

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -132,7 +132,7 @@ func TestCopyIncludes(t *testing.T) {
 func TestRunProducts(t *testing.T) {
 	l := hclog.Default()
 	pCfg := product.Config{OS: "auto"}
-	p := make(map[string]*product.Product)
+	p := make(map[product.Name]*product.Product)
 	a := NewAgent(Config{}, hclog.Default())
 	a.products = p
 	p["host"] = product.NewHost(l, pCfg)
@@ -146,7 +146,7 @@ func TestRunProducts(t *testing.T) {
 func TestAgent_RecordManifest(t *testing.T) {
 	t.Run("adds to ManifestOps when ops exist", func(t *testing.T) {
 		// Setup
-		testProduct := "host"
+		testProduct := product.Host
 		testResults := map[string]op.Op{
 			"": {},
 		}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/hashicorp/hcdiag/hcl"
+
 	"github.com/hashicorp/hcdiag/op"
 
 	"github.com/hashicorp/go-hclog"
@@ -135,9 +137,11 @@ func TestRunProducts(t *testing.T) {
 	p := make(map[product.Name]*product.Product)
 	a := NewAgent(Config{}, hclog.Default())
 	a.products = p
-	p["host"] = product.NewHost(l, pCfg)
+	h, err := product.NewHost(l, pCfg, &hcl.Host{})
+	assert.NoError(t, err)
+	p[product.Host] = h
 
-	err := a.RunProducts()
+	err = a.RunProducts()
 	assert.NoError(t, err)
 	assert.Len(t, a.products, 1, "has one product")
 	assert.NotNil(t, a.products["host"], "product is under \"host\" key")

--- a/changelog/161.txt
+++ b/changelog/161.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+agent: Refactor agent.Setup() by migrating HCL runner setup into each product's New<product> function.
+```

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -164,3 +164,12 @@ func mapProductGETs(cfgs []GET, c *client.APIClient) []runner.Runner {
 	}
 	return runners
 }
+
+// ProductsMap takes the collection of products and returns a map that keys each product to its Name.
+func ProductsMap(products []*Product) map[string]*Product {
+	m := make(map[string]*Product)
+	for _, p := range products {
+		m[p.Name] = p
+	}
+	return m
+}

--- a/product/consul.go
+++ b/product/consul.go
@@ -48,7 +48,7 @@ func NewConsul(logger hclog.Logger, cfg Config) (*Product, error) {
 	return product, nil
 }
 
-// consulRunners generates a slice of ops to inspect consul
+// consulRunners generates a slice of runners to inspect consul.
 func consulRunners(cfg Config, api *client.APIClient) ([]runner.Runner, error) {
 	runners := []runner.Runner{
 		runner.NewCommander("consul version", "string"),

--- a/product/consul.go
+++ b/product/consul.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/hashicorp/hcdiag/hcl"
+
 	"github.com/hashicorp/go-hclog"
 
 	"github.com/hashicorp/hcdiag/client"
@@ -16,27 +18,38 @@ const (
 	ConsulAgentCheck  = "consul info"
 )
 
-// NewConsul takes a product config and creates a Product with all of Consul's default ops
+// NewConsul takes a logger, config, and HCL and creates a Product with all of Consul's default ops.
 func NewConsul(logger hclog.Logger, cfg Config) (*Product, error) {
+	product := &Product{
+		l:      logger.Named("product"),
+		Name:   Consul,
+		Config: cfg,
+	}
 	api, err := client.NewConsulAPI()
 	if err != nil {
 		return nil, err
 	}
 
-	ops, err := ConsulOps(cfg, api)
+	product.Runners, err = consulRunners(cfg, api)
 	if err != nil {
 		return nil, err
 	}
-	return &Product{
-		l:       logger.Named("product"),
-		Name:    Consul,
-		Runners: ops,
-		Config:  cfg,
-	}, nil
+
+	if cfg.HCL != nil {
+		hclRunners, err := hcl.BuildRunners(cfg.HCL, cfg.TmpDir, api)
+		if err != nil {
+			return nil, err
+		}
+		product.Runners = append(product.Runners, hclRunners...)
+		product.Excludes = cfg.HCL.Excludes
+		product.Selects = cfg.HCL.Selects
+	}
+
+	return product, nil
 }
 
-// ConsulOps generates a slice of ops to inspect consul
-func ConsulOps(cfg Config, api *client.APIClient) ([]runner.Runner, error) {
+// consulRunners generates a slice of ops to inspect consul
+func consulRunners(cfg Config, api *client.APIClient) ([]runner.Runner, error) {
 	runners := []runner.Runner{
 		runner.NewCommander("consul version", "string"),
 		runner.NewCommander(fmt.Sprintf("consul debug -output=%s/ConsulDebug -duration=%s -interval=%s", cfg.TmpDir, cfg.DebugDuration, cfg.DebugInterval), "string"),

--- a/product/consul.go
+++ b/product/consul.go
@@ -18,7 +18,7 @@ const (
 	ConsulAgentCheck  = "consul info"
 )
 
-// NewConsul takes a logger and product config, and it creates a Product with all of Consul's default ops.
+// NewConsul takes a logger and product config, and it creates a Product with all of Consul's default runners.
 func NewConsul(logger hclog.Logger, cfg Config) (*Product, error) {
 	product := &Product{
 		l:      logger.Named("product"),

--- a/product/consul.go
+++ b/product/consul.go
@@ -18,7 +18,7 @@ const (
 	ConsulAgentCheck  = "consul info"
 )
 
-// NewConsul takes a logger, config, and HCL and creates a Product with all of Consul's default ops.
+// NewConsul takes a logger and product config, and it creates a Product with all of Consul's default ops.
 func NewConsul(logger hclog.Logger, cfg Config) (*Product, error) {
 	product := &Product{
 		l:      logger.Named("product"),

--- a/product/host.go
+++ b/product/host.go
@@ -37,7 +37,7 @@ func NewHost(logger hclog.Logger, cfg Config, hcl2 *hcl.Host) (*Product, error) 
 	return product, nil
 }
 
-// hostRunners checks the operating system and passes it into the operations, returning a list of ops to run.
+// hostRunners generates a slice of runners to inspect the host.
 func hostRunners(os string) []runner.Runner {
 	return []runner.Runner{
 		host.NewOS(os),

--- a/product/host.go
+++ b/product/host.go
@@ -23,7 +23,7 @@ func NewHost(logger hclog.Logger, cfg Config, hcl2 *hcl.Host) (*Product, error) 
 		os = runtime.GOOS
 	}
 	// TODO(mkcp): Host can have an API client now and it would simplify quite a bit.
-	runners := hostRunners(os)
+	product.Runners = hostRunners(os)
 	if hcl2 != nil {
 		hclRunners, err := hcl.BuildRunners(hcl2, cfg.TmpDir, nil)
 		if err != nil {
@@ -33,7 +33,6 @@ func NewHost(logger hclog.Logger, cfg Config, hcl2 *hcl.Host) (*Product, error) 
 		product.Excludes = hcl2.Excludes
 		product.Selects = hcl2.Selects
 	}
-	product.Runners = runners
 	return product, nil
 }
 

--- a/product/host.go
+++ b/product/host.go
@@ -3,6 +3,8 @@ package product
 import (
 	"runtime"
 
+	"github.com/hashicorp/hcdiag/hcl"
+
 	"github.com/hashicorp/go-hclog"
 
 	"github.com/hashicorp/hcdiag/runner"
@@ -10,20 +12,33 @@ import (
 )
 
 // NewHost takes a product config and creates a Product containing all of the host's ops.
-func NewHost(logger hclog.Logger, cfg Config) *Product {
-	return &Product{
-		l:       logger.Named("product"),
-		Name:    Host,
-		Runners: HostRunners(cfg.OS),
-		Config:  cfg,
+func NewHost(logger hclog.Logger, cfg Config, hcl2 *hcl.Host) (*Product, error) {
+	product := &Product{
+		l:      logger.Named("product"),
+		Name:   Host,
+		Config: cfg,
 	}
-}
-
-// HostRunners checks the operating system and passes it into the operations, returning a list of ops to run.
-func HostRunners(os string) []runner.Runner {
-	if os == "auto" {
+	var os string
+	if cfg.OS == "auto" {
 		os = runtime.GOOS
 	}
+	// TODO(mkcp): Host can have an API client now and it would simplify quite a bit.
+	runners := hostRunners(os)
+	if hcl2 != nil {
+		hclRunners, err := hcl.BuildRunners(hcl2, cfg.TmpDir, nil)
+		if err != nil {
+			return nil, err
+		}
+		product.Runners = append(product.Runners, hclRunners...)
+		product.Excludes = hcl2.Excludes
+		product.Selects = hcl2.Selects
+	}
+	product.Runners = runners
+	return product, nil
+}
+
+// hostRunners checks the operating system and passes it into the operations, returning a list of ops to run.
+func hostRunners(os string) []runner.Runner {
 	return []runner.Runner{
 		host.NewOS(os),
 		host.NewDisk(),

--- a/product/host.go
+++ b/product/host.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/hcdiag/runner/host"
 )
 
-// NewHost takes a product config and creates a Product containing all of the host's ops.
+// NewHost takes a logger, config, and HCL, and it creates a Product with all the host's default ops.
 func NewHost(logger hclog.Logger, cfg Config, hcl2 *hcl.Host) (*Product, error) {
 	product := &Product{
 		l:      logger.Named("product"),

--- a/product/host.go
+++ b/product/host.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/hcdiag/runner/host"
 )
 
-// NewHost takes a logger, config, and HCL, and it creates a Product with all the host's default ops.
+// NewHost takes a logger, config, and HCL, and it creates a Product with all the host's default runners.
 func NewHost(logger hclog.Logger, cfg Config, hcl2 *hcl.Host) (*Product, error) {
 	product := &Product{
 		l:      logger.Named("product"),

--- a/product/nomad.go
+++ b/product/nomad.go
@@ -21,7 +21,7 @@ const (
 	NomadDebugInterval = 30 * time.Second
 )
 
-// NewNomad takes a product config and creates a Product with all of Nomad's default ops
+// NewNomad takes a logger and product config, and it creates a Product with all of Nomad's default ops.
 func NewNomad(logger hclog.Logger, cfg Config) (*Product, error) {
 	product := &Product{
 		l:      logger.Named("product"),

--- a/product/nomad.go
+++ b/product/nomad.go
@@ -21,7 +21,7 @@ const (
 	NomadDebugInterval = 30 * time.Second
 )
 
-// NewNomad takes a logger and product config, and it creates a Product with all of Nomad's default ops.
+// NewNomad takes a logger and product config, and it creates a Product with all of Nomad's default runners.
 func NewNomad(logger hclog.Logger, cfg Config) (*Product, error) {
 	product := &Product{
 		l:      logger.Named("product"),

--- a/product/nomad.go
+++ b/product/nomad.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/hashicorp/hcdiag/hcl"
+
 	"github.com/hashicorp/go-hclog"
 
 	"github.com/hashicorp/hcdiag/client"
@@ -21,6 +23,11 @@ const (
 
 // NewNomad takes a product config and creates a Product with all of Nomad's default ops
 func NewNomad(logger hclog.Logger, cfg Config) (*Product, error) {
+	product := &Product{
+		l:      logger.Named("product"),
+		Name:   Nomad,
+		Config: cfg,
+	}
 	api, err := client.NewNomadAPI()
 	if err != nil {
 		return nil, err
@@ -36,22 +43,26 @@ func NewNomad(logger hclog.Logger, cfg Config) (*Product, error) {
 	if DefaultInterval == cfg.DebugInterval {
 		cfg.DebugInterval = NomadDebugInterval
 	}
-	ops, err := NomadRunners(cfg, api)
+	product.Runners, err = nomadRunners(cfg, api)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Product{
-		l:       logger.Named("product"),
-		Name:    Nomad,
-		Runners: ops,
-		Config:  cfg,
-	}, nil
+	if cfg.HCL != nil {
+		hclRunners, err := hcl.BuildRunners(cfg.HCL, cfg.TmpDir, api)
+		if err != nil {
+			return nil, err
+		}
+		product.Runners = append(product.Runners, hclRunners...)
+		product.Excludes = cfg.HCL.Excludes
+		product.Selects = cfg.HCL.Selects
+	}
+
+	return product, nil
 }
 
-// FIXME(mkcp): doccment
-// NomadRunners ...
-func NomadRunners(cfg Config, api *client.APIClient) ([]runner.Runner, error) {
+// nomadRunners generates a slice of runners to inspect nomad
+func nomadRunners(cfg Config, api *client.APIClient) ([]runner.Runner, error) {
 	runners := []runner.Runner{
 		runner.NewCommander("nomad version", "string"),
 		runner.NewCommander("nomad node status -self -json", "json"),

--- a/product/product.go
+++ b/product/product.go
@@ -10,12 +10,14 @@ import (
 	"github.com/hashicorp/hcdiag/runner"
 )
 
+type Name string
+
 const (
-	Consul = "consul"
-	Host   = "host"
-	Nomad  = "nomad"
-	TFE    = "terraform-ent"
-	Vault  = "vault"
+	Consul Name = "consul"
+	Host   Name = "host"
+	Nomad  Name = "nomad"
+	TFE    Name = "terraform-ent"
+	Vault  Name = "vault"
 )
 
 const (
@@ -24,7 +26,7 @@ const (
 )
 
 type Config struct {
-	Name          string
+	Name          Name
 	TmpDir        string
 	Since         time.Time
 	Until         time.Time
@@ -35,7 +37,7 @@ type Config struct {
 
 type Product struct {
 	l        hclog.Logger
-	Name     string
+	Name     Name
 	Runners  []runner.Runner
 	Excludes []string
 	Selects  []string
@@ -97,7 +99,7 @@ func CommanderHealthCheck(client, agent string) error {
 }
 
 // CountRunners takes a map of product references and returns a count of all the runners
-func CountRunners(products map[string]*Product) int {
+func CountRunners(products map[Name]*Product) int {
 	var count int
 	for _, product := range products {
 		count += len(product.Runners)

--- a/product/product.go
+++ b/product/product.go
@@ -107,20 +107,3 @@ func CountRunners(products map[Name]*Product) int {
 	}
 	return count
 }
-
-// DestructureHCL takes the collection of products and assigns them to vars.
-func DestructureHCL(products []*hcl.Product) (consulHCL, nomadHCL, tfeHCL, vaultHCL *hcl.Product) {
-	for _, p := range products {
-		switch p.Name {
-		case string(Consul):
-			consulHCL = p
-		case string(Nomad):
-			nomadHCL = p
-		case string(TFE):
-			tfeHCL = p
-		case string(Vault):
-			vaultHCL = p
-		}
-	}
-	return consulHCL, nomadHCL, tfeHCL, vaultHCL
-}

--- a/product/product.go
+++ b/product/product.go
@@ -47,15 +47,13 @@ type Product struct {
 	Config   Config
 }
 
-// Run iterates over the list of ops in a product and stores each runner into a map.
+// Run iterates over the list of runners in a product and returns a map of runner IDs to Ops.
 func (p *Product) Run() map[string]op.Op {
 	p.l.Info("Running operations for", "product", p.Name)
 	results := make(map[string]op.Op)
 	for _, r := range p.Runners {
 		p.l.Info("running operation", "product", p.Name, "runner", r.ID())
 		o := r.Run()
-		// NOTE(mkcp): There's nothing stopping Run() from being called multiple times, so we'll copy the runner off the product once it's done.
-		// TODO(mkcp): It would be nice if we got an immutable runner result type back from runner runs instead.
 		results[r.ID()] = o
 		// Note runner errors to users and keep going.
 		if o.Error != nil {
@@ -69,7 +67,7 @@ func (p *Product) Run() map[string]op.Op {
 	return results
 }
 
-// Filter applies our slices of exclude and select runner.Identifier matchers to the set of the product's ops
+// Filter applies our slices of exclude and select runner.ID() matchers to the set of the product's runners.
 func (p *Product) Filter() error {
 	if p.Runners == nil {
 		p.Runners = []runner.Runner{}
@@ -101,7 +99,7 @@ func CommanderHealthCheck(client, agent string) error {
 	return nil
 }
 
-// CountRunners takes a map of product references and returns a count of all the runners
+// CountRunners takes a map of product references and returns a count of all the runners.
 func CountRunners(products map[Name]*Product) int {
 	var count int
 	for _, product := range products {
@@ -110,7 +108,7 @@ func CountRunners(products map[Name]*Product) int {
 	return count
 }
 
-// DestructureHCL takes the collection of products and assigns them to vars
+// DestructureHCL takes the collection of products and assigns them to vars.
 func DestructureHCL(products []*hcl.Product) (consulHCL, nomadHCL, tfeHCL, vaultHCL *hcl.Product) {
 	for _, p := range products {
 		switch p.Name {

--- a/product/product.go
+++ b/product/product.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/hcdiag/hcl"
+
 	"github.com/hashicorp/hcdiag/op"
 
 	"github.com/hashicorp/go-hclog"
@@ -33,6 +35,7 @@ type Config struct {
 	OS            string
 	DebugDuration time.Duration
 	DebugInterval time.Duration
+	HCL           *hcl.Product
 }
 
 type Product struct {
@@ -105,4 +108,21 @@ func CountRunners(products map[Name]*Product) int {
 		count += len(product.Runners)
 	}
 	return count
+}
+
+// DestructureHCL takes the collection of products and assigns them to vars
+func DestructureHCL(products []*hcl.Product) (consulHCL, nomadHCL, tfeHCL, vaultHCL *hcl.Product) {
+	for _, p := range products {
+		switch p.Name {
+		case string(Consul):
+			consulHCL = p
+		case string(Nomad):
+			nomadHCL = p
+		case string(TFE):
+			tfeHCL = p
+		case string(Vault):
+			vaultHCL = p
+		}
+	}
+	return consulHCL, nomadHCL, tfeHCL, vaultHCL
 }

--- a/product/tfe.go
+++ b/product/tfe.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/hcdiag/runner"
 )
 
-// NewTFE takes a logger and product config, and it creates a Product with all of TFE's default ops.
+// NewTFE takes a logger and product config, and it creates a Product with all of TFE's default runners.
 func NewTFE(logger hclog.Logger, cfg Config) (*Product, error) {
 	product := &Product{
 		l:      logger.Named("product"),
@@ -19,7 +19,7 @@ func NewTFE(logger hclog.Logger, cfg Config) (*Product, error) {
 		return nil, err
 	}
 
-	product.Runners, err = TFERunners(cfg, api)
+	product.Runners, err = tfeRunners(cfg, api)
 	if err != nil {
 		return nil, err
 	}
@@ -37,8 +37,8 @@ func NewTFE(logger hclog.Logger, cfg Config) (*Product, error) {
 	return product, nil
 }
 
-// TFERunners configures a set of default runners for TFE.
-func TFERunners(cfg Config, api *client.APIClient) ([]runner.Runner, error) {
+// tfeRunners configures a set of default runners for TFE.
+func tfeRunners(cfg Config, api *client.APIClient) ([]runner.Runner, error) {
 	return []runner.Runner{
 		runner.NewCommander("replicatedctl support-bundle", "string"),
 

--- a/product/tfe.go
+++ b/product/tfe.go
@@ -3,26 +3,38 @@ package product
 import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcdiag/client"
+	"github.com/hashicorp/hcdiag/hcl"
 	"github.com/hashicorp/hcdiag/runner"
 )
 
 // NewTFE takes a product config and creates a Product containing all of TFE's ops.
 func NewTFE(logger hclog.Logger, cfg Config) (*Product, error) {
+	product := &Product{
+		l:      logger.Named("product"),
+		Name:   TFE,
+		Config: cfg,
+	}
 	api, err := client.NewTFEAPI()
 	if err != nil {
 		return nil, err
 	}
 
-	runners, err := TFERunners(cfg, api)
+	product.Runners, err = TFERunners(cfg, api)
 	if err != nil {
 		return nil, err
 	}
-	return &Product{
-		l:       logger.Named("product"),
-		Name:    TFE,
-		Runners: runners,
-		Config:  cfg,
-	}, nil
+
+	if cfg.HCL != nil {
+		hclRunners, err := hcl.BuildRunners(cfg.HCL, cfg.TmpDir, api)
+		if err != nil {
+			return nil, err
+		}
+		product.Runners = append(product.Runners, hclRunners...)
+		product.Excludes = cfg.HCL.Excludes
+		product.Selects = cfg.HCL.Selects
+	}
+
+	return product, nil
 }
 
 // TFERunners configures a set of default runners for TFE.

--- a/product/tfe.go
+++ b/product/tfe.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/hcdiag/runner"
 )
 
-// NewTFE takes a product config and creates a Product containing all of TFE's ops.
+// NewTFE takes a logger and product config, and it creates a Product with all of TFE's default ops.
 func NewTFE(logger hclog.Logger, cfg Config) (*Product, error) {
 	product := &Product{
 		l:      logger.Named("product"),

--- a/product/vault.go
+++ b/product/vault.go
@@ -19,7 +19,7 @@ const (
 	VaultAgentCheck  = "vault status"
 )
 
-// NewVault takes a product config and creates a Product containing all of Vault's ops.
+// NewVault takes a product config and creates a Product containing all of Vault's runners.
 func NewVault(logger hclog.Logger, cfg Config) (*Product, error) {
 	product := &Product{
 		l:      logger.Named("product"),
@@ -48,7 +48,7 @@ func NewVault(logger hclog.Logger, cfg Config) (*Product, error) {
 	return product, nil
 }
 
-// vaultRunners provides a list of default runners to inspect vault
+// vaultRunners provides a list of default runners to inspect vault.
 func vaultRunners(cfg Config, api *client.APIClient) ([]runner.Runner, error) {
 	runners := []runner.Runner{
 		runner.NewCommander("vault version", "string"),


### PR DESCRIPTION
Here we leverage the new hcl pkg to compose the HCL config and product config _outside_ of the agent. Products now have an HCL field on them that contains the data they need to generate runners using that configuration. The Agent ensures the config gets composed correctly, then defers to the product to create _all_ of its runners. Also, I added a Name type to the product pkg and swapped out its usage in agent. HCL doesn't get to use this type because that would create a circular dep... but it's just a string so it's easy to convert when passing the HCL to product boundary.

Much cleaner! I'm pushing this up as it is for now, but I want to make some changes to host later so that way it doesn't need an extra arg for its hcl.