### PR TITLE
Add redact.ApplyMany

### DIFF
--- a/changelog/173.txt
+++ b/changelog/173.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+redact: Add ApplyMany function.
+```

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -238,6 +238,11 @@ func mapCopies(cfgs []Copy, redactions []Redact, dest string) ([]runner.Runner, 
 			return nil, err
 		}
 
+		err = ValidateRedactions(c.Redactions)
+		if err != nil {
+			return nil, err
+		}
+
 		// Set `from` with a timestamp
 		if c.Since != "" {
 			sinceDur, err := time.ParseDuration(c.Since)

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -234,15 +234,6 @@ func mapCopies(cfgs []Copy, redactions []Redact, dest string) ([]runner.Runner, 
 			return nil, err
 		}
 
-		if err != nil {
-			return nil, err
-		}
-
-		err = ValidateRedactions(c.Redactions)
-		if err != nil {
-			return nil, err
-		}
-
 		// Set `from` with a timestamp
 		if c.Since != "" {
 			sinceDur, err := time.ParseDuration(c.Since)


### PR DESCRIPTION
`redact.ApplyMany([]*Redact, io.Writer, io.Reader)` is similar to apply, but instead of being a method on a single redaction we take a collection of redactions and apply them in order to the result of Reader. This allows us to perform many redactions at once while only bringing any bytes to redact into memory once, and allows us to redact multi-gig log files if needed.