### PR TITLE
Add redact blocks to HCL

### DIFF
--- a/changelog/169.txt
+++ b/changelog/169.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+hcl: Add redact blocks to product, host, and runners in HCL.
+```

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -42,22 +42,31 @@ type Product struct {
 	Selects      []string      `hcl:"selects,optional"`
 }
 
+type Redact struct {
+	Name    string `hcl:"name,label"`
+	Replace string `hcl:"replace,optional"`
+}
+
 type Command struct {
-	Run    string `hcl:"run"`
-	Format string `hcl:"format"`
+	Run        string   `hcl:"run"`
+	Format     string   `hcl:"format"`
+	Redactions []Redact `hcl:"redact,block"`
 }
 
 type Shell struct {
-	Run string `hcl:"run"`
+	Run        string   `hcl:"run"`
+	Redactions []Redact `hcl:"redact,block"`
 }
 
 type GET struct {
-	Path string `hcl:"path"`
+	Path       string   `hcl:"path"`
+	Redactions []Redact `hcl:"redact,block"`
 }
 
 type Copy struct {
-	Path  string `hcl:"path"`
-	Since string `hcl:"since,optional"`
+	Path       string   `hcl:"path"`
+	Since      string   `hcl:"since,optional"`
+	Redactions []Redact `hcl:"redact,block"`
 }
 
 type DockerLog struct {


### PR DESCRIPTION
This PR adds redact blocks to HCL runners and host+product blocks. If a host or product gets a redact then it will pass it through to every runner defined in HCL. This does not support HCL redact passthrough to a product/host's default runners, that will be implemented in a future PR.