### PR TITLE
DockerNotFoundError should not be an error

### DIFF
--- a/changelog/201.txt
+++ b/changelog/201.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+runner: DockerNotFoundError should result in skipped runner, not error.
+```

--- a/runner/log/docker.go
+++ b/runner/log/docker.go
@@ -42,7 +42,7 @@ func (d Docker) Run() op.Op {
 	// Check that docker exists
 	o := runner.NewSheller("docker version", d.Redactions).Run()
 	if o.Error != nil {
-		return op.New(d.ID(), o.Result, op.Fail, DockerNotFoundError{
+		return op.New(d.ID(), o.Result, op.Skip, DockerNotFoundError{
 			container: d.Container,
 			err:       o.Error,
 		},


### PR DESCRIPTION
My first crack at this just fixes the symptom we talked about yesterday: it makes a DockerNotFoundError a skip instead of a failure.

Another approach would be to remove the docker runner from the default product runners (except for TFE, where docker is expected). Interested to hear what you have to say.