### PR TITLE
Add redactions to util/copyfiles and redact in Copier

### DIFF
--- a/changelog/180.txt
+++ b/changelog/180.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+util: copyfiles now accepts redactions and scans files line by line to apply many redactions at once.
+```

--- a/redact/redact.go
+++ b/redact/redact.go
@@ -1,12 +1,10 @@
 package redact
 
 import (
-	"bufio"
 	"bytes"
 	"crypto/md5"
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"strings"
 )
@@ -188,33 +186,4 @@ func redactMap(m map[string]any, redactions []*Redact) (map[string]any, error) {
 		}
 	}
 	return m, nil
-}
-
-// File takes src, dest paths and a slice of redactions. It applies redactions line by line, reading from the source and
-// writing to the destination
-// redactions, returning a string back. Returns nil on success, otherwise an error.
-func File(src, dest string, redactions []*Redact) error {
-	srcFile, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer srcFile.Close()
-	destFile, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer destFile.Close()
-	scanner := bufio.NewScanner(srcFile)
-	// Scan, redact, and write each line of the src file
-	for scanner.Scan() {
-		res, err := String(scanner.Text(), redactions)
-		if err != nil {
-			return err
-		}
-		_, err = destFile.Write([]byte(res))
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/runner/copier.go
+++ b/runner/copier.go
@@ -47,33 +47,33 @@ func (c Copier) Run() op.Op {
 	// Ensure destination directory exists
 	err := os.MkdirAll(c.DestDir, 0755)
 	if err != nil {
-		return op.New(c.ID(), nil, op.Fail, MakeDirError{
-			path: c.DestDir,
-			err:  err,
-		},
-			Params(c))
+		return op.New(c.ID(), nil, op.Fail,
+			MakeDirError{
+				path: c.DestDir,
+				err:  err,
+			}, Params(c))
 	}
 
 	// Find all the files
 	files, err := util.FilterWalk(c.SourceDir, c.Filter, c.Since, c.Until)
 	if err != nil {
-		return op.New(c.ID(), nil, op.Fail, FindFilesError{
-			path: c.SourceDir,
-			err:  err,
-		},
-			Params(c))
+		return op.New(c.ID(), nil, op.Fail,
+			FindFilesError{
+				path: c.SourceDir,
+				err:  err,
+			}, Params(c))
 	}
 
 	// Copy the files
 	for _, s := range files {
-		err = util.CopyDir(c.DestDir, s)
+		err = util.CopyDir(c.DestDir, s, c.Redactions)
 		if err != nil {
-			return op.New(c.ID(), nil, op.Fail, CopyFilesError{
-				dest:  c.DestDir,
-				files: files,
-				err:   err,
-			},
-				Params(c))
+			return op.New(c.ID(), nil, op.Fail,
+				CopyFilesError{
+					dest:  c.DestDir,
+					files: files,
+					err:   err,
+				}, Params(c))
 		}
 	}
 

--- a/tests/resources/example.log
+++ b/tests/resources/example.log
@@ -1,0 +1,142 @@
+2022-08-03T14:43:15.930-0700 [DEBUG] agent: Check status updated: check=_nomad-check-531739bb774721d47d2fdf2a5581f5e04a004dad status=passing
+2022-08-03T14:43:15.930-0700 [DEBUG] agent: Check status updated: check=_nomad-check-feb7984a79b74b402ae6164c434be57e665acf5a status=passing
+2022-08-03T14:43:24.138-0700 [DEBUG] agent: Check status updated: check=_nomad-check-cf2031031358830ba6bef4717afa7ec7e6b8b502 status=passing
+2022-08-03T14:43:24.138-0700 [DEBUG] agent: Check status updated: check=_nomad-check-36a6d5207f8f687c20b1d3e994b77bd797b27651 status=passing
+2022-08-03T14:43:25.924-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/self from=127.0.0.1:56506 latency=560.628µs
+2022-08-03T14:43:25.931-0700 [DEBUG] agent: Check status updated: check=_nomad-check-531739bb774721d47d2fdf2a5581f5e04a004dad status=passing
+2022-08-03T14:43:25.932-0700 [DEBUG] agent: Check status updated: check=_nomad-check-feb7984a79b74b402ae6164c434be57e665acf5a status=passing
+2022-08-03T14:43:27.319-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/self from=127.0.0.1:56533 latency=1.469439ms
+2022-08-03T14:43:27.321-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/services from=127.0.0.1:56533 latency=158.254µs
+2022-08-03T14:43:27.322-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/checks from=127.0.0.1:56533 latency=193.707µs
+2022-08-03T14:43:34.138-0700 [DEBUG] agent: Check status updated: check=_nomad-check-36a6d5207f8f687c20b1d3e994b77bd797b27651 status=passing
+2022-08-03T14:43:34.138-0700 [DEBUG] agent: Check status updated: check=_nomad-check-cf2031031358830ba6bef4717afa7ec7e6b8b502 status=passing
+2022-08-03T14:43:35.933-0700 [DEBUG] agent: Check status updated: check=_nomad-check-531739bb774721d47d2fdf2a5581f5e04a004dad status=passing
+2022-08-03T14:43:35.933-0700 [DEBUG] agent: Check status updated: check=_nomad-check-feb7984a79b74b402ae6164c434be57e665acf5a status=passing
+2022-08-03T14:43:40.928-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/self from=127.0.0.1:56506 latency=773.936µs
+2022-08-03T14:43:44.140-0700 [DEBUG] agent: Check status updated: check=_nomad-check-36a6d5207f8f687c20b1d3e994b77bd797b27651 status=passing
+2022-08-03T14:43:44.140-0700 [DEBUG] agent: Check status updated: check=_nomad-check-cf2031031358830ba6bef4717afa7ec7e6b8b502 status=passing
+2022-08-03T14:43:45.936-0700 [DEBUG] agent: Check status updated: check=_nomad-check-531739bb774721d47d2fdf2a5581f5e04a004dad status=passing
+2022-08-03T14:43:45.936-0700 [DEBUG] agent: Check status updated: check=_nomad-check-feb7984a79b74b402ae6164c434be57e665acf5a status=passing
+2022-08-03T14:43:54.141-0700 [DEBUG] agent: Check status updated: check=_nomad-check-cf2031031358830ba6bef4717afa7ec7e6b8b502 status=passing
+2022-08-03T14:43:54.141-0700 [DEBUG] agent: Check status updated: check=_nomad-check-36a6d5207f8f687c20b1d3e994b77bd797b27651 status=passing
+2022-08-03T14:43:55.932-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/self from=127.0.0.1:56506 latency=819.883µs
+2022-08-03T14:43:55.939-0700 [DEBUG] agent: Check status updated: check=_nomad-check-feb7984a79b74b402ae6164c434be57e665acf5a status=passing
+2022-08-03T14:43:55.939-0700 [DEBUG] agent: Check status updated: check=_nomad-check-531739bb774721d47d2fdf2a5581f5e04a004dad status=passing
+2022-08-03T14:43:57.325-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/services from=127.0.0.1:56533 latency=296.003µs
+2022-08-03T14:43:57.326-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/checks from=127.0.0.1:56533 latency=198.735µs
+2022-08-03T14:44:02.927-0700 [DEBUG] agent.router.manager: Rebalanced servers, new active server: number_of_servers=1 active_server="kitpatella-C02Z7870LVDL (Addr: tcp/127.0.0.1:8300) (DC: dc1)"
+2022-08-03T14:44:04.144-0700 [DEBUG] agent: Check status updated: check=_nomad-check-36a6d5207f8f687c20b1d3e994b77bd797b27651 status=passing
+2022-08-03T14:44:04.144-0700 [DEBUG] agent: Check status updated: check=_nomad-check-cf2031031358830ba6bef4717afa7ec7e6b8b502 status=passing
+2022-08-03T14:44:05.940-0700 [DEBUG] agent: Check status updated: check=_nomad-check-531739bb774721d47d2fdf2a5581f5e04a004dad status=passing
+2022-08-03T14:44:05.941-0700 [DEBUG] agent: Check status updated: check=_nomad-check-feb7984a79b74b402ae6164c434be57e665acf5a status=passing
+2022-08-03T14:44:10.932-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/self from=127.0.0.1:56506 latency=593.24µs
+2022-08-03T14:44:14.148-0700 [DEBUG] agent: Check status updated: check=_nomad-check-36a6d5207f8f687c20b1d3e994b77bd797b27651 status=passing
+2022-08-03T14:44:14.148-0700 [DEBUG] agent: Check status updated: check=_nomad-check-cf2031031358830ba6bef4717afa7ec7e6b8b502 status=passing
+2022-08-03T14:44:15.945-0700 [DEBUG] agent: Check status updated: check=_nomad-check-feb7984a79b74b402ae6164c434be57e665acf5a status=passing
+2022-08-03T14:44:15.945-0700 [DEBUG] agent: Check status updated: check=_nomad-check-531739bb774721d47d2fdf2a5581f5e04a004dad status=passing
+2022-08-03T14:44:16.240-0700 [DEBUG] agent.router.manager: Rebalanced servers, new active server: number_of_servers=1 active_server="kitpatella-C02Z7870LVDL.dc1 (Addr: tcp/127.0.0.1:8300) (DC: dc1)"
+2022-08-03T14:44:24.149-0700 [DEBUG] agent: Check status updated: check=_nomad-check-36a6d5207f8f687c20b1d3e994b77bd797b27651 status=passing
+2022-08-03T14:44:24.149-0700 [DEBUG] agent: Check status updated: check=_nomad-check-cf2031031358830ba6bef4717afa7ec7e6b8b502 status=passing
+2022-08-03T14:44:25.934-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/self from=127.0.0.1:56506 latency=887.167µs
+2022-08-03T14:44:25.948-0700 [DEBUG] agent: Check status updated: check=_nomad-check-531739bb774721d47d2fdf2a5581f5e04a004dad status=passing
+2022-08-03T14:44:25.949-0700 [DEBUG] agent: Check status updated: check=_nomad-check-feb7984a79b74b402ae6164c434be57e665acf5a status=passing
+2022-08-03T14:44:27.330-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/self from=127.0.0.1:56533 latency=580.377µs
+2022-08-03T14:44:27.331-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/services from=127.0.0.1:56533 latency=99.823µs
+2022-08-03T14:44:27.332-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/checks from=127.0.0.1:56533 latency=106.651µs
+2022-08-03T14:44:34.150-0700 [DEBUG] agent: Check status updated: check=_nomad-check-cf2031031358830ba6bef4717afa7ec7e6b8b502 status=passing
+2022-08-03T14:44:34.150-0700 [DEBUG] agent: Check status updated: check=_nomad-check-36a6d5207f8f687c20b1d3e994b77bd797b27651 status=passing
+2022-08-03T14:44:35.955-0700 [DEBUG] agent: Check status updated: check=_nomad-check-feb7984a79b74b402ae6164c434be57e665acf5a status=passing
+2022-08-03T14:44:35.955-0700 [DEBUG] agent: Check status updated: check=_nomad-check-531739bb774721d47d2fdf2a5581f5e04a004dad status=passing
+2022-08-03T14:44:40.940-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/self from=127.0.0.1:56506 latency=1.530645ms
+2022-08-03T14:44:44.151-0700 [DEBUG] agent: Check status updated: check=_nomad-check-cf2031031358830ba6bef4717afa7ec7e6b8b502 status=passing
+2022-08-03T14:44:44.151-0700 [DEBUG] agent: Check status updated: check=_nomad-check-36a6d5207f8f687c20b1d3e994b77bd797b27651 status=passing
+2022-08-03T14:44:45.958-0700 [DEBUG] agent: Check status updated: check=_nomad-check-531739bb774721d47d2fdf2a5581f5e04a004dad status=passing
+2022-08-03T14:44:45.959-0700 [DEBUG] agent: Check status updated: check=_nomad-check-feb7984a79b74b402ae6164c434be57e665acf5a status=passing
+2022-08-03T14:44:46.168-0700 [DEBUG] agent: Skipping remote check since it is managed automatically: check=serfHealth
+2022-08-03T14:44:46.168-0700 [DEBUG] agent: Node info in sync
+2022-08-03T14:44:46.168-0700 [DEBUG] agent: Service in sync: service=_nomad-server-k5zjlaqx5qv3sz7oksmrxafcd6wv45fp
+2022-08-03T14:44:46.168-0700 [DEBUG] agent: Service in sync: service=_nomad-client-s6pxrvnmilluqd6pbwhivrfgoxn6y2bp
+2022-08-03T14:44:46.168-0700 [DEBUG] agent: Service in sync: service=_nomad-server-el4cbcvnl5vhjq6cvok5weiasityir4r
+2022-08-03T14:44:46.168-0700 [DEBUG] agent: Service in sync: service=_nomad-server-5fpzvxurt4wharun5dh5alxqmbukh32r
+2022-08-03T14:44:46.168-0700 [DEBUG] agent: Check in sync: check=_nomad-check-36a6d5207f8f687c20b1d3e994b77bd797b27651
+2022-08-03T14:44:46.168-0700 [DEBUG] agent: Check in sync: check=_nomad-check-feb7984a79b74b402ae6164c434be57e665acf5a
+2022-08-03T14:44:46.168-0700 [DEBUG] agent: Check in sync: check=_nomad-check-531739bb774721d47d2fdf2a5581f5e04a004dad
+2022-08-03T14:44:46.168-0700 [DEBUG] agent: Check in sync: check=_nomad-check-cf2031031358830ba6bef4717afa7ec7e6b8b502
+2022-08-03T14:44:54.152-0700 [DEBUG] agent: Check status updated: check=_nomad-check-cf2031031358830ba6bef4717afa7ec7e6b8b502 status=passing
+2022-08-03T14:44:54.152-0700 [DEBUG] agent: Check status updated: check=_nomad-check-36a6d5207f8f687c20b1d3e994b77bd797b27651 status=passing
+2022-08-03T14:44:55.940-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/self from=127.0.0.1:56506 latency=751.185µs
+2022-08-03T14:44:55.962-0700 [DEBUG] agent: Check status updated: check=_nomad-check-531739bb774721d47d2fdf2a5581f5e04a004dad status=passing
+2022-08-03T14:44:55.962-0700 [DEBUG] agent: Check status updated: check=_nomad-check-feb7984a79b74b402ae6164c434be57e665acf5a status=passing
+2022-08-03T14:44:57.335-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/services from=127.0.0.1:56533 latency=200.406µs
+2022-08-03T14:44:57.336-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/checks from=127.0.0.1:56533 latency=147.541µs
+2022-08-03T14:45:04.154-0700 [DEBUG] agent: Check status updated: check=_nomad-check-cf2031031358830ba6bef4717afa7ec7e6b8b502 status=passing
+2022-08-03T14:45:04.154-0700 [DEBUG] agent: Check status updated: check=_nomad-check-36a6d5207f8f687c20b1d3e994b77bd797b27651 status=passing
+2022-08-03T14:45:05.964-0700 [DEBUG] agent: Check status updated: check=_nomad-check-531739bb774721d47d2fdf2a5581f5e04a004dad status=passing
+2022-08-03T14:45:05.964-0700 [DEBUG] agent: Check status updated: check=_nomad-check-feb7984a79b74b402ae6164c434be57e665acf5a status=passing
+2022-08-03T14:45:10.945-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/self from=127.0.0.1:56506 latency=610.899µs
+2022-08-03T14:45:14.155-0700 [DEBUG] agent: Check status updated: check=_nomad-check-36a6d5207f8f687c20b1d3e994b77bd797b27651 status=passing
+2022-08-03T14:45:14.155-0700 [DEBUG] agent: Check status updated: check=_nomad-check-cf2031031358830ba6bef4717afa7ec7e6b8b502 status=passing
+2022-08-03T14:45:15.967-0700 [DEBUG] agent: Check status updated: check=_nomad-check-531739bb774721d47d2fdf2a5581f5e04a004dad status=passing
+2022-08-03T14:45:15.967-0700 [DEBUG] agent: Check status updated: check=_nomad-check-feb7984a79b74b402ae6164c434be57e665acf5a status=passing
+2022-08-03T14:45:24.156-0700 [DEBUG] agent: Check status updated: check=_nomad-check-36a6d5207f8f687c20b1d3e994b77bd797b27651 status=passing
+2022-08-03T14:45:24.156-0700 [DEBUG] agent: Check status updated: check=_nomad-check-cf2031031358830ba6bef4717afa7ec7e6b8b502 status=passing
+2022-08-03T14:45:25.948-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/self from=127.0.0.1:56506 latency=533.209µs
+2022-08-03T14:45:25.972-0700 [DEBUG] agent: Check status updated: check=_nomad-check-531739bb774721d47d2fdf2a5581f5e04a004dad status=passing
+2022-08-03T14:45:25.972-0700 [DEBUG] agent: Check status updated: check=_nomad-check-feb7984a79b74b402ae6164c434be57e665acf5a status=passing
+2022-08-03T14:45:27.341-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/self from=127.0.0.1:56533 latency=1.41775ms
+2022-08-03T14:45:27.344-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/services from=127.0.0.1:56533 latency=186.947µs
+2022-08-03T14:45:27.345-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/checks from=127.0.0.1:56533 latency=117.426µs
+2022-08-03T14:45:34.158-0700 [DEBUG] agent: Check status updated: check=_nomad-check-36a6d5207f8f687c20b1d3e994b77bd797b27651 status=passing
+2022-08-03T14:45:34.158-0700 [DEBUG] agent: Check status updated: check=_nomad-check-cf2031031358830ba6bef4717afa7ec7e6b8b502 status=passing
+2022-08-03T14:45:35.973-0700 [DEBUG] agent: Check status updated: check=_nomad-check-531739bb774721d47d2fdf2a5581f5e04a004dad status=passing
+2022-08-03T14:45:35.974-0700 [DEBUG] agent: Check status updated: check=_nomad-check-feb7984a79b74b402ae6164c434be57e665acf5a status=passing
+2022-08-03T14:45:40.954-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/self from=127.0.0.1:56506 latency=1.08208ms
+2022-08-03T14:45:44.159-0700 [DEBUG] agent: Check status updated: check=_nomad-check-cf2031031358830ba6bef4717afa7ec7e6b8b502 status=passing
+2022-08-03T14:45:44.159-0700 [DEBUG] agent: Check status updated: check=_nomad-check-36a6d5207f8f687c20b1d3e994b77bd797b27651 status=passing
+2022-08-03T14:45:45.975-0700 [DEBUG] agent: Check status updated: check=_nomad-check-feb7984a79b74b402ae6164c434be57e665acf5a status=passing
+2022-08-03T14:45:45.975-0700 [DEBUG] agent: Check status updated: check=_nomad-check-531739bb774721d47d2fdf2a5581f5e04a004dad status=passing
+2022-08-03T14:45:54.159-0700 [DEBUG] agent: Check status updated: check=_nomad-check-36a6d5207f8f687c20b1d3e994b77bd797b27651 status=passing
+2022-08-03T14:45:54.159-0700 [DEBUG] agent: Check status updated: check=_nomad-check-cf2031031358830ba6bef4717afa7ec7e6b8b502 status=passing
+2022-08-03T14:45:55.957-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/self from=127.0.0.1:56506 latency=507.816µs
+2022-08-03T14:45:55.978-0700 [DEBUG] agent: Check status updated: check=_nomad-check-531739bb774721d47d2fdf2a5581f5e04a004dad status=passing
+2022-08-03T14:45:55.978-0700 [DEBUG] agent: Check status updated: check=_nomad-check-feb7984a79b74b402ae6164c434be57e665acf5a status=passing
+2022-08-03T14:45:57.349-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/services from=127.0.0.1:56533 latency=194.987µs
+2022-08-03T14:45:57.349-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/checks from=127.0.0.1:56533 latency=201.25µs
+2022-08-03T14:46:04.163-0700 [DEBUG] agent: Check status updated: check=_nomad-check-36a6d5207f8f687c20b1d3e994b77bd797b27651 status=passing
+2022-08-03T14:46:04.163-0700 [DEBUG] agent: Check status updated: check=_nomad-check-cf2031031358830ba6bef4717afa7ec7e6b8b502 status=passing
+2022-08-03T14:46:05.982-0700 [DEBUG] agent: Check status updated: check=_nomad-check-feb7984a79b74b402ae6164c434be57e665acf5a status=passing
+2022-08-03T14:46:05.982-0700 [DEBUG] agent: Check status updated: check=_nomad-check-531739bb774721d47d2fdf2a5581f5e04a004dad status=passing
+2022-08-03T14:46:08.570-0700 [DEBUG] agent: Skipping remote check since it is managed automatically: check=serfHealth
+2022-08-03T14:46:08.570-0700 [DEBUG] agent: Node info in sync
+2022-08-03T14:46:08.570-0700 [DEBUG] agent: Service in sync: service=_nomad-server-5fpzvxurt4wharun5dh5alxqmbukh32r
+2022-08-03T14:46:08.570-0700 [DEBUG] agent: Service in sync: service=_nomad-server-k5zjlaqx5qv3sz7oksmrxafcd6wv45fp
+2022-08-03T14:46:08.570-0700 [DEBUG] agent: Service in sync: service=_nomad-client-s6pxrvnmilluqd6pbwhivrfgoxn6y2bp
+2022-08-03T14:46:08.570-0700 [DEBUG] agent: Service in sync: service=_nomad-server-el4cbcvnl5vhjq6cvok5weiasityir4r
+2022-08-03T14:46:08.570-0700 [DEBUG] agent: Check in sync: check=_nomad-check-feb7984a79b74b402ae6164c434be57e665acf5a
+2022-08-03T14:46:08.570-0700 [DEBUG] agent: Check in sync: check=_nomad-check-531739bb774721d47d2fdf2a5581f5e04a004dad
+2022-08-03T14:46:08.570-0700 [DEBUG] agent: Check in sync: check=_nomad-check-cf2031031358830ba6bef4717afa7ec7e6b8b502
+2022-08-03T14:46:08.570-0700 [DEBUG] agent: Check in sync: check=_nomad-check-36a6d5207f8f687c20b1d3e994b77bd797b27651
+2022-08-03T14:46:10.960-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/self from=127.0.0.1:56506 latency=596.152µs
+2022-08-03T14:46:14.164-0700 [DEBUG] agent: Check status updated: check=_nomad-check-cf2031031358830ba6bef4717afa7ec7e6b8b502 status=passing
+2022-08-03T14:46:14.164-0700 [DEBUG] agent: Check status updated: check=_nomad-check-36a6d5207f8f687c20b1d3e994b77bd797b27651 status=passing
+2022-08-03T14:46:15.983-0700 [DEBUG] agent: Check status updated: check=_nomad-check-531739bb774721d47d2fdf2a5581f5e04a004dad status=passing
+2022-08-03T14:46:15.983-0700 [DEBUG] agent: Check status updated: check=_nomad-check-feb7984a79b74b402ae6164c434be57e665acf5a status=passing
+2022-08-03T14:46:17.250-0700 [DEBUG] agent.router.manager: Rebalanced servers, new active server: number_of_servers=1 active_server="kitpatella-C02Z7870LVDL.dc1 (Addr: tcp/127.0.0.1:8300) (DC: dc1)"
+2022-08-03T14:46:24.168-0700 [DEBUG] agent: Check status updated: check=_nomad-check-36a6d5207f8f687c20b1d3e994b77bd797b27651 status=passing
+2022-08-03T14:46:24.168-0700 [DEBUG] agent: Check status updated: check=_nomad-check-cf2031031358830ba6bef4717afa7ec7e6b8b502 status=passing
+2022-08-03T14:46:25.960-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/self from=127.0.0.1:56506 latency=572.442µs
+2022-08-03T14:46:25.985-0700 [DEBUG] agent: Check status updated: check=_nomad-check-531739bb774721d47d2fdf2a5581f5e04a004dad status=passing
+2022-08-03T14:46:25.985-0700 [DEBUG] agent: Check status updated: check=_nomad-check-feb7984a79b74b402ae6164c434be57e665acf5a status=passing
+2022-08-03T14:46:27.353-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/self from=127.0.0.1:56533 latency=1.017606ms
+2022-08-03T14:46:27.354-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/services from=127.0.0.1:56533 latency=116.124µs
+2022-08-03T14:46:27.355-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/checks from=127.0.0.1:56533 latency=96.485µs
+2022-08-03T14:46:32.577-0700 [DEBUG] agent.router.manager: Rebalanced servers, new active server: number_of_servers=1 active_server="kitpatella-C02Z7870LVDL (Addr: tcp/127.0.0.1:8300) (DC: dc1)"
+2022-08-03T14:46:34.172-0700 [DEBUG] agent: Check status updated: check=_nomad-check-cf2031031358830ba6bef4717afa7ec7e6b8b502 status=passing
+2022-08-03T14:46:34.172-0700 [DEBUG] agent: Check status updated: check=_nomad-check-36a6d5207f8f687c20b1d3e994b77bd797b27651 status=passing
+2022-08-03T14:46:35.988-0700 [DEBUG] agent: Check status updated: check=_nomad-check-feb7984a79b74b402ae6164c434be57e665acf5a status=passing
+2022-08-03T14:46:35.988-0700 [DEBUG] agent: Check status updated: check=_nomad-check-531739bb774721d47d2fdf2a5581f5e04a004dad status=passing
+2022-08-03T14:46:40.965-0700 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/self from=127.0.0.1:56506 latency=970.563µs
+2022-08-03T14:46:44.173-0700 [DEBUG] agent: Check status updated: check=_nomad-check-cf2031031358830ba6bef4717afa7ec7e6b8b502 status=passing
+2022-08-03T14:46:44.173-0700 [DEBUG] agent: Check status updated: check=_nomad-check-36a6d5207f8f687c20b1d3e994b77bd797b27651 status=passing
+2022-08-03T14:46:45.990-0700 [DEBUG] agent: Check status updated: check=_nomad-check-531739bb774721d47d2fdf2a5581f5e04a004dad status=passing
+2022-08-03T14:46:45.990-0700 [DEBUG] agent: Check status updated: check=_nomad-check-feb7984a79b74b402ae6164c434be57e665acf5a status=passing

--- a/util/copyfiles.go
+++ b/util/copyfiles.go
@@ -1,11 +1,14 @@
 package util
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/hashicorp/hcdiag/redact"
 
 	"github.com/hashicorp/go-hclog"
 )
@@ -13,7 +16,7 @@ import (
 const directoryPerms = 0755
 
 // CopyDir copies a directory and all of its contents into a target directory.
-func CopyDir(to, src string) error {
+func CopyDir(to, src string, redactions []*redact.Redact) error {
 	// get the absolute path, so we can remove it
 	// to avoid copying the entire directory structure into the dest
 	absPath, err := filepath.Abs(src)
@@ -36,12 +39,12 @@ func CopyDir(to, src string) error {
 			hclog.L().Info("copying", "path", path, "to", target)
 			return os.MkdirAll(target, directoryPerms)
 		}
-		return CopyFile(target, path)
+		return CopyFile(target, path, redactions)
 	})
 }
 
 // CopyFile copies a file to a target file path.
-func CopyFile(to, src string) error {
+func CopyFile(to, src string, redactions []*redact.Redact) error {
 	hclog.L().Info("copying", "path", src, "to", to)
 
 	// Ensure directories
@@ -73,7 +76,25 @@ func CopyFile(to, src string) error {
 		}
 	}()
 
-	// Write source contents to destination
-	_, err = io.Copy(w, r)
-	return err
+	if 0 < len(redactions) {
+		scanner := bufio.NewScanner(r)
+		// Scan, redact, and write each line of the src file
+		for scanner.Scan() {
+			bts := scanner.Bytes()
+			bts = append(bts, '\n')
+			rBts, re := redact.Bytes(bts, redactions)
+			if re != nil {
+				return re
+			}
+			_, we := w.Write(rBts)
+			if we != nil {
+				return we
+			}
+		}
+		return nil
+	}
+
+	// No redactions, copy as normal
+	_, ce := io.Copy(w, r)
+	return ce
 }

--- a/util/copyfiles_test.go
+++ b/util/copyfiles_test.go
@@ -62,7 +62,7 @@ func TestCopyDir(t *testing.T) {
 	defer os.RemoveAll(absTestDestination)
 
 	// this also implicitly tests CopyFile()
-	err = CopyDir(absTestDestination, absTestDir)
+	err = CopyDir(absTestDestination, absTestDir, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -80,7 +80,7 @@ func TestCopyDir(t *testing.T) {
 }
 
 func TestCopyDirNotExists(t *testing.T) {
-	err := CopyDir(testDestination, "not-a-real-dir")
+	err := CopyDir(testDestination, "not-a-real-dir", nil)
 	strErr := fmt.Sprintf("%s", err)
 	expect := "no such file or directory"
 	if !strings.Contains(strErr, expect) {
@@ -89,7 +89,7 @@ func TestCopyDirNotExists(t *testing.T) {
 }
 
 func TestCopyFileNotExists(t *testing.T) {
-	err := CopyFile(testDestination, "not-a-real-file")
+	err := CopyFile(testDestination, "not-a-real-file", nil)
 	strErr := fmt.Sprintf("%s", err)
 	expect := "no such file or directory"
 	if !strings.Contains(strErr, expect) {


### PR DESCRIPTION
Here we add line-by-line application of many redactions at once in `runner.Copier` and other places that use util/copyfiles.go. I ended up deleting the `redact.Files()` function because it didn't quite match the data boundary that the other redact functions have. Instead I utilized `redact.Bytes()` in our currently existing filecopy utils when redactions are passed in.

One benefit of this approach is that agent-level default and hcl redactions can be applied to `-include`ed files.

Here's an example of the redactor in action:

cli command: `go run ./... -autodetect=false -config cfg/copy-redacts.hcl `

HCL:
```
host {
  copy {
    path = "./tests/resources/example.log"
    redact "regex" {
      match = "kitpatella"
    }
    redact "regex" {
      match = "127.0.0.1"
    }
  }
}
```

Result in bundle:
![Screen Shot 2022-08-03 at 3 31 39 PM](https://user-images.githubusercontent.com/938395/182723616-1de92e91-a833-4323-bd62-55755b1ecefe.png)
