### PR TITLE
Redact command results

### DIFF
--- a/changelog/177.txt
+++ b/changelog/177.txt
@@ -1,0 +1,6 @@
+```release-note:improvement
+redact: Add redact.JSON()
+```
+```release-note:improvement
+runner: Redact JSON and string results in Command.Run()
+```

--- a/redact/redact.go
+++ b/redact/redact.go
@@ -124,7 +124,7 @@ func JSON(a any, redactions []*Redact) (any, error) {
 		}
 		return r, nil
 	case []any:
-		r, err := redactArray(coll, redactions)
+		r, err := redactSlice(coll, redactions)
 		if err != nil {
 			return nil, err
 		}
@@ -134,7 +134,7 @@ func JSON(a any, redactions []*Redact) (any, error) {
 	}
 }
 
-func redactArray(a []any, redactions []*Redact) ([]any, error) {
+func redactSlice(a []any, redactions []*Redact) ([]any, error) {
 	for i, v := range a {
 		switch val := v.(type) {
 		case map[string]any:
@@ -144,7 +144,7 @@ func redactArray(a []any, redactions []*Redact) ([]any, error) {
 			}
 			a[i] = res
 		case []any:
-			res, err := redactArray(val, redactions)
+			res, err := redactSlice(val, redactions)
 			if err != nil {
 				return nil, err
 			}
@@ -172,7 +172,7 @@ func redactMap(m map[string]any, redactions []*Redact) (map[string]any, error) {
 			}
 			m[k] = res
 		case []any:
-			res, err := redactArray(val, redactions)
+			res, err := redactSlice(val, redactions)
 			if err != nil {
 				return nil, err
 			}

--- a/redact/redact.go
+++ b/redact/redact.go
@@ -88,6 +88,8 @@ func ApplyMany(redactions []*Redact, w io.Writer, r io.Reader) error {
 
 // String takes a string result and a slice of redactions, and wraps it with a reader and writer to apply the
 // redactions, returning a string back.
+// TODO(mkcp): Speed improvement & out of memory error: JSON responses can be really big, so we're going to have to
+//  chunk extremely large strings down.
 func String(result string, redactions []*Redact) (string, error) {
 	r := strings.NewReader(result)
 	buf := new(bytes.Buffer)
@@ -100,6 +102,8 @@ func String(result string, redactions []*Redact) (string, error) {
 
 // Bytes takes a byte slice and a slice of redactions, and wraps it with a reader and writer to apply the
 // redactions, returning a string back.
+// TODO(mkcp): Speed improvement & out of memory error: JSON responses can be really big, so we're going to have to
+//  chunk extremely large byte arrays down.
 func Bytes(b []byte, redactions []*Redact) ([]byte, error) {
 	r := bytes.NewReader(b)
 	buf := new(bytes.Buffer)
@@ -108,6 +112,82 @@ func Bytes(b []byte, redactions []*Redact) ([]byte, error) {
 		return nil, err
 	}
 	return buf.Bytes(), nil
+}
+
+// JSON accepts a json map or array and traverses the collections and redacts any strings we find.
+func JSON(a any, redactions []*Redact) (any, error) {
+	switch coll := a.(type) {
+	case map[string]any:
+		r, err := redactMap(coll, redactions)
+		if err != nil {
+			return nil, err
+		}
+		return r, nil
+	case []any:
+		r, err := redactArray(coll, redactions)
+		if err != nil {
+			return nil, err
+		}
+		return r, nil
+	default:
+		return nil, fmt.Errorf("json collection to redact is neither a map nor an array, coll=%v", coll)
+	}
+}
+
+func redactArray(a []any, redactions []*Redact) ([]any, error) {
+	for i, v := range a {
+		switch val := v.(type) {
+		case map[string]any:
+			res, err := redactMap(val, redactions)
+			if err != nil {
+				return nil, err
+			}
+			a[i] = res
+		case []any:
+			res, err := redactArray(val, redactions)
+			if err != nil {
+				return nil, err
+			}
+			a[i] = res
+		case string:
+			res, err := String(val, redactions)
+			if err != nil {
+				return nil, err
+			}
+			a[i] = res
+		default:
+			continue
+		}
+	}
+	return a, nil
+}
+
+func redactMap(m map[string]any, redactions []*Redact) (map[string]any, error) {
+	for k, v := range m {
+		switch val := v.(type) {
+		case map[string]any:
+			res, err := redactMap(val, redactions)
+			if err != nil {
+				return nil, err
+			}
+			m[k] = res
+		case []any:
+			res, err := redactArray(val, redactions)
+			if err != nil {
+				return nil, err
+			}
+			m[k] = res
+		case string:
+			res, err := String(val, redactions)
+			if err != nil {
+				return nil, err
+			}
+			m[k] = res
+		default:
+			continue
+		}
+	}
+	return m, nil
 }
 
 // File takes src, dest paths and a slice of redactions. It applies redactions line by line, reading from the source and

--- a/runner/commander.go
+++ b/runner/commander.go
@@ -35,8 +35,6 @@ func (c Commander) ID() string {
 
 // Run executes the Command
 func (c Commander) Run() op.Op {
-	var result interface{}
-
 	bits := strings.Split(c.Command, " ")
 	cmd := bits[0]
 	args := bits[1:]
@@ -50,32 +48,48 @@ func (c Commander) Run() op.Op {
 		return op.New(c.ID(), string(bts), op.Unknown, err1, Params(c))
 	}
 
-	// Parse result
+	// Parse result format
 	// TODO(mkcp): This can be detected rather than branching on user input
 	switch {
 	case c.Format == "string":
-		result = strings.TrimSuffix(string(bts), "\n")
+		redBts, err := redact.Bytes(bts, c.Redactions)
+		if err != nil {
+			return op.New(c.ID(), nil, op.Fail, err, Params(c))
+		}
+		redResult := strings.TrimSuffix(string(redBts), "\n")
+		return op.New(c.ID(), redResult, op.Success, nil, Params(c))
 
 	case c.Format == "json":
-		if err := json.Unmarshal(bts, &result); err != nil {
-			// Return the command's response even if we can't parse it as json
-			return op.New(c.ID(), string(bts), op.Unknown,
+		var obj any
+		marshErr := json.Unmarshal(bts, &obj)
+		if marshErr != nil {
+			// Redact the string to return the failed-to-parse JSON
+			redBts, redErr := redact.Bytes(bts, c.Redactions)
+			if redErr != nil {
+				return op.New(c.ID(), nil, op.Fail, redErr, Params(c))
+			}
+			return op.New(c.ID(), string(redBts), op.Unknown,
 				UnmarshalError{
 					command: c.Command,
-					err:     err,
-				},
-				Params(c))
+					err:     marshErr,
+				}, Params(c))
 		}
-
+		redResult, redErr := redact.JSON(obj, c.Redactions)
+		if redErr != nil {
+			return op.New(c.ID(), nil, op.Fail, redErr, Params(c))
+		}
+		return op.New(c.ID(), redResult, op.Success, nil, Params(c))
 	default:
-		return op.New(c.ID(), result, op.Fail, FormatUnknownError{
-			command: c.Command,
-			format:  c.Format,
-		},
-			Params(c))
+		redBts, redErr := redact.Bytes(bts, c.Redactions)
+		if redErr != nil {
+			return op.New(c.ID(), nil, op.Fail, redErr, Params(c))
+		}
+		return op.New(c.ID(), string(redBts), op.Fail,
+			FormatUnknownError{
+				command: c.Command,
+				format:  c.Format,
+			}, Params(c))
 	}
-
-	return op.New(c.ID(), result, op.Success, nil, Params(c))
 }
 
 type CommandExecError struct {


### PR DESCRIPTION
This PR introduces `redact.JSON()` and applies it and other redact functions to the output of Commander. Because redacts can return errors and we want to redact the results of errored commands, handling these cases in commander.Run gets a bit spaghettied - redact errors interleave with command errors. Anyway, here's an example of redacting from string values in JSON:

Command:
`VAULT_ADDR="http://127.0.0.1:8200" VAULT_FORMAT=json hcdiag run ./... -vault -config cfg/command-redacts.hcl`

HCL:
```
product "vault" {
  command {
    run = "vault status"
    format = "json"
    redact "regex" {
      match = "cluster"
    }
  }
}
```

```
"vault status": {
      "result": {
        "active_time": "0001-01-01T00:00:00Z",
        "cluster_id": "c8264088-5374-fd70-8041-d9652b0ef4c9",
        "cluster_name": "vault-<REDACTED>-f6c3d71f",
        "ha_enabled": false,
        "initialized": true,
        "migration": false,
        "n": 1,
        "nonce": "",
        "progress": 0,
        "recovery_seal": false,
        "sealed": false,
        "storage_type": "inmem",
        "t": 1,
        "type": "shamir",
        "version": "1.9.1"
      },
      "error": "",
      "status": "success",
      "params": {
        "command": "vault status",
        "format": "json",
        "redactions": [
          {
            "ID": "[6 178 212 185 27 92 158 170 140 32 161 194 112 249 91 60]",
            "replace": "<REDACTED>"
          }
        ]
      }
    }
```