### PR TITLE
BUG: Ensure JSON HTTPer results don't get squashed into a flat string

### DIFF
--- a/changelog/215.txt
+++ b/changelog/215.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+runner: Fixed a redaction and reporting issue where HTTPer incorrectly flattened and redacted JSON responses as strings.
+```

--- a/client/apiclient_test.go
+++ b/client/apiclient_test.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
-
 	"github.com/hashicorp/hcdiag/redact"
 
 	"github.com/stretchr/testify/assert"
@@ -176,7 +174,7 @@ func TestAPIClient_RedactGet(t *testing.T) {
 				{Matcher: "testMatcher"},
 			},
 			mockResp: `{"hello":"testMatcher"}`,
-			expected: []byte(`{"hello":"<REDACTED>"}`),
+			expected: []byte(`{"hello":"\u003cREDACTED\u003e"}`),
 		},
 	}
 
@@ -210,12 +208,8 @@ func TestAPIClient_RedactGet(t *testing.T) {
 		assert.Equal(t, "application/json", reqReceived.Header["Content-Type"][0], tc.name)
 		assert.Equal(t, "headeroni", reqReceived.Header["Special"][0], tc.name)
 
-		bts := make([]byte, 0)
-		spew.Dump(resp)
 		// ensure response is Marshal-able and matches our expected
-		json.NewEncoder(bts)
 		bodyBts, _ := json.Marshal(resp)
-		spew.Dump(bodyBts)
 		assert.Equal(t, tc.expected, bodyBts, tc.name)
 	}
 }


### PR DESCRIPTION
Resolves an implementation bug where I converted an HTTP body into a string before redacting it as a string. It turns out that the apiclient get methods actually request JSON and unmarshal it into map[string]any. So squashing it into a string was bad news and broke some downstream results marshaling.

There's a larger design issue with the boundary between apiclient and runners. Over time we've been migrating external operations in hcdiag into the runners themselves, and apiclient exposes methods that are used by both runners and for querying products directly for their log locations in config. Migrating this pattern into the runner will lead to a more portable solution that composes well with other runner features.