### PR TITLE
Redact HTTP and Shell runners

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -285,7 +285,7 @@ func (a *Agent) CopyIncludes() (err error) {
 		}
 
 		a.l.Debug("getting Copier", "path", f)
-		o := runner.NewCopier(f, dest, a.Config.Since, a.Config.Until).Run()
+		o := runner.NewCopier(f, dest, a.Config.Since, a.Config.Until, nil).Run()
 		if o.Error != nil {
 			return o.Error
 		}

--- a/changelog/174.txt
+++ b/changelog/174.txt
@@ -1,0 +1,6 @@
+```release-note:improvement
+redact: Add redact.String() and redact.Bytes().
+```
+```release-note:improvement
+runner: Redact results in shell and http runners.
+```

--- a/product/consul.go
+++ b/product/consul.go
@@ -51,16 +51,16 @@ func NewConsul(logger hclog.Logger, cfg Config) (*Product, error) {
 // consulRunners generates a slice of runners to inspect consul.
 func consulRunners(cfg Config, api *client.APIClient) ([]runner.Runner, error) {
 	runners := []runner.Runner{
-		runner.NewCommander("consul version", "string"),
-		runner.NewCommander(fmt.Sprintf("consul debug -output=%s/ConsulDebug -duration=%s -interval=%s", cfg.TmpDir, cfg.DebugDuration, cfg.DebugInterval), "string"),
+		runner.NewCommander("consul version", "string", nil),
+		runner.NewCommander(fmt.Sprintf("consul debug -output=%s/ConsulDebug -duration=%s -interval=%s", cfg.TmpDir, cfg.DebugDuration, cfg.DebugInterval), "string", nil),
 
-		runner.NewHTTPer(api, "/v1/agent/self"),
-		runner.NewHTTPer(api, "/v1/agent/metrics"),
-		runner.NewHTTPer(api, "/v1/catalog/datacenters"),
-		runner.NewHTTPer(api, "/v1/catalog/services"),
-		runner.NewHTTPer(api, "/v1/namespace"),
-		runner.NewHTTPer(api, "/v1/status/leader"),
-		runner.NewHTTPer(api, "/v1/status/peers"),
+		runner.NewHTTPer(api, "/v1/agent/self", nil),
+		runner.NewHTTPer(api, "/v1/agent/metrics", nil),
+		runner.NewHTTPer(api, "/v1/catalog/datacenters", nil),
+		runner.NewHTTPer(api, "/v1/catalog/services", nil),
+		runner.NewHTTPer(api, "/v1/namespace", nil),
+		runner.NewHTTPer(api, "/v1/status/leader", nil),
+		runner.NewHTTPer(api, "/v1/status/peers", nil),
 
 		logs.NewDocker("consul", cfg.TmpDir, cfg.Since),
 		logs.NewJournald("consul", cfg.TmpDir, cfg.Since, cfg.Until),
@@ -69,7 +69,7 @@ func consulRunners(cfg Config, api *client.APIClient) ([]runner.Runner, error) {
 	// try to detect log location to copy
 	if logPath, err := client.GetConsulLogPath(api); err == nil {
 		dest := filepath.Join(cfg.TmpDir, "logs/consul")
-		logCopier := runner.NewCopier(logPath, dest, cfg.Since, cfg.Until)
+		logCopier := runner.NewCopier(logPath, dest, cfg.Since, cfg.Until, nil)
 		runners = append([]runner.Runner{logCopier}, runners...)
 	}
 

--- a/product/nomad.go
+++ b/product/nomad.go
@@ -64,14 +64,14 @@ func NewNomad(logger hclog.Logger, cfg Config) (*Product, error) {
 // nomadRunners generates a slice of runners to inspect nomad
 func nomadRunners(cfg Config, api *client.APIClient) ([]runner.Runner, error) {
 	runners := []runner.Runner{
-		runner.NewCommander("nomad version", "string"),
-		runner.NewCommander("nomad node status -self -json", "json"),
-		runner.NewCommander("nomad agent-info -json", "json"),
-		runner.NewCommander(fmt.Sprintf("nomad operator debug -log-level=TRACE -node-id=all -max-nodes=10 -output=%s -duration=%s -interval=%s", cfg.TmpDir, cfg.DebugDuration, cfg.DebugInterval), "string"),
+		runner.NewCommander("nomad version", "string", nil),
+		runner.NewCommander("nomad node status -self -json", "json", nil),
+		runner.NewCommander("nomad agent-info -json", "json", nil),
+		runner.NewCommander(fmt.Sprintf("nomad operator debug -log-level=TRACE -node-id=all -max-nodes=10 -output=%s -duration=%s -interval=%s", cfg.TmpDir, cfg.DebugDuration, cfg.DebugInterval), "string", nil),
 
-		runner.NewHTTPer(api, "/v1/agent/members?stale=true"),
-		runner.NewHTTPer(api, "/v1/operator/autopilot/configuration?stale=true"),
-		runner.NewHTTPer(api, "/v1/operator/raft/configuration?stale=true"),
+		runner.NewHTTPer(api, "/v1/agent/members?stale=true", nil),
+		runner.NewHTTPer(api, "/v1/operator/autopilot/configuration?stale=true", nil),
+		runner.NewHTTPer(api, "/v1/operator/raft/configuration?stale=true", nil),
 
 		logs.NewDocker("nomad", cfg.TmpDir, cfg.Since),
 		logs.NewJournald("nomad", cfg.TmpDir, cfg.Since, cfg.Until),
@@ -80,7 +80,7 @@ func nomadRunners(cfg Config, api *client.APIClient) ([]runner.Runner, error) {
 	// try to detect log location to copy
 	if logPath, err := client.GetNomadLogPath(api); err == nil {
 		dest := filepath.Join(cfg.TmpDir, "logs", "nomad")
-		logCopier := runner.NewCopier(logPath, dest, cfg.Since, cfg.Until)
+		logCopier := runner.NewCopier(logPath, dest, cfg.Since, cfg.Until, nil)
 		runners = append([]runner.Runner{logCopier}, runners...)
 	}
 

--- a/product/product.go
+++ b/product/product.go
@@ -107,11 +107,11 @@ func (p *Product) Filter() error {
 
 // CommanderHealthCheck employs the CLI to check if the client and then the agent are available.
 func CommanderHealthCheck(client, agent string) error {
-	checkClient := runner.NewCommander(client, "string").Run()
+	checkClient := runner.NewCommander(client, "string", nil).Run()
 	if checkClient.Error != nil {
 		return fmt.Errorf("client not available, healthcheck=%v, result=%v, error=%v", client, checkClient.Result, checkClient.Error)
 	}
-	checkAgent := runner.NewCommander(agent, "string").Run()
+	checkAgent := runner.NewCommander(agent, "string", nil).Run()
 	if checkAgent.Error != nil {
 		return fmt.Errorf("agent not available, healthcheck=%v, result=%v, error=%v", agent, checkAgent.Result, checkAgent.Error)
 	}

--- a/product/tfe.go
+++ b/product/tfe.go
@@ -40,16 +40,16 @@ func NewTFE(logger hclog.Logger, cfg Config) (*Product, error) {
 // tfeRunners configures a set of default runners for TFE.
 func tfeRunners(cfg Config, api *client.APIClient) ([]runner.Runner, error) {
 	return []runner.Runner{
-		runner.NewCommander("replicatedctl support-bundle", "string"),
+		runner.NewCommander("replicatedctl support-bundle", "string", nil),
 
-		runner.NewCopier("/var/lib/replicated/support-bundles/replicated-support*.tar.gz", cfg.TmpDir, cfg.Since, cfg.Until),
+		runner.NewCopier("/var/lib/replicated/support-bundles/replicated-support*.tar.gz", cfg.TmpDir, cfg.Since, cfg.Until, nil),
 
-		runner.NewHTTPer(api, "/api/v2/admin/customization-settings"),
-		runner.NewHTTPer(api, "/api/v2/admin/general-settings"),
-		runner.NewHTTPer(api, "/api/v2/admin/organizations"),
-		runner.NewHTTPer(api, "/api/v2/admin/terraform-versions"),
-		runner.NewHTTPer(api, "/api/v2/admin/twilio-settings"),
+		runner.NewHTTPer(api, "/api/v2/admin/customization-settings", nil),
+		runner.NewHTTPer(api, "/api/v2/admin/general-settings", nil),
+		runner.NewHTTPer(api, "/api/v2/admin/organizations", nil),
+		runner.NewHTTPer(api, "/api/v2/admin/terraform-versions", nil),
+		runner.NewHTTPer(api, "/api/v2/admin/twilio-settings", nil),
 		// page size 1 because we only actually care about total workspace count in the `meta` field
-		runner.NewHTTPer(api, "/api/v2/admin/workspaces?page[size]=1"),
+		runner.NewHTTPer(api, "/api/v2/admin/workspaces?page[size]=1", nil),
 	}, nil
 }

--- a/product/vault.go
+++ b/product/vault.go
@@ -51,12 +51,12 @@ func NewVault(logger hclog.Logger, cfg Config) (*Product, error) {
 // vaultRunners provides a list of default runners to inspect vault.
 func vaultRunners(cfg Config, api *client.APIClient) ([]runner.Runner, error) {
 	runners := []runner.Runner{
-		runner.NewCommander("vault version", "string"),
-		runner.NewCommander("vault status -format=json", "json"),
-		runner.NewCommander("vault read sys/health -format=json", "json"),
-		runner.NewCommander("vault read sys/seal-status -format=json", "json"),
-		runner.NewCommander("vault read sys/host-info -format=json", "json"),
-		runner.NewCommander(fmt.Sprintf("vault debug -output=%s/VaultDebug.tar.gz -duration=%s -interval=%s", cfg.TmpDir, cfg.DebugDuration, cfg.DebugInterval), "string"),
+		runner.NewCommander("vault version", "string", nil),
+		runner.NewCommander("vault status -format=json", "json", nil),
+		runner.NewCommander("vault read sys/health -format=json", "json", nil),
+		runner.NewCommander("vault read sys/seal-status -format=json", "json", nil),
+		runner.NewCommander("vault read sys/host-info -format=json", "json", nil),
+		runner.NewCommander(fmt.Sprintf("vault debug -output=%s/VaultDebug.tar.gz -duration=%s -interval=%s", cfg.TmpDir, cfg.DebugDuration, cfg.DebugInterval), "string", nil),
 
 		logs.NewDocker("vault", cfg.TmpDir, cfg.Since),
 		logs.NewJournald("vault", cfg.TmpDir, cfg.Since, cfg.Until),
@@ -65,7 +65,7 @@ func vaultRunners(cfg Config, api *client.APIClient) ([]runner.Runner, error) {
 	// try to detect log location to copy
 	if logPath, err := client.GetVaultAuditLogPath(api); err == nil {
 		dest := filepath.Join(cfg.TmpDir, "logs/vault")
-		logCopier := runner.NewCopier(logPath, dest, cfg.Since, cfg.Until)
+		logCopier := runner.NewCopier(logPath, dest, cfg.Since, cfg.Until, nil)
 		runners = append([]runner.Runner{logCopier}, runners...)
 	}
 

--- a/redact/redact.go
+++ b/redact/redact.go
@@ -98,6 +98,18 @@ func String(result string, redactions []*Redact) (string, error) {
 	return buf.String(), nil
 }
 
+// Bytes takes a byte slice and a slice of redactions, and wraps it with a reader and writer to apply the
+// redactions, returning a string back.
+func Bytes(b []byte, redactions []*Redact) ([]byte, error) {
+	r := bytes.NewReader(b)
+	buf := new(bytes.Buffer)
+	err := ApplyMany(redactions, buf, r)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
 // File takes src, dest paths and a slice of redactions. It applies redactions line by line, reading from the source and
 // writing to the destination
 // redactions, returning a string back. Returns nil on success, otherwise an error.

--- a/redact/redact.go
+++ b/redact/redact.go
@@ -1,10 +1,14 @@
 package redact
 
 import (
+	"bufio"
+	"bytes"
 	"crypto/md5"
 	"fmt"
 	"io"
+	"os"
 	"regexp"
+	"strings"
 )
 
 const DefaultReplace = "<REDACTED>"
@@ -78,6 +82,47 @@ func ApplyMany(redactions []*Redact, w io.Writer, r io.Reader) error {
 	_, err = w.Write(bts)
 	if err != nil {
 		return err
+	}
+	return nil
+}
+
+// String takes a string result and a slice of redactions, and wraps it with a reader and writer to apply the
+// redactions, returning a string back.
+func String(result string, redactions []*Redact) (string, error) {
+	r := strings.NewReader(result)
+	buf := new(bytes.Buffer)
+	err := ApplyMany(redactions, buf, r)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// File takes src, dest paths and a slice of redactions. It applies redactions line by line, reading from the source and
+// writing to the destination
+// redactions, returning a string back. Returns nil on success, otherwise an error.
+func File(src, dest string, redactions []*Redact) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+	destFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer destFile.Close()
+	scanner := bufio.NewScanner(srcFile)
+	// Scan, redact, and write each line of the src file
+	for scanner.Scan() {
+		res, err := String(scanner.Text(), redactions)
+		if err != nil {
+			return err
+		}
+		_, err = destFile.Write([]byte(res))
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/runner/commander.go
+++ b/runner/commander.go
@@ -1,10 +1,13 @@
 package runner
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os/exec"
 	"strings"
+
+	"github.com/hashicorp/hcdiag/redact"
 
 	"github.com/hashicorp/hcdiag/op"
 )
@@ -13,15 +16,17 @@ var _ Runner = Commander{}
 
 // Commander runs shell commands.
 type Commander struct {
-	Command string `json:"command"`
-	Format  string `json:"format"`
+	Command    string           `json:"command"`
+	Format     string           `json:"format"`
+	Redactions []*redact.Redact `json:"redactions"`
 }
 
 // NewCommander provides a runner for bin commands
-func NewCommander(command string, format string) *Commander {
+func NewCommander(command string, format string, redactions []*redact.Redact) *Commander {
 	return &Commander{
-		Command: command,
-		Format:  format,
+		Command:    command,
+		Format:     format,
+		Redactions: redactions,
 	}
 }
 

--- a/runner/commander.go
+++ b/runner/commander.go
@@ -1,7 +1,6 @@
 package runner
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"os/exec"

--- a/runner/commander_test.go
+++ b/runner/commander_test.go
@@ -18,7 +18,7 @@ func TestNewCommander(t *testing.T) {
 		Command: testCmd,
 		Format:  testFmt,
 	}
-	actual := NewCommander(testCmd, testFmt)
+	actual := NewCommander(testCmd, testFmt, nil)
 	assert.Equal(t, expect, actual)
 }
 
@@ -49,7 +49,7 @@ func TestCommander_Run(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.desc, func(t *testing.T) {
-			c := NewCommander(tc.command, tc.format)
+			c := NewCommander(tc.command, tc.format, nil)
 			o := c.Run()
 			assert.NoError(t, o.Error)
 			assert.Equal(t, op.Success, o.Status)
@@ -83,7 +83,7 @@ func TestCommander_RunError(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.desc, func(t *testing.T) {
-			c := NewCommander(tc.command, tc.format)
+			c := NewCommander(tc.command, tc.format, nil)
 			o := c.Run()
 			assert.Error(t, o.Error)
 			hclog.L().Trace("commander.Run() errored", "error", o.Error, "error type", reflect.TypeOf(o.Error))

--- a/runner/copier.go
+++ b/runner/copier.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/hashicorp/hcdiag/redact"
+
 	"github.com/hashicorp/hcdiag/op"
 
 	"github.com/hashicorp/hcdiag/util"
@@ -15,22 +17,24 @@ var _ Runner = Copier{}
 
 // Copier copies files to temp dir based on a filter.
 type Copier struct {
-	SourceDir string    `json:"source_directory"`
-	Filter    string    `json:"filter"`
-	DestDir   string    `json:"destination_directory"`
-	Since     time.Time `json:"since"`
-	Until     time.Time `json:"until"`
+	SourceDir  string           `json:"source_directory"`
+	Filter     string           `json:"filter"`
+	DestDir    string           `json:"destination_directory"`
+	Since      time.Time        `json:"since"`
+	Until      time.Time        `json:"until"`
+	Redactions []*redact.Redact `json:"redactions"`
 }
 
 // NewCopier provides a Runner for copying files to temp dir based on a filter.
-func NewCopier(path, destDir string, since, until time.Time) *Copier {
+func NewCopier(path, destDir string, since, until time.Time, redactions []*redact.Redact) *Copier {
 	sourceDir, filter := util.SplitFilepath(path)
 	return &Copier{
-		SourceDir: sourceDir,
-		Filter:    filter,
-		DestDir:   destDir,
-		Since:     since,
-		Until:     until,
+		SourceDir:  sourceDir,
+		Filter:     filter,
+		DestDir:    destDir,
+		Since:      since,
+		Until:      until,
+		Redactions: redactions,
 	}
 }
 

--- a/runner/copier_test.go
+++ b/runner/copier_test.go
@@ -19,6 +19,6 @@ func TestNewCopier(t *testing.T) {
 		Since:     since,
 		Until:     until,
 	}
-	copier := NewCopier(src, dest, since, until)
+	copier := NewCopier(src, dest, since, until, nil)
 	assert.Equal(t, expect, copier)
 }

--- a/runner/host/etc_hosts.go
+++ b/runner/host/etc_hosts.go
@@ -31,7 +31,7 @@ func (r EtcHosts) Run() op.Op {
 		err := fmt.Errorf(" EtcHosts.Run() not available on os, os=%s", r.OS)
 		return op.New(r.ID(), nil, op.Skip, err, runner.Params(r))
 	}
-	s := runner.NewSheller("cat /etc/hosts").Run()
+	s := runner.NewSheller("cat /etc/hosts", nil).Run()
 	if s.Error != nil {
 		return op.New(r.ID(), s.Result, op.Fail, s.Error, runner.Params(r))
 	}

--- a/runner/host/fstab.go
+++ b/runner/host/fstab.go
@@ -18,7 +18,7 @@ type FSTab struct {
 func NewFSTab(os string) *FSTab {
 	return &FSTab{
 		OS:      os,
-		Sheller: runner.NewSheller("cat /etc/fstab"),
+		Sheller: runner.NewSheller("cat /etc/fstab", nil),
 	}
 }
 

--- a/runner/host/get.go
+++ b/runner/host/get.go
@@ -3,6 +3,8 @@ package host
 import (
 	"strings"
 
+	"github.com/hashicorp/hcdiag/redact"
+
 	"github.com/hashicorp/hcdiag/op"
 
 	"github.com/hashicorp/hcdiag/runner"
@@ -11,11 +13,15 @@ import (
 var _ runner.Runner = Get{}
 
 type Get struct {
-	Path string `json:"path"`
+	Path       string           `json:"path"`
+	Redactions []*redact.Redact `json:"redactions"`
 }
 
-func NewGetter(path string) *Get {
-	return &Get{path}
+func NewGetter(path string, redactions []*redact.Redact) *Get {
+	return &Get{
+		Path:       path,
+		Redactions: redactions,
+	}
 }
 
 func (g Get) ID() string {
@@ -26,7 +32,7 @@ func (g Get) Run() op.Op {
 	cmd := strings.Join([]string{"curl -s", g.Path}, " ")
 	// NOTE(mkcp): We will get JSON back from a lot of requests, so this can be improved
 	format := "string"
-	o := runner.NewCommander(cmd, format).Run()
+	o := runner.NewCommander(cmd, format, nil).Run()
 	return op.New(g.ID(), o.Result, o.Status, o.Error, runner.Params(g))
 
 }

--- a/runner/host/iptables.go
+++ b/runner/host/iptables.go
@@ -36,7 +36,7 @@ func (r IPTables) Run() op.Op {
 	}
 	result := make(map[string]string)
 	for _, c := range r.Commands {
-		o := runner.NewCommander(c, "string").Run()
+		o := runner.NewCommander(c, "string", nil).Run()
 		result[c] = o.Result.(string)
 		if o.Error != nil {
 			return op.New(r.ID(), result, op.Fail, o.Error, runner.Params(r))

--- a/runner/host/os.go
+++ b/runner/host/os.go
@@ -32,6 +32,6 @@ func (o OS) ID() string {
 func (o OS) Run() op.Op {
 	// NOTE(mkcp): This runner can be made consistent between multiple operating systems if we parse the output of
 	//   systeminfo to match uname's scope of concerns.
-	c := runner.NewCommander(o.Command, "string").Run()
+	c := runner.NewCommander(o.Command, "string", nil).Run()
 	return op.New(o.ID(), c.Result, c.Status, c.Error, runner.Params(o))
 }

--- a/runner/host/proc_file.go
+++ b/runner/host/proc_file.go
@@ -37,7 +37,7 @@ func (p ProcFile) Run() op.Op {
 	}
 	m := make(map[string]interface{})
 	for _, c := range p.Commands {
-		sheller := runner.NewSheller(c).Run()
+		sheller := runner.NewSheller(c, nil).Run()
 		m[c] = sheller.Result
 		if sheller.Error != nil {
 			return op.New(p.ID(), m, op.Fail, sheller.Error, runner.Params(p))

--- a/runner/httper.go
+++ b/runner/httper.go
@@ -1,6 +1,10 @@
 package runner
 
 import (
+	"bytes"
+	"fmt"
+	"strings"
+
 	"github.com/hashicorp/hcdiag/client"
 	"github.com/hashicorp/hcdiag/op"
 	"github.com/hashicorp/hcdiag/redact"
@@ -27,8 +31,22 @@ func (h HTTPer) ID() string {
 // Run executes a GET request to the Path using the Client
 func (h HTTPer) Run() op.Op {
 	result, err := h.Client.Get(h.Path)
+	redResult, redErr := h.redact(fmt.Sprint(result))
 	if err != nil {
-		return op.New(h.ID(), result, op.Unknown, err, Params(h))
+		if redErr != nil {
+			return op.New(h.ID(), nil, op.Fail, redErr, Params(h))
+		}
+		return op.New(h.ID(), redResult, op.Unknown, err, Params(h))
 	}
-	return op.New(h.ID(), result, op.Success, nil, Params(h))
+	return op.New(h.ID(), redResult, op.Success, nil, Params(h))
+}
+
+func (h HTTPer) redact(result string) (string, error) {
+	r := strings.NewReader(result)
+	buf := new(bytes.Buffer)
+	err := redact.ApplyMany(h.Redactions, buf, r)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
 }

--- a/runner/httper.go
+++ b/runner/httper.go
@@ -1,9 +1,7 @@
 package runner
 
 import (
-	"bytes"
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/hcdiag/client"
 	"github.com/hashicorp/hcdiag/op"
@@ -31,7 +29,7 @@ func (h HTTPer) ID() string {
 // Run executes a GET request to the Path using the Client
 func (h HTTPer) Run() op.Op {
 	result, err := h.Client.Get(h.Path)
-	redResult, redErr := h.redact(fmt.Sprint(result))
+	redResult, redErr := redact.String(fmt.Sprint(result), h.Redactions)
 	if err != nil {
 		if redErr != nil {
 			return op.New(h.ID(), nil, op.Fail, redErr, Params(h))
@@ -39,14 +37,4 @@ func (h HTTPer) Run() op.Op {
 		return op.New(h.ID(), redResult, op.Unknown, err, Params(h))
 	}
 	return op.New(h.ID(), redResult, op.Success, nil, Params(h))
-}
-
-func (h HTTPer) redact(result string) (string, error) {
-	r := strings.NewReader(result)
-	buf := new(bytes.Buffer)
-	err := redact.ApplyMany(h.Redactions, buf, r)
-	if err != nil {
-		return "", err
-	}
-	return buf.String(), nil
 }

--- a/runner/httper.go
+++ b/runner/httper.go
@@ -3,15 +3,17 @@ package runner
 import (
 	"github.com/hashicorp/hcdiag/client"
 	"github.com/hashicorp/hcdiag/op"
+	"github.com/hashicorp/hcdiag/redact"
 )
 
 // HTTPer hits APIs.
 type HTTPer struct {
-	Path   string            `json:"path"`
-	Client *client.APIClient `json:"client"`
+	Path       string            `json:"path"`
+	Client     *client.APIClient `json:"client"`
+	Redactions []*redact.Redact  `json:"redactions"`
 }
 
-func NewHTTPer(client *client.APIClient, path string) *HTTPer {
+func NewHTTPer(client *client.APIClient, path string, redactions []*redact.Redact) *HTTPer {
 	return &HTTPer{
 		Client: client,
 		Path:   path,

--- a/runner/httper.go
+++ b/runner/httper.go
@@ -17,8 +17,9 @@ type HTTPer struct {
 
 func NewHTTPer(client *client.APIClient, path string, redactions []*redact.Redact) *HTTPer {
 	return &HTTPer{
-		Client: client,
-		Path:   path,
+		Client:     client,
+		Path:       path,
+		Redactions: redactions,
 	}
 }
 

--- a/runner/log/docker.go
+++ b/runner/log/docker.go
@@ -37,7 +37,7 @@ func (d Docker) ID() string {
 // Run executes the runner
 func (d Docker) Run() op.Op {
 	// Check that docker exists
-	o := runner.NewSheller("docker version").Run()
+	o := runner.NewSheller("docker version", nil).Run()
 	if o.Error != nil {
 		return op.New(d.ID(), o.Result, op.Fail, DockerNotFoundError{
 			container: d.Container,
@@ -48,7 +48,7 @@ func (d Docker) Run() op.Op {
 
 	// Retrieve logs
 	cmd := DockerLogCmd(d.Container, d.DestDir, d.Since)
-	o = runner.NewSheller(cmd).Run()
+	o = runner.NewSheller(cmd, nil).Run()
 	// NOTE(mkcp): If the container does not exist, docker will exit non-zero and it'll surface as a ShellExecError.
 	//  The result actionably states that the container wasn't found. In the future we may want to scrub the result
 	//  and only return an actionable error message

--- a/runner/sheller.go
+++ b/runner/sheller.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os/exec"
 
+	"github.com/hashicorp/hcdiag/redact"
+
 	"github.com/hashicorp/hcdiag/op"
 
 	"github.com/hashicorp/hcdiag/util"
@@ -11,14 +13,16 @@ import (
 
 // Sheller runs shell commands in a real unix shell.
 type Sheller struct {
-	Command string `json:"command"`
-	Shell   string `json:"shell"`
+	Command    string           `json:"command"`
+	Shell      string           `json:"shell"`
+	Redactions []*redact.Redact `json:"redactions"`
 }
 
 // NewSheller provides a runner for arbitrary shell code.
-func NewSheller(command string) *Sheller {
+func NewSheller(command string, redactions []*redact.Redact) *Sheller {
 	return &Sheller{
-		Command: command,
+		Command:    command,
+		Redactions: redactions,
 	}
 }
 

--- a/runner/sheller.go
+++ b/runner/sheller.go
@@ -43,19 +43,19 @@ func (s Sheller) Run() op.Op {
 	args := []string{"-c", s.Command}
 	bts, cmdErr := exec.Command(s.Shell, args...).CombinedOutput()
 	// Store and redact the result before cmd error handling, so we can return it in error and success cases.
-	redResult, redErr := redact.String(string(bts), s.Redactions)
+	redBts, redErr := redact.Bytes(bts, s.Redactions)
 	// Fail run if unable to redact
 	if redErr != nil {
-		return op.New(s.ID(), nil, op.Fail, err, Params(s))
+		return op.New(s.ID(), nil, op.Fail, redErr, Params(s))
 	}
 	if cmdErr != nil {
-		return op.New(s.ID(), redResult, op.Unknown,
+		return op.New(s.ID(), string(redBts), op.Unknown,
 			ShellExecError{
 				command: s.Command,
-				err:     err,
+				err:     cmdErr,
 			}, Params(s))
 	}
-	return op.New(s.ID(), redResult, op.Success, nil, Params(s))
+	return op.New(s.ID(), string(redBts), op.Success, nil, Params(s))
 }
 
 type ShellExecError struct {

--- a/runner/sheller_test.go
+++ b/runner/sheller_test.go
@@ -19,7 +19,7 @@ func TestSheller(t *testing.T) {
 	os.Setenv("SHELL", "/bin/sh")
 
 	// features pipe "|" and file redirection ">"
-	c := NewSheller("echo hiii | grep hi > cooltestfile")
+	c := NewSheller("echo hiii | grep hi > cooltestfile", nil)
 	defer os.Remove("cooltestfile")
 	o := c.Run()
 	assert.Equal(t, "", o.Result)


### PR DESCRIPTION
This PR adds type-specific functions: `redact.String(), redact.Bytes(), and redact.Files` that abstract away the readers and writers needed for `redact`'s `Redact.Apply` and `ApplyMany` functions. These provide a boundary for runners to pass and receive data back, instead of needing to be concerned with reader & writer behavior. The goal is to provide a toolkit of redactors that can meet the varied performance needs of different kinds of data.

In the PR we apply these to the HTTP and Shell runners. I decided to cut scope and solve commander and copier elsewhere because they each have more complex concerns.