### PR TITLE
fix extra spaces in go comments

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -243,7 +243,7 @@ func (a *Agent) TempDir() string {
 }
 
 // CreateTemp Creates a temporary directory so that we may gather results and files before compressing the final
-//  artifact.
+// artifact.
 func (a *Agent) CreateTemp() error {
 	tmp, err := os.MkdirTemp(a.Config.Destination, a.TempDir())
 	if err != nil {
@@ -308,7 +308,7 @@ func (a *Agent) CopyIncludes() (err error) {
 
 // RunProducts executes all ops for this run.
 // TODO(mkcp): We can avoid locking and waiting on results if all results are generated async. Then they can get streamed
-//  back to the dispatcher and merged into either a sync.Map or a purpose-built results map with insert(), read(), and merge().
+// back to the dispatcher and merged into either a sync.Map or a purpose-built results map with insert(), read(), and merge().
 func (a *Agent) RunProducts() error {
 	// Set up our waitgroup to make sure we don't proceed until all products execute.
 	wg := sync.WaitGroup{}

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -377,7 +377,7 @@ func mapDockerLogs(cfgs []DockerLog, dest string, since time.Time, redactions []
 				return nil, err
 			}
 			// TODO(mkcp): Adding an agent.Now would help us pass an absolute now into this function. There's a subtle
-			//  bug: different runners have different now values but it's unlikely to ever cause an issues for users.
+			// bug: different runners have different now values but it's unlikely to ever cause an issues for users.
 			since = time.Now().Add(-dur)
 		}
 		runners[i] = log.NewDocker(d.Container, dest, since, runnerRedacts)
@@ -402,7 +402,7 @@ func mapJournaldLogs(cfgs []JournaldLog, dest string, since, until time.Time, re
 				return nil, err
 			}
 			// TODO(mkcp): Adding an agent.Now would help us pass an absolute now into this function. There's a subtle
-			//  bug: different runners have different now values but it's unlikely to ever cause an issues for users.
+			// bug: different runners have different now values but it's unlikely to ever cause an issues for users.
 			now := time.Now()
 			since = now.Add(dur)
 			until = time.Time{}

--- a/op/op.go
+++ b/op/op.go
@@ -15,8 +15,8 @@ const (
 	Fail Status = "fail"
 
 	// Unknown means that we detected an error and the result is indeterminate (e.g. some side effect like disk or
-	//   network may or may not have completed) or we don't recognize the error. If we don't recognize the error that's
-	//   a signal to improve the error handling to account for it.
+	// network may or may not have completed) or we don't recognize the error. If we don't recognize the error that's
+	// a signal to improve the error handling to account for it.
 	Unknown Status = "unknown"
 
 	// Skip means that this Op was intentionally not run

--- a/product/nomad.go
+++ b/product/nomad.go
@@ -43,8 +43,8 @@ func NewNomad(logger hclog.Logger, cfg Config) (*Product, error) {
 
 	// Apply nomad duration and interval default if CLI is using global defaults.
 	// NOTE(mkcp): The downside to this approach is that Nomad cannot be run with a 10s duration and 5s interval.
-	//  passing in a zero value from the agent would allow us to do that, but the flags library requires a default value
-	//  to be set in order to _show_ that default to the user, so we have to set the agent with that default.
+	// passing in a zero value from the agent would allow us to do that, but the flags library requires a default value
+	// to be set in order to _show_ that default to the user, so we have to set the agent with that default.
 	if DefaultDuration == cfg.DebugDuration {
 		cfg.DebugDuration = NomadDebugDuration
 	}

--- a/redact/redact.go
+++ b/redact/redact.go
@@ -83,7 +83,7 @@ func Apply(redactions []*Redact, w io.Writer, r io.Reader) error {
 // String takes a string result and a slice of redactions, and wraps it with a reader and writer to apply the
 // redactions, returning a string back.
 // TODO(mkcp): Speed improvement & out of memory error: JSON responses can be really big, so we're going to have to
-//  chunk extremely large strings down.
+// chunk extremely large strings down.
 func String(result string, redactions []*Redact) (string, error) {
 	if len(redactions) == 0 {
 		return result, nil
@@ -101,7 +101,7 @@ func String(result string, redactions []*Redact) (string, error) {
 // Bytes takes a byte slice and a slice of redactions, and wraps it with a reader and writer to apply the
 // redactions, returning a string back.
 // TODO(mkcp): Speed improvement & out of memory error: JSON responses can be really big, so we're going to have to
-//  chunk extremely large byte arrays down.
+// chunk extremely large byte arrays down.
 func Bytes(b []byte, redactions []*Redact) ([]byte, error) {
 	if len(redactions) == 0 {
 		return b, nil

--- a/runner/host/os.go
+++ b/runner/host/os.go
@@ -34,7 +34,7 @@ func (o OS) ID() string {
 // Run calls the given OS utility to get information on the operating system
 func (o OS) Run() op.Op {
 	// NOTE(mkcp): This runner can be made consistent between multiple operating systems if we parse the output of
-	//   systeminfo to match uname's scope of concerns.
+	// systeminfo to match uname's scope of concerns.
 	c := runner.NewCommander(o.Command, "string", o.Redactions).Run()
 	return op.New(o.ID(), c.Result, c.Status, c.Error, runner.Params(o))
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -19,8 +19,8 @@ type Runner interface {
 // Exclude takes a slice of matcher strings and a slice of ops. If any of the runner identifiers match the exclude
 // according to filepath.Match() then it will not be present in the returned runner slice.
 // NOTE(mkcp): This is precisely identical to Select() except we flip the match check. Maybe we can perform both rounds
-//  of filtering in one pass one rather than iterating over all the ops several times. Not likely to be a huge speed
-//  increase though... we're not even remotely bottlenecked on runner filtering.
+// of filtering in one pass one rather than iterating over all the ops several times. Not likely to be a huge speed
+// increase though... we're not even remotely bottlenecked on runner filtering.
 func Exclude(excludes []string, runners []Runner) ([]Runner, error) {
 	newRunners := make([]Runner, 0)
 	for _, r := range runners {

--- a/version/version.go
+++ b/version/version.go
@@ -10,7 +10,6 @@ const (
 
 var (
 	// version is the main version number that is being run at the moment.
-	//
 	// version must be of the format <MAJOR>.<MINOR>.<PATCH>, as described in the semantic versioning specification.
 	version = "0.5.0"
 
@@ -68,7 +67,6 @@ func (v Version) SemanticVersion() string {
 }
 
 // FullVersionNumber produces a human-readable string representation of the Version object.
-//
 // In addition to a short slug that includes the product name (hcdiag) and the semantic version,
 // the Revision will be included if the optional argument, `rev`, is true. Further, if a buildDate
 // is set, it is also included in the output.


### PR DESCRIPTION
These spaces mess with Go's automatic documentation formatting, so I've removed them.