### PR TITLE
Accept and pass redaction config through in higher order runners

### DIFF
--- a/changelog/189.txt
+++ b/changelog/189.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+runner: add redactions pass-through for higher-order host runners.
+```

--- a/product/consul.go
+++ b/product/consul.go
@@ -81,8 +81,8 @@ func consulRunners(cfg Config, api *client.APIClient) ([]runner.Runner, error) {
 		runner.NewHTTPer(api, "/v1/status/leader", cfg.Redactions),
 		runner.NewHTTPer(api, "/v1/status/peers", cfg.Redactions),
 
-		logs.NewDocker("consul", cfg.TmpDir, cfg.Since),
-		logs.NewJournald("consul", cfg.TmpDir, cfg.Since, cfg.Until),
+		logs.NewDocker("consul", cfg.TmpDir, cfg.Since, cfg.Redactions),
+		logs.NewJournald("consul", cfg.TmpDir, cfg.Since, cfg.Until, cfg.Redactions),
 	}
 
 	// try to detect log location to copy

--- a/product/host.go
+++ b/product/host.go
@@ -61,16 +61,16 @@ func NewHost(logger hclog.Logger, cfg Config, hcl2 *hcl.Host) (*Product, error) 
 // hostRunners generates a slice of runners to inspect the host.
 func hostRunners(os string, redactions []*redact.Redact) []runner.Runner {
 	return []runner.Runner{
-		host.NewOS(os),
+		host.NewOS(os, redactions),
 		host.NewDisk(),
 		host.Info{},
 		host.Memory{},
 		host.Process{},
 		host.Network{},
-		host.NewEtcHosts(),
-		host.NewIPTables(),
-		host.NewProcFile(os),
-		host.NewFSTab(os),
+		host.NewEtcHosts(redactions),
+		host.NewIPTables(redactions),
+		host.NewProcFile(os, redactions),
+		host.NewFSTab(os, redactions),
 	}
 }
 

--- a/product/nomad.go
+++ b/product/nomad.go
@@ -92,8 +92,8 @@ func nomadRunners(cfg Config, api *client.APIClient) ([]runner.Runner, error) {
 		runner.NewHTTPer(api, "/v1/operator/autopilot/configuration?stale=true", cfg.Redactions),
 		runner.NewHTTPer(api, "/v1/operator/raft/configuration?stale=true", cfg.Redactions),
 
-		logs.NewDocker("nomad", cfg.TmpDir, cfg.Since),
-		logs.NewJournald("nomad", cfg.TmpDir, cfg.Since, cfg.Until),
+		logs.NewDocker("nomad", cfg.TmpDir, cfg.Since, cfg.Redactions),
+		logs.NewJournald("nomad", cfg.TmpDir, cfg.Since, cfg.Until, cfg.Redactions),
 	}
 
 	// try to detect log location to copy

--- a/product/vault.go
+++ b/product/vault.go
@@ -77,8 +77,8 @@ func vaultRunners(cfg Config, api *client.APIClient) ([]runner.Runner, error) {
 		runner.NewCommander("vault read sys/host-info -format=json", "json", cfg.Redactions),
 		runner.NewCommander(fmt.Sprintf("vault debug -output=%s/VaultDebug.tar.gz -duration=%s -interval=%s", cfg.TmpDir, cfg.DebugDuration, cfg.DebugInterval), "string", cfg.Redactions),
 
-		logs.NewDocker("vault", cfg.TmpDir, cfg.Since),
-		logs.NewJournald("vault", cfg.TmpDir, cfg.Since, cfg.Until),
+		logs.NewDocker("vault", cfg.TmpDir, cfg.Since, cfg.Redactions),
+		logs.NewJournald("vault", cfg.TmpDir, cfg.Since, cfg.Until, cfg.Redactions),
 	}
 
 	// try to detect log location to copy

--- a/runner/host/etc_hosts.go
+++ b/runner/host/etc_hosts.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 
 	"github.com/hashicorp/hcdiag/op"
+	"github.com/hashicorp/hcdiag/redact"
 
 	"github.com/hashicorp/hcdiag/runner"
 )
@@ -12,12 +13,14 @@ import (
 var _ runner.Runner = EtcHosts{}
 
 type EtcHosts struct {
-	OS string `json:"os"`
+	OS         string           `json:"os"`
+	Redactions []*redact.Redact `json:"redactions"`
 }
 
-func NewEtcHosts() *EtcHosts {
+func NewEtcHosts(redactions []*redact.Redact) *EtcHosts {
 	return &EtcHosts{
-		OS: runtime.GOOS,
+		OS:         runtime.GOOS,
+		Redactions: redactions,
 	}
 }
 
@@ -31,7 +34,7 @@ func (r EtcHosts) Run() op.Op {
 		err := fmt.Errorf(" EtcHosts.Run() not available on os, os=%s", r.OS)
 		return op.New(r.ID(), nil, op.Skip, err, runner.Params(r))
 	}
-	s := runner.NewSheller("cat /etc/hosts", nil).Run()
+	s := runner.NewSheller("cat /etc/hosts", r.Redactions).Run()
 	if s.Error != nil {
 		return op.New(r.ID(), s.Result, op.Fail, s.Error, runner.Params(r))
 	}

--- a/runner/host/fstab.go
+++ b/runner/host/fstab.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcdiag/op"
+	"github.com/hashicorp/hcdiag/redact"
 
 	"github.com/hashicorp/hcdiag/runner"
 )
@@ -15,10 +16,10 @@ type FSTab struct {
 	Sheller runner.Runner `json:"sheller"`
 }
 
-func NewFSTab(os string) *FSTab {
+func NewFSTab(os string, redactions []*redact.Redact) *FSTab {
 	return &FSTab{
 		OS:      os,
-		Sheller: runner.NewSheller("cat /etc/fstab", nil),
+		Sheller: runner.NewSheller("cat /etc/fstab", redactions),
 	}
 }
 

--- a/runner/host/fstab_test.go
+++ b/runner/host/fstab_test.go
@@ -124,7 +124,7 @@ func TestNewFSTab(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			fstab := NewFSTab(tc.os)
+			fstab := NewFSTab(tc.os, nil)
 			assert.Equal(t, tc.expected.OS, fstab.OS)
 		})
 	}

--- a/runner/host/get.go
+++ b/runner/host/get.go
@@ -32,7 +32,7 @@ func (g Get) Run() op.Op {
 	cmd := strings.Join([]string{"curl -s", g.Path}, " ")
 	// NOTE(mkcp): We will get JSON back from a lot of requests, so this can be improved
 	format := "string"
-	o := runner.NewCommander(cmd, format, nil).Run()
+	o := runner.NewCommander(cmd, format, g.Redactions).Run()
 	return op.New(g.ID(), o.Result, o.Status, o.Error, runner.Params(g))
 
 }

--- a/runner/host/os.go
+++ b/runner/host/os.go
@@ -2,25 +2,28 @@ package host
 
 import (
 	"github.com/hashicorp/hcdiag/op"
+	"github.com/hashicorp/hcdiag/redact"
 	"github.com/hashicorp/hcdiag/runner"
 )
 
 var _ runner.Runner = OS{}
 
 type OS struct {
-	OS      string `json:"os"`
-	Command string `json:"command"`
+	OS         string           `json:"os"`
+	Command    string           `json:"command"`
+	Redactions []*redact.Redact `json:"redactions"`
 }
 
-func NewOS(os string) *OS {
+func NewOS(os string, redactions []*redact.Redact) *OS {
 	osCmd := "uname -v"
 	if os == "windows" {
 		osCmd = "systeminfo"
 	}
 
 	return &OS{
-		OS:      os,
-		Command: osCmd,
+		OS:         os,
+		Command:    osCmd,
+		Redactions: redactions,
 	}
 }
 
@@ -32,6 +35,6 @@ func (o OS) ID() string {
 func (o OS) Run() op.Op {
 	// NOTE(mkcp): This runner can be made consistent between multiple operating systems if we parse the output of
 	//   systeminfo to match uname's scope of concerns.
-	c := runner.NewCommander(o.Command, "string", nil).Run()
+	c := runner.NewCommander(o.Command, "string", o.Redactions).Run()
 	return op.New(o.ID(), c.Result, c.Status, c.Error, runner.Params(o))
 }

--- a/runner/log/docker.go
+++ b/runner/log/docker.go
@@ -5,20 +5,12 @@ import (
 	"time"
 
 	"github.com/hashicorp/hcdiag/op"
+	"github.com/hashicorp/hcdiag/redact"
 
 	"github.com/hashicorp/hcdiag/runner"
 )
 
 var _ runner.Runner = Docker{}
-
-// NewDocker returns a runner with an identifier and fully configured docker runner
-func NewDocker(container, destDir string, since time.Time) *Docker {
-	return &Docker{
-		Container: container,
-		DestDir:   destDir,
-		Since:     since,
-	}
-}
 
 // Docker allows logs to be retrieved for a docker container
 type Docker struct {
@@ -27,7 +19,18 @@ type Docker struct {
 	// DestDir is the directory we will write the logs to
 	DestDir string `json:"destDir"`
 	// Since marks the beginning of the time range to include logs
-	Since time.Time `json:"since"`
+	Since      time.Time        `json:"since"`
+	Redactions []*redact.Redact `json:"redactions"`
+}
+
+// NewDocker returns a runner with an identifier and fully configured docker runner
+func NewDocker(container, destDir string, since time.Time, redactions []*redact.Redact) *Docker {
+	return &Docker{
+		Container:  container,
+		DestDir:    destDir,
+		Since:      since,
+		Redactions: redactions,
+	}
 }
 
 func (d Docker) ID() string {
@@ -37,7 +40,7 @@ func (d Docker) ID() string {
 // Run executes the runner
 func (d Docker) Run() op.Op {
 	// Check that docker exists
-	o := runner.NewSheller("docker version", nil).Run()
+	o := runner.NewSheller("docker version", d.Redactions).Run()
 	if o.Error != nil {
 		return op.New(d.ID(), o.Result, op.Fail, DockerNotFoundError{
 			container: d.Container,
@@ -48,7 +51,7 @@ func (d Docker) Run() op.Op {
 
 	// Retrieve logs
 	cmd := DockerLogCmd(d.Container, d.DestDir, d.Since)
-	o = runner.NewSheller(cmd, nil).Run()
+	o = runner.NewSheller(cmd, d.Redactions).Run()
 	// NOTE(mkcp): If the container does not exist, docker will exit non-zero and it'll surface as a ShellExecError.
 	//  The result actionably states that the container wasn't found. In the future we may want to scrub the result
 	//  and only return an actionable error message

--- a/runner/log/journald_test.go
+++ b/runner/log/journald_test.go
@@ -4,54 +4,60 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/hcdiag/redact"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestJournalctlGetLogsCmd(t *testing.T) {
 	testTable := []struct {
-		desc    string
-		name    string
-		destDir string
-		since   time.Time
-		until   time.Time
-		expect  string
+		desc       string
+		name       string
+		destDir    string
+		since      time.Time
+		until      time.Time
+		expect     string
+		redactions []*redact.Redact
 	}{
 		{
-			desc:    "No since or until",
-			name:    "nomad",
-			destDir: "/testing/test",
-			since:   time.Time{},
-			until:   time.Time{},
-			expect:  "journalctl -x -u nomad --no-pager > /testing/test/journald-nomad.log",
+			desc:       "No since or until",
+			name:       "nomad",
+			destDir:    "/testing/test",
+			since:      time.Time{},
+			until:      time.Time{},
+			expect:     "journalctl -x -u nomad --no-pager > /testing/test/journald-nomad.log",
+			redactions: make([]*redact.Redact, 0),
 		},
 		{
-			desc:    "With since but not until",
-			name:    "nomad",
-			destDir: "/testing/test",
-			since:   time.Date(1, 1, 1, 1, 1, 1, 1, &time.Location{}),
-			until:   time.Time{},
-			expect:  "journalctl -x -u nomad --since \"0001-01-01 01:01:01\" --no-pager > /testing/test/journald-nomad.log",
+			desc:       "With since but not until",
+			name:       "nomad",
+			destDir:    "/testing/test",
+			since:      time.Date(1, 1, 1, 1, 1, 1, 1, &time.Location{}),
+			until:      time.Time{},
+			expect:     "journalctl -x -u nomad --since \"0001-01-01 01:01:01\" --no-pager > /testing/test/journald-nomad.log",
+			redactions: []*redact.Redact{},
 		},
 		{
-			desc:    "With until but not since",
-			name:    "nomad",
-			destDir: "/testing/test",
-			since:   time.Time{},
-			until:   time.Date(2, 1, 1, 1, 1, 1, 1, &time.Location{}),
-			expect:  "journalctl -x -u nomad --until \"0002-01-01 01:01:01\" --no-pager > /testing/test/journald-nomad.log",
+			desc:       "With until but not since",
+			name:       "nomad",
+			destDir:    "/testing/test",
+			since:      time.Time{},
+			until:      time.Date(2, 1, 1, 1, 1, 1, 1, &time.Location{}),
+			expect:     "journalctl -x -u nomad --until \"0002-01-01 01:01:01\" --no-pager > /testing/test/journald-nomad.log",
+			redactions: nil,
 		},
 		{
-			desc:    "with since and until",
-			name:    "nomad",
-			destDir: "/testing/test",
-			since:   time.Date(1, 1, 1, 1, 1, 1, 1, &time.Location{}),
-			until:   time.Date(2, 1, 1, 1, 1, 1, 1, &time.Location{}),
-			expect:  "journalctl -x -u nomad --since \"0001-01-01 01:01:01\" --until \"0002-01-01 01:01:01\" --no-pager > /testing/test/journald-nomad.log",
+			desc:       "with since and until",
+			name:       "nomad",
+			destDir:    "/testing/test",
+			since:      time.Date(1, 1, 1, 1, 1, 1, 1, &time.Location{}),
+			until:      time.Date(2, 1, 1, 1, 1, 1, 1, &time.Location{}),
+			expect:     "journalctl -x -u nomad --since \"0001-01-01 01:01:01\" --until \"0002-01-01 01:01:01\" --no-pager > /testing/test/journald-nomad.log",
+			redactions: nil,
 		},
 	}
 
 	for _, tc := range testTable {
-		j := NewJournald(tc.name, tc.destDir, tc.since, tc.until)
+		j := NewJournald(tc.name, tc.destDir, tc.since, tc.until, tc.redactions)
 		result := j.LogsCmd()
 		assert.Equal(t, tc.expect, result)
 	}


### PR DESCRIPTION
This PR adds redaction pass-through for higher-order host runners.

docker-log and journald-log reification now also takes redactions into account -- custom redactions can be added with an HCL block as shown in this example docker-log runner:
```
  docker-log {
    container = "arch-testcontainer"
    redact "literal" {
      match = "teststring"
      replace = "HCL: product 'consul' -> dockerlog -> redact"
    }
  }
```