### PR TITLE
Add 'skip' status counts to the summary output at the end of a run

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -513,6 +513,7 @@ func (a *Agent) WriteSummary(writer io.Writer) error {
 		"product",
 		string(op.Success),
 		string(op.Fail),
+		string(op.Skip),
 		string(op.Unknown),
 		"total",
 	}
@@ -531,7 +532,7 @@ func (a *Agent) WriteSummary(writer io.Writer) error {
 	sort.Strings(products)
 
 	for _, prod := range products {
-		var success, fail, unknown int
+		var success, fail, skip, unknown int
 		ops := a.ManifestOps[prod]
 
 		for _, o := range ops {
@@ -540,6 +541,8 @@ func (a *Agent) WriteSummary(writer io.Writer) error {
 				success++
 			case op.Fail:
 				fail++
+			case op.Skip:
+				skip++
 			default:
 				unknown++
 			}
@@ -549,6 +552,7 @@ func (a *Agent) WriteSummary(writer io.Writer) error {
 			prod,
 			strconv.Itoa(success),
 			strconv.Itoa(fail),
+			strconv.Itoa(skip),
 			strconv.Itoa(unknown),
 			strconv.Itoa(len(ops))))
 		if err != nil {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -273,6 +273,9 @@ func TestAgent_WriteSummary(t *testing.T) {
 						Status: op.Fail,
 					},
 					{
+						Status: op.Skip,
+					},
+					{
 						Status: op.Unknown,
 					},
 				},
@@ -282,6 +285,9 @@ func TestAgent_WriteSummary(t *testing.T) {
 					},
 					{
 						Status: op.Unknown,
+					},
+					{
+						Status: op.Skip,
 					},
 				},
 			}},
@@ -332,8 +338,8 @@ func Test_formatReportLine(t *testing.T) {
 		},
 		{
 			name:   "Test Sample Header Row",
-			cells:  []string{"product", "success", "failed", "unknown", "total"},
-			expect: "product\tsuccess\tfailed\tunknown\ttotal\t\n",
+			cells:  []string{"product", "success", "failed", "skip", "unknown", "total"},
+			expect: "product\tsuccess\tfailed\tskip\tunknown\ttotal\t\n",
 		},
 	}
 

--- a/agent/testdata/WriteSummary/Test Header Only.golden
+++ b/agent/testdata/WriteSummary/Test Header Only.golden
@@ -1,1 +1,1 @@
-product  success  fail  unknown  total  
+product  success  fail  skip  unknown  total  

--- a/agent/testdata/WriteSummary/Test with Products.golden
+++ b/agent/testdata/WriteSummary/Test with Products.golden
@@ -1,3 +1,3 @@
-product  success  fail  unknown  total  
-consul   2        1     1        4      
-nomad    0        1     1        2      
+product  success  fail  skip  unknown  total  
+consul   2        1     1     1        5      
+nomad    0        1     1     1        3      

--- a/changelog/229.txt
+++ b/changelog/229.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+improvement: Add "skip" status counts to the summary output at the end of a run"
+```


### PR DESCRIPTION
Does what it says:

Before:
```
product  success  fail  unknown  total
host     9        1     0        10
nomad    7        0     2        9
```

After:
```
product  success  fail  skip  unknown  total
host     9        1     0     0        10
nomad    7        0     2     0        9
```