### PR TITLE
Fix --includes by decoupling from global since/until Time

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -298,7 +298,8 @@ func (a *Agent) CopyIncludes() (err error) {
 		}
 
 		a.l.Debug("getting Copier", "path", f)
-		o := runner.NewCopier(f, dest, a.Config.Since, a.Config.Until, nil).Run()
+		// In this case, newCopier doesn't need real since/until; if I am passing the -includes CLI flag, I want matching files regardless of creation/mod timestamps
+		o := runner.NewCopier(f, dest, time.Time{}, time.Now(), nil).Run()
 		if o.Error != nil {
 			return o.Error
 		}

--- a/changelog/232.txt
+++ b/changelog/232.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+agent: decouple -includes from global since/until times, so it just copies files without users having to worry about modification time
+```


### PR DESCRIPTION
This fixes a sneaky little bug where users' `-includes` arguments were being ignored. It removes `CopyIncludes()`' dependency on global/agent config (it was passing global `since` and `until` time values into `NewCopier()`, which was leading to lots of ignored files by default).

After this change, users can just pass e.g. `-includes='/etc/consul.d/*'` or `-includes='/etc/consul.d'` and have the files they need for troubleshooting copied as expected.