### PR TITLE
Track Runner Durations

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -246,7 +246,8 @@ func (a *Agent) TempDir() string {
 }
 
 // CreateTemp Creates a temporary directory so that we may gather results and files before compressing the final
-//  artifact.
+//
+//	artifact.
 func (a *Agent) CreateTemp() error {
 	tmp, err := os.MkdirTemp(a.Config.Destination, a.TempDir())
 	if err != nil {
@@ -311,7 +312,8 @@ func (a *Agent) CopyIncludes() (err error) {
 
 // RunProducts executes all ops for this run.
 // TODO(mkcp): We can avoid locking and waiting on results if all results are generated async. Then they can get streamed
-//  back to the dispatcher and merged into either a sync.Map or a purpose-built results map with insert(), read(), and merge().
+//
+//	back to the dispatcher and merged into either a sync.Map or a purpose-built results map with insert(), read(), and merge().
 func (a *Agent) RunProducts() error {
 	// Set up our waitgroup to make sure we don't proceed until all products execute.
 	wg := sync.WaitGroup{}
@@ -356,10 +358,14 @@ func (a *Agent) RunProducts() error {
 func (a *Agent) RecordManifest() {
 	for name, ops := range a.results {
 		for _, o := range ops {
+			// duration string, in nanoseconds
+			dur := fmt.Sprintf("%d nanoseconds", o.EndTime.Sub(o.StartTime).Nanoseconds())
+
 			m := ManifestOp{
-				ID:     o.Identifier,
-				Error:  o.ErrString,
-				Status: o.Status,
+				ID:       o.Identifier,
+				Error:    o.ErrString,
+				Status:   o.Status,
+				Duration: dur,
 			}
 			a.ManifestOps[string(name)] = append(a.ManifestOps[string(name)], m)
 		}

--- a/agent/manifest.go
+++ b/agent/manifest.go
@@ -7,7 +7,8 @@ import (
 // ManifestOp provides a subset of op state, specifically excluding results, so we can safely render metadata
 // about ops without exposing customer info in manifest.json
 type ManifestOp struct {
-	ID     string    `json:"op"`
-	Error  string    `json:"error"`
-	Status op.Status `json:"status"`
+	ID       string    `json:"op"`
+	Error    string    `json:"error"`
+	Status   op.Status `json:"status"`
+	Duration string    `json:"duration"`
 }

--- a/op/op.go
+++ b/op/op.go
@@ -2,6 +2,7 @@ package op
 
 import (
 	"fmt"
+	"time"
 )
 
 // Status describes the result of an operation.
@@ -31,10 +32,12 @@ type Op struct {
 	Error      error                  `json:"-"`
 	Status     Status                 `json:"status"`
 	Params     map[string]interface{} `json:"params,omitempty"`
+	StartTime  time.Time              `json:"start_time"`
+	EndTime    time.Time              `json:"end_time"`
 }
 
 // New takes a runner its results, serializing it into an immutable Op struct.
-func New(id string, result interface{}, status Status, err error, params map[string]interface{}) Op {
+func New(id string, result interface{}, status Status, err error, params map[string]interface{}, start time.Time, end time.Time) Op {
 	// We store the error directly to make JSON serialization easier
 	var message string
 	if err != nil {
@@ -47,6 +50,8 @@ func New(id string, result interface{}, status Status, err error, params map[str
 		ErrString:  message,
 		Status:     status,
 		Params:     params,
+		StartTime:  start,
+		EndTime:    end,
 	}
 }
 

--- a/runner/copier.go
+++ b/runner/copier.go
@@ -49,6 +49,8 @@ func (c Copier) ID() string {
 
 // Run satisfies the Runner interface and copies the filtered source files to the destination.
 func (c Copier) Run() op.Op {
+	startTime := time.Now()
+
 	// Ensure destination directory exists
 	err := os.MkdirAll(c.DestDir, 0755)
 	if err != nil {
@@ -56,7 +58,7 @@ func (c Copier) Run() op.Op {
 			MakeDirError{
 				path: c.DestDir,
 				err:  err,
-			}, Params(c))
+			}, Params(c), startTime, time.Now())
 	}
 
 	// Find all the files
@@ -66,7 +68,7 @@ func (c Copier) Run() op.Op {
 			FindFilesError{
 				path: c.SourceDir,
 				err:  err,
-			}, Params(c))
+			}, Params(c), startTime, time.Now())
 	}
 
 	// Copy the files
@@ -78,11 +80,11 @@ func (c Copier) Run() op.Op {
 					dest:  c.DestDir,
 					files: files,
 					err:   err,
-				}, Params(c))
+				}, Params(c), startTime, time.Now())
 		}
 	}
 
-	return op.New(c.ID(), files, op.Success, nil, Params(c))
+	return op.New(c.ID(), files, op.Success, nil, Params(c), startTime, time.Now())
 }
 
 type MakeDirError struct {

--- a/runner/host/disk.go
+++ b/runner/host/disk.go
@@ -2,6 +2,7 @@ package host
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/hcdiag/op"
 	"github.com/hashicorp/hcdiag/redact"
@@ -39,22 +40,23 @@ func (d Disk) ID() string {
 
 func (d Disk) Run() op.Op {
 	var partitions []Partition
+	startTime := time.Now()
 
 	dp, err := disk.Partitions(true)
 	if err != nil {
 		hclog.L().Trace("runner/host.Disk.Run()", "error", err)
 		err1 := fmt.Errorf("error getting disk information err=%w", err)
-		return op.New(d.ID(), partitions, op.Unknown, err1, nil)
+		return op.New(d.ID(), partitions, op.Unknown, err1, nil, startTime, time.Now())
 	}
 
 	partitions, err = d.partitions(dp)
 	if err != nil {
 		hclog.L().Trace("runner/host.Disk.Run() failed to convert partition info", "error", err)
 		err1 := fmt.Errorf("error converting partition information err=%w", err)
-		return op.New(d.ID(), partitions, op.Fail, err1, nil)
+		return op.New(d.ID(), partitions, op.Fail, err1, nil, startTime, time.Now())
 	}
 
-	return op.New(d.ID(), partitions, op.Success, nil, nil)
+	return op.New(d.ID(), partitions, op.Success, nil, nil, startTime, time.Now())
 }
 
 func (d Disk) partitions(dps []disk.PartitionStat) ([]Partition, error) {

--- a/runner/host/etc_hosts.go
+++ b/runner/host/etc_hosts.go
@@ -3,6 +3,7 @@ package host
 import (
 	"fmt"
 	"runtime"
+	"time"
 
 	"github.com/hashicorp/hcdiag/op"
 	"github.com/hashicorp/hcdiag/redact"
@@ -29,14 +30,16 @@ func (r EtcHosts) ID() string {
 }
 
 func (r EtcHosts) Run() op.Op {
+	startTime := time.Now()
+
 	// Not compatible with windows
 	if r.OS == "windows" {
 		err := fmt.Errorf(" EtcHosts.Run() not available on os, os=%s", r.OS)
-		return op.New(r.ID(), nil, op.Skip, err, runner.Params(r))
+		return op.New(r.ID(), nil, op.Skip, err, runner.Params(r), startTime, time.Now())
 	}
 	s := runner.NewSheller("cat /etc/hosts", r.Redactions).Run()
 	if s.Error != nil {
-		return op.New(r.ID(), s.Result, op.Fail, s.Error, runner.Params(r))
+		return op.New(r.ID(), s.Result, op.Fail, s.Error, runner.Params(r), startTime, time.Now())
 	}
-	return op.New(r.ID(), s.Result, op.Success, nil, runner.Params(r))
+	return op.New(r.ID(), s.Result, op.Success, nil, runner.Params(r), startTime, time.Now())
 }

--- a/runner/host/fstab.go
+++ b/runner/host/fstab.go
@@ -2,6 +2,7 @@ package host
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/hcdiag/op"
 	"github.com/hashicorp/hcdiag/redact"
@@ -28,14 +29,16 @@ func (r FSTab) ID() string {
 }
 
 func (r FSTab) Run() op.Op {
+	startTime := time.Now()
+
 	// Only Linux is supported currently; Windows is unsupported, and Darwin doesn't use /etc/fstab by default.
 	if r.OS != "linux" {
-		return op.New(r.ID(), nil, op.Skip, fmt.Errorf("FSTab.Run() not available on os, os=%s", r.OS), runner.Params(r))
+		return op.New(r.ID(), nil, op.Skip, fmt.Errorf("FSTab.Run() not available on os, os=%s", r.OS), runner.Params(r), startTime, time.Now())
 	}
 	o := r.Sheller.Run()
 	if o.Error != nil {
-		return op.New(r.ID(), o.Result, op.Fail, o.Error, runner.Params(r))
+		return op.New(r.ID(), o.Result, op.Fail, o.Error, runner.Params(r), startTime, time.Now())
 	}
 
-	return op.New(r.ID(), o.Result, op.Success, nil, runner.Params(r))
+	return op.New(r.ID(), o.Result, op.Success, nil, runner.Params(r), startTime, time.Now())
 }

--- a/runner/host/get.go
+++ b/runner/host/get.go
@@ -2,6 +2,7 @@ package host
 
 import (
 	"strings"
+	"time"
 
 	"github.com/hashicorp/hcdiag/redact"
 
@@ -29,10 +30,12 @@ func (g Get) ID() string {
 }
 
 func (g Get) Run() op.Op {
+	startTime := time.Now()
+
 	cmd := strings.Join([]string{"curl -s", g.Path}, " ")
 	// NOTE(mkcp): We will get JSON back from a lot of requests, so this can be improved
 	format := "string"
 	o := runner.NewCommander(cmd, format, g.Redactions).Run()
-	return op.New(g.ID(), o.Result, o.Status, o.Error, runner.Params(g))
+	return op.New(g.ID(), o.Result, o.Status, o.Error, runner.Params(g), startTime, time.Now())
 
 }

--- a/runner/host/info.go
+++ b/runner/host/info.go
@@ -2,6 +2,7 @@ package host
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcdiag/op"
@@ -46,22 +47,24 @@ func (i Info) ID() string {
 }
 
 func (i Info) Run() op.Op {
+	startTime := time.Now()
+
 	// third party
 	var hostInfo InfoStat
 	hi, err := host.Info()
 	if err != nil {
 		hclog.L().Trace("runner/host.Info.Run()", "error", err)
-		return op.New(i.ID(), hostInfo, op.Fail, err, nil)
+		return op.New(i.ID(), hostInfo, op.Fail, err, nil, startTime, time.Now())
 	}
 
 	hostInfo, err = i.infoStat(hi)
 	if err != nil {
 		hclog.L().Trace("runner/host.Info.Run() failed to convert host info", "error", err)
 		err1 := fmt.Errorf("error converting host information err=%w", err)
-		return op.New(i.ID(), hostInfo, op.Fail, err1, nil)
+		return op.New(i.ID(), hostInfo, op.Fail, err1, nil, startTime, time.Now())
 	}
 
-	return op.New(i.ID(), hostInfo, op.Success, nil, nil)
+	return op.New(i.ID(), hostInfo, op.Success, nil, nil, startTime, time.Now())
 }
 
 func (i Info) infoStat(hi *host.InfoStat) (InfoStat, error) {

--- a/runner/host/iptables.go
+++ b/runner/host/iptables.go
@@ -3,6 +3,7 @@ package host
 import (
 	"fmt"
 	"runtime"
+	"time"
 
 	"github.com/hashicorp/hcdiag/op"
 	"github.com/hashicorp/hcdiag/redact"
@@ -34,8 +35,10 @@ func (r IPTables) ID() string {
 }
 
 func (r IPTables) Run() op.Op {
+	startTime := time.Now()
+
 	if runtime.GOOS != "linux" {
-		return op.New(r.ID(), nil, op.Skip, fmt.Errorf("os not linux, skipping, os=%s", runtime.GOOS), runner.Params(r))
+		return op.New(r.ID(), nil, op.Skip, fmt.Errorf("os not linux, skipping, os=%s", runtime.GOOS), runner.Params(r), startTime, time.Now())
 	}
 	result := make(map[string]string)
 	for _, c := range r.Commands {
@@ -47,8 +50,8 @@ func (r IPTables) Run() op.Op {
 
 		if o.Error != nil {
 			// If there's an error, pass through the Op's status and Error
-			return op.New(r.ID(), result, o.Status, o.Error, runner.Params(r))
+			return op.New(r.ID(), result, o.Status, o.Error, runner.Params(r), startTime, time.Now())
 		}
 	}
-	return op.New(r.ID(), result, op.Success, nil, runner.Params(r))
+	return op.New(r.ID(), result, op.Success, nil, runner.Params(r), startTime, time.Now())
 }

--- a/runner/host/memory.go
+++ b/runner/host/memory.go
@@ -1,6 +1,8 @@
 package host
 
 import (
+	"time"
+
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcdiag/op"
 	"github.com/hashicorp/hcdiag/runner"
@@ -17,11 +19,13 @@ func (m Memory) ID() string {
 
 // Run calls out to mem.VirtualMemory
 func (m Memory) Run() op.Op {
+	startTime := time.Now()
+
 	memoryInfo, err := mem.VirtualMemory()
 	if err != nil {
 		hclog.L().Trace("runner/host.Memory.Run()", "error", err)
-		return op.New(m.ID(), memoryInfo, op.Fail, err, nil)
+		return op.New(m.ID(), memoryInfo, op.Fail, err, nil, startTime, time.Now())
 	}
 
-	return op.New(m.ID(), memoryInfo, op.Success, nil, nil)
+	return op.New(m.ID(), memoryInfo, op.Success, nil, nil, startTime, time.Now())
 }

--- a/runner/host/network.go
+++ b/runner/host/network.go
@@ -2,6 +2,7 @@ package host
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcdiag/op"
@@ -37,11 +38,12 @@ func (n Network) ID() string {
 }
 
 func (n Network) Run() op.Op {
+	startTime := time.Now()
 	var interfaces []NetworkInterface
 	netIfs, err := net.Interfaces()
 	if err != nil {
 		hclog.L().Trace("runner/host.Network.Run()", "error", err)
-		return op.New(n.ID(), interfaces, op.Fail, err, nil)
+		return op.New(n.ID(), interfaces, op.Fail, err, nil, startTime, time.Now())
 	}
 
 	for _, netIf := range netIfs {
@@ -49,12 +51,12 @@ func (n Network) Run() op.Op {
 		if err != nil {
 			hclog.L().Trace("runner/host.Network.Run()", "error", err)
 			err1 := fmt.Errorf("error converting network information err=%w", err)
-			return op.New(n.ID(), interfaces, op.Fail, err1, nil)
+			return op.New(n.ID(), interfaces, op.Fail, err1, nil, startTime, time.Now())
 		}
 		interfaces = append(interfaces, ifce)
 	}
 
-	return op.New(n.ID(), interfaces, op.Success, nil, nil)
+	return op.New(n.ID(), interfaces, op.Success, nil, nil, startTime, time.Now())
 }
 
 func (n Network) networkInterface(nis net.InterfaceStat) (NetworkInterface, error) {

--- a/runner/host/os.go
+++ b/runner/host/os.go
@@ -1,6 +1,8 @@
 package host
 
 import (
+	"time"
+
 	"github.com/hashicorp/hcdiag/op"
 	"github.com/hashicorp/hcdiag/redact"
 	"github.com/hashicorp/hcdiag/runner"
@@ -33,8 +35,9 @@ func (o OS) ID() string {
 
 // Run calls the given OS utility to get information on the operating system
 func (o OS) Run() op.Op {
+	startTime := time.Now()
 	// NOTE(mkcp): This runner can be made consistent between multiple operating systems if we parse the output of
 	//   systeminfo to match uname's scope of concerns.
 	c := runner.NewCommander(o.Command, "string", o.Redactions).Run()
-	return op.New(o.ID(), c.Result, c.Status, c.Error, runner.Params(o))
+	return op.New(o.ID(), c.Result, c.Status, c.Error, runner.Params(o), startTime, time.Now())
 }

--- a/runner/host/proc_file.go
+++ b/runner/host/proc_file.go
@@ -2,6 +2,7 @@ package host
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/hcdiag/op"
 	"github.com/hashicorp/hcdiag/redact"
@@ -35,16 +36,18 @@ func (p ProcFile) ID() string {
 }
 
 func (p ProcFile) Run() op.Op {
+	startTime := time.Now()
+
 	if p.OS != "linux" {
-		return op.New(p.ID(), nil, op.Skip, fmt.Errorf("os not linux, skipping, os=%s", p.OS), runner.Params(p))
+		return op.New(p.ID(), nil, op.Skip, fmt.Errorf("os not linux, skipping, os=%s", p.OS), runner.Params(p), startTime, time.Now())
 	}
 	m := make(map[string]interface{})
 	for _, c := range p.Commands {
 		sheller := runner.NewSheller(c, p.Redactions).Run()
 		m[c] = sheller.Result
 		if sheller.Error != nil {
-			return op.New(p.ID(), m, op.Fail, sheller.Error, runner.Params(p))
+			return op.New(p.ID(), m, op.Fail, sheller.Error, runner.Params(p), startTime, time.Now())
 		}
 	}
-	return op.New(p.ID(), m, op.Success, nil, runner.Params(p))
+	return op.New(p.ID(), m, op.Success, nil, runner.Params(p), startTime, time.Now())
 }

--- a/runner/host/processes.go
+++ b/runner/host/processes.go
@@ -1,6 +1,8 @@
 package host
 
 import (
+	"time"
+
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcdiag/op"
 	"github.com/hashicorp/hcdiag/redact"
@@ -33,21 +35,22 @@ func (p Process) ID() string {
 }
 
 func (p Process) Run() op.Op {
+	startTime := time.Now()
 	var procs []Proc
 
 	psProcs, err := ps.Processes()
 	if err != nil {
 		hclog.L().Trace("runner/host.Process.Run()", "error", err)
-		return op.New(p.ID(), procs, op.Fail, err, nil)
+		return op.New(p.ID(), procs, op.Fail, err, nil, startTime, time.Now())
 	}
 
 	procs, err = p.procs(psProcs)
 	if err != nil {
 		hclog.L().Trace("runner/host.Process.Run()", "error", err)
-		return op.New(p.ID(), procs, op.Fail, err, nil)
+		return op.New(p.ID(), procs, op.Fail, err, nil, startTime, time.Now())
 	}
 
-	return op.New(p.ID(), procs, op.Success, nil, nil)
+	return op.New(p.ID(), procs, op.Success, nil, nil, startTime, time.Now())
 }
 
 func (p Process) procs(psProcs []ps.Process) ([]Proc, error) {

--- a/runner/httper.go
+++ b/runner/httper.go
@@ -1,6 +1,8 @@
 package runner
 
 import (
+	"time"
+
 	"github.com/hashicorp/hcdiag/client"
 	"github.com/hashicorp/hcdiag/op"
 	"github.com/hashicorp/hcdiag/redact"
@@ -29,11 +31,13 @@ func (h HTTPer) ID() string {
 
 // Run executes a GET request to the Path using the Client
 func (h HTTPer) Run() op.Op {
+	startTime := time.Now()
+
 	result, err := h.Client.RedactGet(h.Path, h.Redactions)
 	if err != nil {
-		op.New(h.ID(), result, op.Fail, err, Params(h))
+		op.New(h.ID(), result, op.Fail, err, Params(h), startTime, time.Now())
 	}
 
 	// Check type of result to see if we can return a redacted result in the op
-	return op.New(h.ID(), result, op.Success, nil, Params(h))
+	return op.New(h.ID(), result, op.Success, nil, Params(h), startTime, time.Now())
 }

--- a/runner/log/docker.go
+++ b/runner/log/docker.go
@@ -39,6 +39,8 @@ func (d Docker) ID() string {
 
 // Run executes the runner
 func (d Docker) Run() op.Op {
+	startTime := time.Now()
+
 	// Check that docker exists
 	o := runner.NewSheller("docker version", d.Redactions).Run()
 	if o.Error != nil {
@@ -46,7 +48,7 @@ func (d Docker) Run() op.Op {
 			container: d.Container,
 			err:       o.Error,
 		},
-			runner.Params(d))
+			runner.Params(d), startTime, time.Now())
 	}
 
 	// Check whether the container can be found on the system
@@ -54,17 +56,17 @@ func (d Docker) Run() op.Op {
 		return op.New(d.ID(), "", op.Skip, ContainerNotFoundError{
 			container: d.Container,
 		},
-			runner.Params(d))
+			runner.Params(d), startTime, time.Now())
 	}
 
 	// Retrieve logs
 	cmd := DockerLogCmd(d.Container, d.DestDir, d.Since)
 	o = runner.NewSheller(cmd, d.Redactions).Run()
 	if o.Error != nil {
-		return op.New(d.ID(), o.Result, o.Status, o.Error, runner.Params(d))
+		return op.New(d.ID(), o.Result, o.Status, o.Error, runner.Params(d), startTime, time.Now())
 	}
 
-	return op.New(d.ID(), o.Result, op.Success, nil, runner.Params(d))
+	return op.New(d.ID(), o.Result, op.Success, nil, runner.Params(d), startTime, time.Now())
 }
 
 func DockerLogCmd(container, destDir string, since time.Time) string {

--- a/runner/sheller.go
+++ b/runner/sheller.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"fmt"
 	"os/exec"
+	"time"
 
 	"github.com/hashicorp/hcdiag/redact"
 
@@ -32,10 +33,12 @@ func (s Sheller) ID() string {
 
 // Run ensures a shell exists and optimistically executes the given Command string
 func (s Sheller) Run() op.Op {
+	startTime := time.Now()
+
 	// Read the shell from the environment
 	shell, err := util.GetShell()
 	if err != nil {
-		return op.New(s.ID(), nil, op.Fail, err, Params(s))
+		return op.New(s.ID(), nil, op.Fail, err, Params(s), startTime, time.Now())
 	}
 	s.Shell = shell
 
@@ -46,16 +49,16 @@ func (s Sheller) Run() op.Op {
 	redBts, redErr := redact.Bytes(bts, s.Redactions)
 	// Fail run if unable to redact
 	if redErr != nil {
-		return op.New(s.ID(), nil, op.Fail, redErr, Params(s))
+		return op.New(s.ID(), nil, op.Fail, redErr, Params(s), startTime, time.Now())
 	}
 	if cmdErr != nil {
 		return op.New(s.ID(), string(redBts), op.Unknown,
 			ShellExecError{
 				command: s.Command,
 				err:     cmdErr,
-			}, Params(s))
+			}, Params(s), startTime, time.Now())
 	}
-	return op.New(s.ID(), string(redBts), op.Success, nil, Params(s))
+	return op.New(s.ID(), string(redBts), op.Success, nil, Params(s), startTime, time.Now())
 }
 
 type ShellExecError struct {


### PR DESCRIPTION
Adds start and end times to all runners, and writes each op's duration (in ns) to manifest.

I originally thought about doing something fancy from outside the runners to save lines of code, but I think this ended up cleaner.

Ops now have a StartTime and EndTime, and all the runners have the same change at each possible return:

```
startTime := time.Now()
...
return Op.New(..., startTime, time.Now())
```

The duration for each Op (currently in nanoseconds, because host runners are really fast) is added to Manifest.json.