### PR TITLE
Implement Default Redactions (#207)

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -587,7 +587,13 @@ func formatReportLine(cells ...string) string {
 
 // agentRedactions returns the default agent-level redactions that we ship with hcdiag
 func agentRedactions() ([]*redact.Redact, error) {
-	configs := []redact.Config{}
+	configs := []redact.Config{
+		// Email redactions applied to all products/runners
+		{
+			Matcher: redact.EmailPattern,
+			Replace: redact.EmailReplace,
+		},
+	}
 	redactions, err := redact.MapNew(configs)
 	if err != nil {
 		return nil, err

--- a/changelog/207.txt
+++ b/changelog/207.txt
@@ -1,0 +1,11 @@
+```release-note:improvement
+redact: Redact email addresses by default.
+```
+
+```release-note:improvement
+redact: Implement default Terraform Enterprise redactions.
+```
+
+```release-note:improvement
+network: Do not collect Network Interface hardware addresses.
+```

--- a/product/tfe.go
+++ b/product/tfe.go
@@ -81,7 +81,24 @@ func tfeRunners(cfg Config, api *client.APIClient) ([]runner.Runner, error) {
 
 // tfeRedactions returns a slice of default redactions for this product
 func tfeRedactions() ([]*redact.Redact, error) {
-	configs := []redact.Config{}
+	configs := []redact.Config{
+		{
+			Matcher: `(postgres://)[^@{]+`,
+			Replace: "${1}REDACTED",
+		},
+		{
+			Matcher: `(SECRET0=)[^ ]+`,
+			Replace: "${1}REDACTED",
+		},
+		{
+			Matcher: `(SECRET=)[^ ]+`,
+			Replace: "${1}REDACTED",
+		},
+		{
+			Matcher: `(\s+")[a-zA-Z0-9]{32}("\s+)`,
+			Replace: "${1}REDACTED${2}",
+		},
+	}
 	redactions, err := redact.MapNew(configs)
 	if err != nil {
 		return nil, err

--- a/redact/redact.go
+++ b/redact/redact.go
@@ -9,7 +9,15 @@ import (
 	"strings"
 )
 
+// DefaultReplace is the default string to include in place of matched redactions.
 const DefaultReplace = "<REDACTED>"
+
+// EmailPattern is a simple RegEx pattern intended to identify anything that looks like an email address.
+const EmailPattern = `([a-zA-Z0-9_.+-]+)@([a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+)`
+
+// EmailReplace is the default replacement pattern for email addresses. It includes the @ symbol to indicate it was
+// an email address, but otherwise, the remainder of the address is redacted.
+const EmailReplace = "REDACTED@REDACTED"
 
 type Redact struct {
 	ID      string `json:"ID"`

--- a/redact/redact_test.go
+++ b/redact/redact_test.go
@@ -158,6 +158,14 @@ func TestString(t *testing.T) {
 			in:     "an input string with a secret value 😬",
 			expect: "an input string with a secret value REDACTED",
 		},
+		{
+			name: "Test email redaction",
+			redacts: []*Redact{
+				newTestRedact(t, EmailPattern, EmailReplace),
+			},
+			in:     "lorem ipsum abc.def+_@ghi.jkl.mnop lorem ipsum",
+			expect: "lorem ipsum REDACTED@REDACTED lorem ipsum",
+		},
 	}
 
 	for _, tc := range tcs {

--- a/runner/host/network.go
+++ b/runner/host/network.go
@@ -15,12 +15,11 @@ var _ runner.Runner = &Network{}
 // NetworkInterface represents details about a network interface. This serves as the basis for the results produced
 // by the Network runner.
 type NetworkInterface struct {
-	Index        int      `json:"index"`
-	MTU          int      `json:"mtu"`
-	Name         string   `json:"name"`
-	HardwareAddr string   `json:"hardwareAddr"`
-	Flags        []string `json:"flags"`
-	Addrs        []string `json:"addrs"`
+	Index int      `json:"index"`
+	MTU   int      `json:"mtu"`
+	Name  string   `json:"name"`
+	Flags []string `json:"flags"`
+	Addrs []string `json:"addrs"`
 }
 
 type Network struct {
@@ -69,12 +68,6 @@ func (n Network) networkInterface(nis net.InterfaceStat) (NetworkInterface, erro
 		return NetworkInterface{}, err
 	}
 	netIf.Name = name
-
-	hwAddr, err := redact.String(nis.HardwareAddr, n.Redactions)
-	if err != nil {
-		return NetworkInterface{}, err
-	}
-	netIf.HardwareAddr = hwAddr
 
 	// Make a slice rather than an empty var declaration to avoid later marshalling null instead of empty array
 	flags := make([]string, 0)

--- a/runner/host/network_test.go
+++ b/runner/host/network_test.go
@@ -41,10 +41,9 @@ func TestNetwork_networkInterface(t *testing.T) {
 				},
 			},
 			expected: NetworkInterface{
-				Index:        10,
-				MTU:          1500,
-				Name:         "eth0",
-				HardwareAddr: "aa:bb:cc:dd:ee:ff",
+				Index: 10,
+				MTU:   1500,
+				Name:  "eth0",
 				Flags: []string{
 					"up",
 					"loopback",
@@ -61,8 +60,7 @@ func TestNetwork_networkInterface(t *testing.T) {
 			network: Network{
 				Redactions: createRedactionSlice(
 					t,
-					redact.Config{Matcher: "192.[\\d]{1,3}.[\\d]{1,3}.[\\d]{1,3}"},
-					redact.Config{Matcher: "aa:bb:cc:dd:ee:ff"}),
+					redact.Config{Matcher: "192.[\\d]{1,3}.[\\d]{1,3}.[\\d]{1,3}"}),
 			},
 			inputInterfaceStat: net.InterfaceStat{
 				Index:        10,
@@ -84,10 +82,9 @@ func TestNetwork_networkInterface(t *testing.T) {
 				},
 			},
 			expected: NetworkInterface{
-				Index:        10,
-				MTU:          1500,
-				Name:         "eth0",
-				HardwareAddr: redact.DefaultReplace,
+				Index: 10,
+				MTU:   1500,
+				Name:  "eth0",
 				Flags: []string{
 					"up",
 					"loopback",


### PR DESCRIPTION
This addresses a few items brought up with regards to redaction and data frugality:

* MAC addresses are no longer collected as part of the network interface discovery due to concerns about exposing unnecessary information in reports.
* A set of default Terraform Enterprise redactions are now implemented.
* Email addresses are identified and redacted across all products and runners.

(cherry picked from commit 678e2fa83ee36e623c16a95d751ee59a991e1066)