### PR TITLE
BUG: do not serialize hcl.Redact.Match into json for the Manifest

### DIFF
--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -57,7 +57,7 @@ type Product struct {
 type Redact struct {
 	Label   string `hcl:"name,label"`
 	ID      string `hcl:"id,optional"`
-	Match   string `hcl:"match"`
+	Match   string `hcl:"match" json:"-"`
 	Replace string `hcl:"replace,optional"`
 }
 


### PR DESCRIPTION
This is a crucial bug that we caught in the RC: matchers that are provided in HCL currently get serialized into JSON because, while redact.Redact uses a private field and is not serialized, hcl.Redact is all public and therefore requires json annotations. I'll be making a follow up PR to correctly format all of the HCL fields in manifest to match their hcl representation.