### PR TITLE
Doc improvements: custom config examples, bugfix, FAQ addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Terraform Enterprise historically uses replicated to provide similar functionali
   - `hcdiag -vault -dest /tmp/hcdiag`
 
 - Gather diagnostics and use the CLI to copy individual files or whole directories
-  - `hcdiag -vault -include "/var/log/dmesg,/var/log/vault-"`
+  - `hcdiag -vault -includes "/var/log/dmesg,/var/log/vault-"`
 
 - Gather only host diagnostics (prior to `0.4.0`, this was the behavior of running `hcdiag` with no flags).
   - `hcdiag -autodetect=false`

--- a/changelog/233.txt
+++ b/changelog/233.txt
@@ -1,3 +1,3 @@
 ```release-note:docs
-docs: add custom config examples, faq content"
+docs: add custom config examples, faq content
 ```

--- a/changelog/233.txt
+++ b/changelog/233.txt
@@ -1,3 +1,3 @@
-```release-note:docs
+```release-note:improvement
 docs: add custom config examples, faq content
 ```

--- a/changelog/233.txt
+++ b/changelog/233.txt
@@ -1,0 +1,3 @@
+```release-note:docs
+docs: add custom config examples, faq content"
+```

--- a/docs/custom-config.md
+++ b/docs/custom-config.md
@@ -69,3 +69,77 @@ product "consul" {
 Beginning with version `0.4.0`, `hcdiag` supports redactions. Redactions enable users to tell `hcdiag` about patterns of text that should be omitted from the results bundle.
 
 Read more about them [here](./redactions.md).
+
+## Custom Config Examples
+
+### Collect additional Consul information
+
+**Example:** we want a `-consul` run to collect additional information from several commands:
+
+* The Consul memberlist: `consul members`
+* Raft peer information: `consul operator raft list-peers`
+* A custom journalctl command that's different from the builtin: `journalctl -u consul --since=yesterday --output=json`
+* another custom command (in this case, just running `cat` to collect a file's contents into the bundle `Results.json` file with no redactions).
+
+To do this, we create a custom config file named `hcdiag.hcl` with the following content:
+
+```
+product "consul" {
+  command {
+    run = "consul members"
+    format = "string"
+  }
+
+  command {
+    run = "consul operator raft list-peers"
+    format = "string"
+  }
+
+  // You could copy files with -includes as well
+  command {
+    run = "cat /etc/consul.d/example.hcl"
+    format = "string"
+  }
+
+  // if you want specific journalctl flags, you can use a command:
+  command {
+    run = "journalctl -u consul --since=yesterday --output=json"
+    format = "json"
+  }
+
+}
+```
+
+Then, a user can run hcdiag with the following command:
+
+```
+hcdiag -consul -config hcdiag.hcl
+```
+
+This will point hcdiag at your custom config file and execute your custom commands.
+
+
+### Collect additional Nomad information
+
+**Example:** we want to run a custom `nomad operator debug` command, instead of the built-in. Our command should run with log-level `DEBUG` and return unlimited nodes.
+
+Create a custom config file named `hcdiag.hcl` with the following content:
+
+```
+product "nomad" {
+  command {
+    run = "nomad operator debug -log-level=DEBUG -duration=20s -interval=10s -max-nodes=0"
+    format = "string"
+  }
+}
+```
+
+Run hcdiag with this config file:
+
+```
+hcdiag -nomad -debug-duration=0 -config hcdiag.hcl
+```
+
+This will point hcdiag at your custom config file and execute your custom command.
+
+**NOTE** The -debug-duration flag is here to suppress the built-in nomad debug command, preventing the built-in version of the `nomad operator debug` command from being run, and a second nomad-debug archive being created in your hcdiag bundle.

--- a/docs/custom-config.md
+++ b/docs/custom-config.md
@@ -79,7 +79,7 @@ Read more about them [here](./redactions.md).
 * The Consul memberlist: `consul members`
 * Raft peer information: `consul operator raft list-peers`
 * A custom journalctl command that's different from the builtin: `journalctl -u consul --since=yesterday --output=json`
-* another custom command (in this case, just running `cat` to collect a file's contents into the bundle `Results.json` file with no redactions).
+* Another custom command (in this case, just running `cat` to collect a file's contents into the bundle `Results.json` file with no redactions)
 
 To do this, we create a custom config file named `hcdiag.hcl` with the following content:
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,6 +2,10 @@
 
 Depending on the context you're using hcdiag in, you may have some questions about the tool. Here are questions we see frequently.
 
+### I want hcdiag to gather information from all nodes in a cluster (servers and clients)!
+
+hcdiag is a binary that runs on one host at a time. As a result, each run collects data from that host, and that host alone. If you want to gather information from multiple hosts, e.g. client *and* server config files, you’ll need to run hcdiag on those hosts separately.
+
 ### Why is hcdiag checking for all HashiCorp products when I only want one?
 
 We heard feedback from `hcdiag` users that the default behavior, with no flags provided, could be confusing. In that case,


### PR DESCRIPTION
This PR adds:

- a spelling fix with one example of `-includes`
- custom config examples from the last few weeks of working with users
- a FAQ addition that points out that hcdiag is a single-host binary, and does not collect information from more than one host at a time.