### PR TITLE
Adding more data collection for TFE

### DIFF
--- a/changelog/227.txt
+++ b/changelog/227.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+runner: Add more TFE commands for data collection
+```

--- a/product/tfe.go
+++ b/product/tfe.go
@@ -69,10 +69,18 @@ func tfeRunners(cfg Config, api *client.APIClient) ([]runner.Runner, error) {
 		runner.NewHTTPer(api, "/api/v2/admin/twilio-settings", cfg.Redactions),
 		// page size 1 because we only actually care about total workspace count in the `meta` field
 		runner.NewHTTPer(api, "/api/v2/admin/workspaces?page[size]=1", cfg.Redactions),
+		runner.NewHTTPer(api, "/api/v2/admin/users?page[size]=1", cfg.Redactions),
+		runner.NewHTTPer(api, "/api/v2/admin/runs?page[size]=1", cfg.Redactions),
 
 		runner.NewCommander("docker -v", "string", cfg.Redactions),
 		runner.NewCommander("replicatedctl app status --output json", "json", cfg.Redactions),
 		runner.NewCommander("lsblk --json", "json", cfg.Redactions),
+		runner.NewCommander("replicatedctl app-config view -o json --group capacity", "json", cfg.Redactions),
+		runner.NewCommander("replicatedctl app-config view -o json --group production_type", "json", cfg.Redactions),
+		runner.NewCommander("replicatedctl app-config view -o json --group log_forwarding", "json", cfg.Redactions),
+		runner.NewCommander("replicatedctl app-config view -o json --group blob", "json", cfg.Redactions),
+		runner.NewCommander("replicatedctl app-config view -o json --group worker_image", "json", cfg.Redactions),
+		runner.NewCommander("replicatedctl params export --template '{{.Airgap}}'", "string", cfg.Redactions),
 
 		runner.NewSheller("getenforce", cfg.Redactions),
 		runner.NewSheller("env | grep -i proxy", cfg.Redactions),


### PR DESCRIPTION
Related to #186, this branch adds some more TFE data collection based on [TF-450](https://hashicorp.atlassian.net/browse/TF-450).

[TF-549](https://hashicorp.atlassian.net/browse/TF-549) - gathers the number of users
[TF-550](https://hashicorp.atlassian.net/browse/TF-550) - gathers the number of runs
[TF-461](https://hashicorp.atlassian.net/browse/TF-461) - gathers whether or not it's airgapped
[TF-459](https://hashicorp.atlassian.net/browse/TF-459) - gathers the following:
- Object Storage - Type
- Operational Mode
- Worker Memory capacity limit
- Worker CPU capacity limit
- Concurrent Run limit
- Custom Worker Image?
- Log Forwarding

I tested this on a dev instance of TFE, and I got the desired output with the correct redactions. Happy to share if anyone would like to see them before approving.