### PR TITLE
HCL Cleanup - redact literal label and json tagging

### DIFF
--- a/changelog/204.txt
+++ b/changelog/204.txt
@@ -1,0 +1,6 @@
+```release-note:improvement
+hcl: Add JSON tagging to every hcl field, omitting empty blocks and collections.
+```
+```release-note:bug
+hcl: Ensure redact "literal", which is not implemented yet, doesn't pass HCL validation.
+```

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -15,9 +15,9 @@ import (
 )
 
 type HCL struct {
-	Host     *Host      `hcl:"host,block" json:"host"`
-	Products []*Product `hcl:"product,block" json:"products"`
-	Agent    *Agent     `hcl:"agent,block" json:"agent"`
+	Host     *Host      `hcl:"host,block" json:"host,omitempty"`
+	Products []*Product `hcl:"product,block" json:"products,omitempty"`
+	Agent    *Agent     `hcl:"agent,block" json:"agent,omitempty"`
 }
 
 type Blocks interface {
@@ -26,73 +26,73 @@ type Blocks interface {
 
 // NOTE(dcohen) this is currently a separate config block, as opposed to a parent block of the others
 type Agent struct {
-	Redactions []Redact `hcl:"redact,block"`
+	Redactions []Redact `hcl:"redact,block" json:"redactions,omitempty"`
 }
 
 type Host struct {
-	Commands     []Command     `hcl:"command,block"`
-	Shells       []Shell       `hcl:"shell,block"`
-	GETs         []GET         `hcl:"GET,block"`
-	Copies       []Copy        `hcl:"copy,block"`
-	DockerLogs   []DockerLog   `hcl:"docker-log,block"`
-	JournaldLogs []JournaldLog `hcl:"journald-log,block"`
-	Excludes     []string      `hcl:"excludes,optional"`
-	Selects      []string      `hcl:"selects,optional"`
-	Redactions   []Redact      `hcl:"redact,block"`
+	Commands     []Command     `hcl:"command,block" json:"commands,omitempty"`
+	Shells       []Shell       `hcl:"shell,block" json:"shells,omitempty"`
+	GETs         []GET         `hcl:"GET,block" json:"gets,omitempty"`
+	Copies       []Copy        `hcl:"copy,block" json:"copies,omitempty"`
+	DockerLogs   []DockerLog   `hcl:"docker-log,block" json:"docker_log,omitempty"`
+	JournaldLogs []JournaldLog `hcl:"journald-log,block" json:"journald_log,omitempty"`
+	Excludes     []string      `hcl:"excludes,optional" json:"excludes,omitempty"`
+	Selects      []string      `hcl:"selects,optional" json:"selects,omitempty"`
+	Redactions   []Redact      `hcl:"redact,block" json:"redactions,omitempty"`
 }
 
 type Product struct {
-	Name         string        `hcl:"name,label"`
-	Commands     []Command     `hcl:"command,block"`
-	Shells       []Shell       `hcl:"shell,block"`
-	GETs         []GET         `hcl:"GET,block"`
-	Copies       []Copy        `hcl:"copy,block"`
-	DockerLogs   []DockerLog   `hcl:"docker-log,block"`
-	JournaldLogs []JournaldLog `hcl:"journald-log,block"`
-	Excludes     []string      `hcl:"excludes,optional"`
-	Selects      []string      `hcl:"selects,optional"`
-	Redactions   []Redact      `hcl:"redact,block"`
+	Name         string        `hcl:"name,label" json:"name"`
+	Commands     []Command     `hcl:"command,block" json:"commands,omitempty"`
+	Shells       []Shell       `hcl:"shell,block" json:"shells,omitempty"`
+	GETs         []GET         `hcl:"GET,block" json:"gets,omitempty"`
+	Copies       []Copy        `hcl:"copy,block" json:"copies,omitempty"`
+	DockerLogs   []DockerLog   `hcl:"docker-log,block" json:"docker_log,omitempty"`
+	JournaldLogs []JournaldLog `hcl:"journald-log,block" json:"journald_log,omitempty"`
+	Excludes     []string      `hcl:"excludes,optional" json:"excludes,omitempty"`
+	Selects      []string      `hcl:"selects,optional" json:"selects,omitempty"`
+	Redactions   []Redact      `hcl:"redact,block" json:"redactions,omitempty"`
 }
 
 type Redact struct {
-	Label   string `hcl:"name,label"`
-	ID      string `hcl:"id,optional"`
+	Label   string `hcl:"name,label" json:"label"`
+	ID      string `hcl:"id,optional" json:"ID"`
 	Match   string `hcl:"match"`
-	Replace string `hcl:"replace,optional"`
+	Replace string `hcl:"replace,optional" json:"replace"`
 }
 
 type Command struct {
-	Run        string   `hcl:"run"`
-	Format     string   `hcl:"format"`
-	Redactions []Redact `hcl:"redact,block"`
+	Run        string   `hcl:"run" json:"run"`
+	Format     string   `hcl:"format" json:"format"`
+	Redactions []Redact `hcl:"redact,block" json:"redactions,omitempty"`
 }
 
 type Shell struct {
-	Run        string   `hcl:"run"`
-	Redactions []Redact `hcl:"redact,block"`
+	Run        string   `hcl:"run" json:"run"`
+	Redactions []Redact `hcl:"redact,block" json:"redactions,omitempty"`
 }
 
 type GET struct {
-	Path       string   `hcl:"path"`
-	Redactions []Redact `hcl:"redact,block"`
+	Path       string   `hcl:"path" json:"path"`
+	Redactions []Redact `hcl:"redact,block" json:"redactions,omitempty"`
 }
 
 type Copy struct {
-	Path       string   `hcl:"path"`
-	Since      string   `hcl:"since,optional"`
-	Redactions []Redact `hcl:"redact,block"`
+	Path       string   `hcl:"path" json:"path"`
+	Since      string   `hcl:"since,optional" json:"since"`
+	Redactions []Redact `hcl:"redact,block" json:"redactions,omitempty"`
 }
 
 type DockerLog struct {
-	Container  string   `hcl:"container"`
-	Since      string   `hcl:"since,optional"`
-	Redactions []Redact `hcl:"redact,block"`
+	Container  string   `hcl:"container" json:"container"`
+	Since      string   `hcl:"since,optional" json:"since"`
+	Redactions []Redact `hcl:"redact,block" json:"redactions,omitempty"`
 }
 
 type JournaldLog struct {
-	Service    string   `hcl:"service"`
-	Since      string   `hcl:"since,optional"`
-	Redactions []Redact `hcl:"redact,block"`
+	Service    string   `hcl:"service" json:"service"`
+	Since      string   `hcl:"since,optional" json:"since"`
+	Redactions []Redact `hcl:"redact,block" json:"redactions,omitempty"`
 }
 
 // Parse takes a file path and decodes the file from disk into HCL types.

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -366,6 +366,7 @@ func MapRedacts(redactions []Redact) ([]*redact.Redact, error) {
 
 	s := make([]*redact.Redact, len(redactions))
 	for i, r := range redactions {
+		// TODO(mkcp): Implement literals and `switch r.Label {}`
 		cfg := redact.Config{
 			Matcher: r.Match,
 			ID:      r.ID,
@@ -390,8 +391,9 @@ func ValidateRedactions(redactions []Redact) error {
 			if err != nil {
 				return fmt.Errorf("could not compile regex, matcher=%s, err=%s", r.Match, err)
 			}
-		case "literal":
-			continue
+		// TODO(mkcp): Validate literals when they are implemented
+		// case "literal":
+		// 	continue
 		default:
 			return fmt.Errorf("invalid redact name, name=%s", r.Label)
 		}

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -56,7 +56,7 @@ type Product struct {
 
 type Redact struct {
 	Label   string `hcl:"name,label" json:"label"`
-	ID      string `hcl:"id,optional" json:"ID"`
+	ID      string `hcl:"id,optional" json:"id"`
 	Match   string `hcl:"match"`
 	Replace string `hcl:"replace,optional" json:"replace"`
 }

--- a/hcl/hcl_test.go
+++ b/hcl/hcl_test.go
@@ -353,30 +353,31 @@ func TestValidateRedactions(t *testing.T) {
 			name:       "empty redactions",
 			redactions: []Redact{},
 		},
-		{
-			name: "one literal",
-			redactions: []Redact{
-				{
-					Label: "literal",
-					Match: "something",
-				},
-			},
-		},
-		{
-			name: "many literals",
-			redactions: []Redact{
-				{
-					Label: "literal",
-					ID:    "one",
-					Match: "something",
-				},
-				{
-					Label: "literal",
-					ID:    "two",
-					Match: "something else",
-				},
-			},
-		},
+		// TODO(mkcp): Uncomment when we support literal validation
+		// {
+		// 	name: "one literal",
+		// 	redactions: []Redact{
+		// 		{
+		// 			Label: "literal",
+		// 			Match: "something",
+		// 		},
+		// 	},
+		// },
+		// {
+		//	name: "many literals",
+		//	redactions: []Redact{
+		//		{
+		//			Label: "literal",
+		//			ID:    "one",
+		//			Match: "something",
+		//		},
+		//		{
+		//			Label: "literal",
+		//			ID:    "two",
+		//			Match: "something else",
+		//		},
+		//	},
+		//	},
 		{
 			name: "one regex",
 			redactions: []Redact{
@@ -407,21 +408,22 @@ func TestValidateRedactions(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "both regexes and literals",
-			redactions: []Redact{
-				{
-					Label: "regex",
-					ID:    "reg",
-					Match: "just a regex",
-				},
-				{
-					Label: "literal",
-					ID:    "lit",
-					Match: "something",
-				},
-			},
-		},
+		// TODO(mkcp): Uncomment when we support literal validation
+		// {
+		// 	name: "both regexes and literals",
+		// 	redactions: []Redact{
+		// 		{
+		// 			Label: "regex",
+		// 			ID:    "reg",
+		// 			Match: "just a regex",
+		// 		},
+		// 		{
+		// 			Label: "literal",
+		// 			ID:    "lit",
+		// 			Match: "something",
+		// 		},
+		// 	},
+		// },
 	}
 	shouldErr := []testCase{
 		{


### PR DESCRIPTION
There's two scopes of changes in this PR:
First we fix a bug where we were checking for a redaction feature we cut but will add in the future: literals. This has been commented out with a TODO. Now when "literal" is provided in config, we error out the default case.


Next, we ensure the HCL structs have proper lowercased json tagging. We also set `omitempty` for every block / collection

When no config is provided, we used to:
![Screen Shot 2022-08-22 at 1 52 55 PM](https://user-images.githubusercontent.com/938395/186016895-dcc8c787-a032-4eb3-8fc8-3bcc9b6fa8c4.png)

Now we:
![Screen Shot 2022-08-22 at 1 52 46 PM](https://user-images.githubusercontent.com/938395/186016926-0256c803-68c7-406e-9d79-5faa5f8b7c83.png)

And so on, with each nested block being omitted if it is empty.
