### PR TITLE
Remove the unused function redact.Apply(), rename redact.ApplyMany

### DIFF
--- a/changelog/195.txt
+++ b/changelog/195.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+redact: Remove Apply function.
+```

--- a/redact/redact.go
+++ b/redact/redact.go
@@ -43,11 +43,11 @@ func New(cfg Config) (*Redact, error) {
 	return &Redact{id, r, replace}, nil
 }
 
-// ApplyMany takes a slice of redactions and a writer + reader, reading everything in and applying redactions in
+// Apply takes a slice of redactions and a writer + reader, reading everything in and applying redactions in
 // sequential order before writing. Therefore, each Redact that appears earlier in the list takes precedence over later
 // Redacts. It is possible for redactions to collide with one another if a matcher can match with the Replace string
 // of an earlier Redact.
-func ApplyMany(redactions []*Redact, w io.Writer, r io.Reader) error {
+func Apply(redactions []*Redact, w io.Writer, r io.Reader) error {
 	var bts []byte
 	var err error
 
@@ -79,7 +79,7 @@ func ApplyMany(redactions []*Redact, w io.Writer, r io.Reader) error {
 func String(result string, redactions []*Redact) (string, error) {
 	r := strings.NewReader(result)
 	buf := new(bytes.Buffer)
-	err := ApplyMany(redactions, buf, r)
+	err := Apply(redactions, buf, r)
 	if err != nil {
 		return "", err
 	}
@@ -93,7 +93,7 @@ func String(result string, redactions []*Redact) (string, error) {
 func Bytes(b []byte, redactions []*Redact) ([]byte, error) {
 	r := bytes.NewReader(b)
 	buf := new(bytes.Buffer)
-	err := ApplyMany(redactions, buf, r)
+	err := Apply(redactions, buf, r)
 	if err != nil {
 		return nil, err
 	}

--- a/redact/redact.go
+++ b/redact/redact.go
@@ -43,27 +43,6 @@ func New(cfg Config) (*Redact, error) {
 	return &Redact{id, r, replace}, nil
 }
 
-func (x Redact) Apply(w io.Writer, r io.Reader) error {
-	bts, err := io.ReadAll(r)
-	if err != nil {
-		return err
-	}
-	if len(bts) == 0 {
-		_, err = w.Write(bts)
-		if err != nil {
-			return err
-		}
-		return nil
-	}
-	newBts := x.matcher.ReplaceAll(bts, []byte(x.Replace))
-	_, err = w.Write(newBts)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // ApplyMany takes a slice of redactions and a writer + reader, reading everything in and applying redactions in
 // sequential order before writing. Therefore, each Redact that appears earlier in the list takes precedence over later
 // Redacts. It is possible for redactions to collide with one another if a matcher can match with the Replace string

--- a/redact/redact_test.go
+++ b/redact/redact_test.go
@@ -41,52 +41,6 @@ func TestNewRegex(t *testing.T) {
 	}
 }
 
-func TestRedact_Apply(t *testing.T) {
-	tcs := []struct {
-		name    string
-		matcher string
-		input   string
-		expect  string
-	}{
-		{
-			name:    "empty input",
-			matcher: "/myRegex/",
-			input:   "",
-			expect:  "",
-		},
-		{
-			name:    "redacts once",
-			matcher: "myRegex",
-			input:   "myRegex",
-			expect:  "<REDACTED>",
-		},
-		{
-			name:    "redacts many",
-			matcher: "test",
-			input:   "test test_test+test-test\n!test ??test",
-			expect:  "<REDACTED> <REDACTED>_<REDACTED>+<REDACTED>-<REDACTED>\n!<REDACTED> ??<REDACTED>",
-		},
-	}
-	for _, tc := range tcs {
-		cfg := Config{
-			Matcher: tc.matcher,
-			ID:      "",
-			Replace: "",
-		}
-		redactor, err := New(cfg)
-		assert.NoError(t, err, tc.name)
-
-		r := strings.NewReader(tc.input)
-		buf := new(bytes.Buffer)
-		err = redactor.Apply(buf, r)
-		assert.NoError(t, err, tc.name)
-
-		result := buf.String()
-
-		assert.Equal(t, tc.expect, result, tc.name)
-	}
-}
-
 func TestApplyMany(t *testing.T) {
 	var redactions []*Redact
 	matchers := []string{"myRegex", "test", "does not apply"}

--- a/redact/redact_test.go
+++ b/redact/redact_test.go
@@ -41,7 +41,7 @@ func TestNewRegex(t *testing.T) {
 	}
 }
 
-func TestApplyMany(t *testing.T) {
+func TestApply(t *testing.T) {
 	var redactions []*Redact
 	matchers := []string{"myRegex", "test", "does not apply"}
 	for _, matcher := range matchers {
@@ -78,7 +78,7 @@ func TestApplyMany(t *testing.T) {
 	for _, tc := range tcs {
 		r := strings.NewReader(tc.input)
 		buf := new(bytes.Buffer)
-		err := ApplyMany(redactions, buf, r)
+		err := Apply(redactions, buf, r)
 		assert.NoError(t, err, tc.name)
 
 		result := buf.String()


### PR DESCRIPTION
Does what it says on the tin: removes redact.Apply and renames redact.ApplyMany to redact.Apply.