### PR TITLE
Remove labels from HCL redactions

### DIFF
--- a/changelog/196.txt
+++ b/changelog/196.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+hcl: remove redaction label
+```

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -55,7 +55,6 @@ type Product struct {
 }
 
 type Redact struct {
-	Label   string `hcl:"name,label"`
 	ID      string `hcl:"id,optional"`
 	Match   string `hcl:"match"`
 	Replace string `hcl:"replace,optional"`
@@ -384,16 +383,9 @@ func MapRedacts(redactions []Redact) ([]*redact.Redact, error) {
 func ValidateRedactions(redactions []Redact) error {
 	hclog.L().Trace("hcl.ValidateRedactions()", "redactions", redactions)
 	for _, r := range redactions {
-		switch r.Label {
-		case "regex":
-			_, err := regexp.Compile(r.Match)
-			if err != nil {
-				return fmt.Errorf("could not compile regex, matcher=%s, err=%s", r.Match, err)
-			}
-		case "literal":
-			continue
-		default:
-			return fmt.Errorf("invalid redact name, name=%s", r.Label)
+		_, err := regexp.Compile(r.Match)
+		if err != nil {
+			return fmt.Errorf("could not compile regex, matcher=%s, err=%s", r.Match, err)
 		}
 	}
 	return nil

--- a/hcl/hcl_test.go
+++ b/hcl/hcl_test.go
@@ -354,24 +354,21 @@ func TestValidateRedactions(t *testing.T) {
 			redactions: []Redact{},
 		},
 		{
-			name: "one literal",
+			name: "one redaction",
 			redactions: []Redact{
 				{
-					Label: "literal",
 					Match: "something",
 				},
 			},
 		},
 		{
-			name: "many literals",
+			name: "many redactions",
 			redactions: []Redact{
 				{
-					Label: "literal",
 					ID:    "one",
 					Match: "something",
 				},
 				{
-					Label: "literal",
 					ID:    "two",
 					Match: "something else",
 				},
@@ -381,7 +378,6 @@ func TestValidateRedactions(t *testing.T) {
 			name: "one regex",
 			redactions: []Redact{
 				{
-					Label: "regex",
 					ID:    "reg1",
 					Match: "just a regex",
 				},
@@ -391,52 +387,25 @@ func TestValidateRedactions(t *testing.T) {
 			name: "many regexes",
 			redactions: []Redact{
 				{
-					Label: "regex",
 					ID:    "reg1",
 					Match: "just a regex",
 				},
 				{
-					Label: "regex",
 					ID:    "reg2",
 					Match: "/just a fancy regex/",
 				},
 				{
-					Label: "regex",
 					ID:    "reg3",
 					Match: "^a very fancy (.) regex?",
-				},
-			},
-		},
-		{
-			name: "both regexes and literals",
-			redactions: []Redact{
-				{
-					Label: "regex",
-					ID:    "reg",
-					Match: "just a regex",
-				},
-				{
-					Label: "literal",
-					ID:    "lit",
-					Match: "something",
 				},
 			},
 		},
 	}
 	shouldErr := []testCase{
 		{
-			name: "bad label",
-			redactions: []Redact{
-				{
-					Label: "shouldNotMatchAnyRegexLabel",
-				},
-			},
-		},
-		{
 			name: "one bad regex",
 			redactions: []Redact{
 				{
-					Label: "regex",
 					ID:    "bad-reg-perl-stuff",
 					Match: "\"^/(?!/)(.*?)\"",
 				},
@@ -446,12 +415,10 @@ func TestValidateRedactions(t *testing.T) {
 			name: "good and bad regexes",
 			redactions: []Redact{
 				{
-					Label: "regex",
 					ID:    "the good stuff",
 					Match: "/hello/",
 				},
 				{
-					Label: "regex",
 					ID:    "bad-reg-perl-stuff",
 					Match: "\"^/(?!/)(.*?)\"",
 				},


### PR DESCRIPTION
No more need for the HCL label on redactions.

Old and busted:
```
redact "literal" {
  match = "shazam"
  replace = "custom config (HCL): agent -> redact"
}
```

New hotness:
```
redact {
  match = "shazam"
  replace = "custom config (HCL): agent -> redact"
}
```
