### PR TITLE
Add "skip" status and colorize output appropriately

### DIFF
--- a/op/op.go
+++ b/op/op.go
@@ -10,12 +10,17 @@ type Status string
 const (
 	// Success means all systems green
 	Success Status = "success"
+
 	// Fail means that we detected a known error and can conclusively say that the runner did not complete.
 	Fail Status = "fail"
+
 	// Unknown means that we detected an error and the result is indeterminate (e.g. some side effect like disk or
 	//   network may or may not have completed) or we don't recognize the error. If we don't recognize the error that's
 	//   a signal to improve the error handling to account for it.
 	Unknown Status = "unknown"
+
+	// Skip means that this Op was intentionally not run
+	Skip Status = "skip"
 )
 
 // Op seeks information via its Runner then stores the results.

--- a/product/product.go
+++ b/product/product.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcdiag/runner"
+	"github.com/hashicorp/hcdiag/util"
 )
 
 type Name string
@@ -57,11 +58,26 @@ func (p *Product) Run() map[string]op.Op {
 		results[r.ID()] = o
 		// Note runner errors to users and keep going.
 		if o.Error != nil {
-			p.l.Warn("result",
-				"runner", r.ID(),
-				"result", fmt.Sprintf("%s", o.Result),
-				"error", o.Error,
-			)
+			switch o.Status {
+			case op.Fail:
+				p.l.Error("result",
+					"runner", r.ID(),
+					"result", util.Colorize("red", fmt.Sprintf("%s", o.Result)),
+					"error", o.Error,
+				)
+			case op.Unknown:
+				p.l.Warn("result",
+					"runner", r.ID(),
+					"result", util.Colorize("yellow", fmt.Sprintf("%s", o.Result)),
+					"error", o.Error,
+				)
+			case op.Skip:
+				p.l.Info("result",
+					"runner", r.ID(),
+					"result", util.Colorize("white", fmt.Sprintf("%s", o.Result)),
+					"error", o.Error,
+				)
+			}
 		}
 	}
 	return results

--- a/runner/host/etc_hosts.go
+++ b/runner/host/etc_hosts.go
@@ -28,9 +28,8 @@ func (r EtcHosts) ID() string {
 func (r EtcHosts) Run() op.Op {
 	// Not compatible with windows
 	if r.OS == "windows" {
-		// TODO(mkcp): This should be op.Status("skip") once we implement it
 		err := fmt.Errorf(" EtcHosts.Run() not available on os, os=%s", r.OS)
-		return op.New(r.ID(), nil, op.Success, err, runner.Params(r))
+		return op.New(r.ID(), nil, op.Skip, err, runner.Params(r))
 	}
 	s := runner.NewSheller("cat /etc/hosts").Run()
 	if s.Error != nil {

--- a/runner/host/fstab.go
+++ b/runner/host/fstab.go
@@ -29,8 +29,7 @@ func (r FSTab) ID() string {
 func (r FSTab) Run() op.Op {
 	// Only Linux is supported currently; Windows is unsupported, and Darwin doesn't use /etc/fstab by default.
 	if r.OS != "linux" {
-		// TODO(nwchandler): This should be op.Status("skip") once we implement it
-		return op.New(r.ID(), nil, op.Success, fmt.Errorf("FSTab.Run() not available on os, os=%s", r.OS), runner.Params(r))
+		return op.New(r.ID(), nil, op.Skip, fmt.Errorf("FSTab.Run() not available on os, os=%s", r.OS), runner.Params(r))
 	}
 	o := r.Sheller.Run()
 	if o.Error != nil {

--- a/runner/host/iptables.go
+++ b/runner/host/iptables.go
@@ -32,8 +32,7 @@ func (r IPTables) ID() string {
 
 func (r IPTables) Run() op.Op {
 	if runtime.GOOS != "linux" {
-		// TODO(mkcp): use skip status once available
-		return op.New(r.ID(), nil, op.Success, fmt.Errorf("os not linux, skipping, os=%s", runtime.GOOS), runner.Params(r))
+		return op.New(r.ID(), nil, op.Skip, fmt.Errorf("os not linux, skipping, os=%s", runtime.GOOS), runner.Params(r))
 	}
 	result := make(map[string]string)
 	for _, c := range r.Commands {

--- a/runner/host/proc_file.go
+++ b/runner/host/proc_file.go
@@ -33,8 +33,7 @@ func (p ProcFile) ID() string {
 
 func (p ProcFile) Run() op.Op {
 	if p.OS != "linux" {
-		// TODO(mkcp): Replace status with op.Skip when we implement it
-		return op.New(p.ID(), nil, op.Success, fmt.Errorf("os not linux, skipping, os=%s", p.OS), runner.Params(p))
+		return op.New(p.ID(), nil, op.Skip, fmt.Errorf("os not linux, skipping, os=%s", p.OS), runner.Params(p))
 	}
 	m := make(map[string]interface{})
 	for _, c := range p.Commands {

--- a/runner/log/journald.go
+++ b/runner/log/journald.go
@@ -45,7 +45,7 @@ func (j Journald) Run() op.Op {
 	o := runner.NewCommander(cmd, "string").Run()
 	if o.Error != nil {
 		hclog.L().Debug("skipping journald", "service", j.Service, "output", o.Result, "error", o.Error)
-		return op.New(j.ID(), o.Result, op.Fail, JournaldServiceNotEnabled{
+		return op.New(j.ID(), o.Result, op.Skip, JournaldServiceNotEnabled{
 			service: j.Service,
 			command: cmd,
 			result:  fmt.Sprintf("%s", o.Result),

--- a/util/util.go
+++ b/util/util.go
@@ -251,3 +251,25 @@ func EnsureDirectory(dir string) error {
 
 	return nil
 }
+
+// Colorize colorizes text output for the terminal using a color you specify.
+func Colorize(color string, text string) string {
+	reset := "\033[0m"
+
+	var colorSelect = map[string]string{
+		"red":    "\033[31m",
+		"green":  "\033[32m",
+		"yellow": "\033[33m",
+		"blue":   "\033[34m",
+		"purple": "\033[35m",
+		"cyan":   "\033[36m",
+		"white":  "\033[37m",
+	}
+
+	chosenColor, ok := colorSelect[color]
+	if !ok {
+		chosenColor = ""
+	}
+
+	return fmt.Sprintf("%s%s%s", chosenColor, text, reset)
+}


### PR DESCRIPTION
This change adds a new Op.Status named "skip," which gives us something beyond "success," "fail," or "unknown."

It also adds a colorization function in utils, which makes adding shell color codes to strings easy.