### PR TITLE
Add Redact type, pkg, and validation

### DIFF
--- a/changelog/169.txt
+++ b/changelog/169.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+hcl: Add redact blocks to product, host, and runners in HCL.
+```

--- a/changelog/171.txt
+++ b/changelog/171.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+redact: Add redact package and Redact type that allows a regex to be applied to a reader and written to a writer.
+```

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -239,6 +239,11 @@ func mapCopies(cfgs []Copy, redactions []Redact, dest string) ([]runner.Runner, 
 			return nil, err
 		}
 
+		err := ValidateRedactions(c.Redactions)
+		if err != nil {
+			return nil, err
+		}
+
 		// Set `from` with a timestamp
 		if c.Since != "" {
 			sinceDur, err := time.ParseDuration(c.Since)

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -53,6 +53,11 @@ type Redact struct {
 	Replace string `hcl:"replace,optional"`
 }
 
+type Redact struct {
+	Name    string `hcl:"name,label"`
+	Replace string `hcl:"replace,optional"`
+}
+
 type Command struct {
 	Run        string   `hcl:"run"`
 	Format     string   `hcl:"format"`

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -42,22 +42,31 @@ type Product struct {
 	Selects      []string      `hcl:"selects,optional"`
 }
 
+type Redact struct {
+	Name    string `hcl:"name,label"`
+	Replace string `hcl:"replace,optional"`
+}
+
 type Command struct {
-	Run    string `hcl:"run"`
-	Format string `hcl:"format"`
+	Run        string   `hcl:"run"`
+	Format     string   `hcl:"format"`
+	Redactions []Redact `hcl:"redact,block"`
 }
 
 type Shell struct {
-	Run string `hcl:"run"`
+	Run        string   `hcl:"run"`
+	Redactions []Redact `hcl:"redact,block"`
 }
 
 type GET struct {
-	Path string `hcl:"path"`
+	Path       string   `hcl:"path"`
+	Redactions []Redact `hcl:"redact,block"`
 }
 
 type Copy struct {
-	Path  string `hcl:"path"`
-	Since string `hcl:"since,optional"`
+	Path       string   `hcl:"path"`
+	Since      string   `hcl:"since,optional"`
+	Redactions []Redact `hcl:"redact,block"`
 }
 
 type DockerLog struct {

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -53,11 +53,6 @@ type Redact struct {
 	Replace string `hcl:"replace,optional"`
 }
 
-type Redact struct {
-	Name    string `hcl:"name,label"`
-	Replace string `hcl:"replace,optional"`
-}
-
 type Command struct {
 	Run        string   `hcl:"run"`
 	Format     string   `hcl:"format"`

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -234,7 +234,6 @@ func mapCopies(cfgs []Copy, redactions []Redact, dest string) ([]runner.Runner, 
 			return nil, err
 		}
 
-		err := ValidateRedactions(c.Redactions)
 		if err != nil {
 			return nil, err
 		}

--- a/redact/redact.go
+++ b/redact/redact.go
@@ -1,0 +1,47 @@
+package redact
+
+import (
+	"crypto/md5"
+	"fmt"
+	"io"
+	"regexp"
+)
+
+const DefaultReplace = "<REDACTED>"
+
+type Redact struct {
+	ID      string `json:"ID"`
+	matcher *regexp.Regexp
+	Replace string `json:"replace"`
+}
+
+// New takes the matcher as a string and returned a compiled and ready-to-use redactor. ID and Replace are
+// optional and can be left empty.
+func New(matcher, id, replace string) (*Redact, error) {
+	r, err := regexp.Compile(matcher)
+	if err != nil {
+		return nil, err
+	}
+	if id == "" {
+		genID := md5.Sum([]byte(matcher))
+		id = fmt.Sprint(genID)
+	}
+	if replace == "" {
+		replace = DefaultReplace
+	}
+	return &Redact{id, r, replace}, nil
+}
+
+func (x Redact) Apply(w io.Writer, r io.Reader) error {
+	bts, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	newBts := x.matcher.ReplaceAll(bts, []byte(x.Replace))
+	_, err = w.Write(newBts)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/redact/redact.go
+++ b/redact/redact.go
@@ -37,6 +37,13 @@ func (x Redact) Apply(w io.Writer, r io.Reader) error {
 	if err != nil {
 		return err
 	}
+	if len(bts) == 0 {
+		_, err = w.Write(bts)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 	newBts := x.matcher.ReplaceAll(bts, []byte(x.Replace))
 	_, err = w.Write(newBts)
 	if err != nil {

--- a/redact/redact_test.go
+++ b/redact/redact_test.go
@@ -1,0 +1,81 @@
+package redact
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewRegex(t *testing.T) {
+	tcs := []struct {
+		name    string
+		matcher string
+		id      string
+		replace string
+	}{
+		{
+			name:    "empty optional fields",
+			matcher: "/some regex/",
+		},
+		{
+			name:    "set optional fields",
+			matcher: "/some other regex/",
+			id:      "COOLCOOL",
+			replace: "WOWOW",
+		},
+	}
+
+	for _, tc := range tcs {
+		reg, err := New(tc.matcher, tc.id, tc.replace)
+		assert.NoError(t, err, tc.name)
+		assert.NotEqual(t, "", reg.ID, tc.name)
+		assert.NotEqual(t, "", reg.Replace, tc.name)
+	}
+}
+
+func TestRegex_Redact(t *testing.T) {
+	tcs := []struct {
+		name    string
+		matcher string
+		input   string
+		expect  string
+	}{
+		// {
+		// 	name:    "empty input",
+		// 	matcher: "/myRegex/",
+		// 	input:   "",
+		// 	expect:  "",
+		// },
+		{
+			name:    "redacts once",
+			matcher: "myRegex",
+			input:   "myRegex",
+			expect:  "<REDACTED>",
+		},
+		{
+			name:    "redacts many",
+			matcher: "test",
+			input:   "test test_test+test-test\n!test ??test",
+			expect:  "<REDACTED> <REDACTED>_<REDACTED>+<REDACTED>-<REDACTED>\n!<REDACTED> ??<REDACTED>",
+		},
+	}
+	for _, tc := range tcs {
+		redactor, err := New(tc.matcher, "", "")
+		assert.NoError(t, err, tc.name)
+
+		r := strings.NewReader(tc.input)
+		buf := new(bytes.Buffer)
+		err = redactor.Apply(buf, r)
+		assert.NoError(t, err, tc.name)
+
+		result := buf.String()
+
+		assert.Equal(t, tc.expect, result, tc.name)
+	}
+}
+
+func TestLiteral_Redact(t *testing.T) {
+
+}

--- a/redact/redact_test.go
+++ b/redact/redact_test.go
@@ -35,19 +35,19 @@ func TestNewRegex(t *testing.T) {
 	}
 }
 
-func TestRegex_Redact(t *testing.T) {
+func TestRedact_Apply(t *testing.T) {
 	tcs := []struct {
 		name    string
 		matcher string
 		input   string
 		expect  string
 	}{
-		// {
-		// 	name:    "empty input",
-		// 	matcher: "/myRegex/",
-		// 	input:   "",
-		// 	expect:  "",
-		// },
+		{
+			name:    "empty input",
+			matcher: "/myRegex/",
+			input:   "",
+			expect:  "",
+		},
 		{
 			name:    "redacts once",
 			matcher: "myRegex",


### PR DESCRIPTION
This PR adds the redact package, containing a single Redact type. In the process of building out the HCL, it became clear that, from a user's POV, a regex without anything special regexy behavior looks exactly like a string literal match. Therefore, I don't think we'll need multiple redact types and an interface. That means we'll have to go back and edit out the labels and validation in #169, but i figure we can handle that after both are merged, because this branch depends on the HCL additions.

This branch also sets up `Redact.Apply()` to take a writer and a reader, similar to `io.Copy()`. This prevents redact chaining, and requires that we copy the string we're redacting once per Apply. For multiple gigs of log files, that could result in a lot of extra copies per line. What we might be able to do as a workaround, is implement a `redact.ApplyAll([]Redact, r, w) err` which can accept many different redactors, each with their own replaces, and apply the highest precedence (default < global < product < runner) redacts first on a string. 