### PR TITLE
Count nested operations in StatusCounts

### DIFF
--- a/changelog/245.txt
+++ b/changelog/245.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+op: add op.WalkStatuses(), which recursively walks a tree of result ops to accumulate statuscounts.
+```

--- a/op/op.go
+++ b/op/op.go
@@ -59,7 +59,8 @@ func StatusCounts(ops map[string]Op) (map[Status]int, error) {
 	}
 
 	// Create our accumulator and Walk ops
-	acc := make(map[Status]int, 0)
+	// We'll always have at least len(ops) Ops; more if there are nested Ops
+	acc := make(map[Status]int, len(ops))
 	statuses := WalkStatuses(acc, m)
 
 	if val, ok := statuses[""]; ok {

--- a/op/op_test.go
+++ b/op/op_test.go
@@ -59,20 +59,17 @@ func Test_WalkStatuses(t *testing.T) {
 		desc   string
 		opMap  map[string]any
 		expect map[Status]int
-		result map[Status]int
 	}{
 		{
 			desc:   "Empty case",
 			opMap:  map[string]any{},
 			expect: map[Status]int{},
-			result: make(map[Status]int, 0),
 		},
 		{
 			desc: "Walk a single nested Op",
 			opMap: map[string]any{
 				"1": map[string]any{"1-nested": Op{Status: Success, Result: map[string]any{"foo": "bar"}}}},
 			expect: map[Status]int{Success: 1},
-			result: make(map[Status]int, 0),
 		},
 		{
 			desc: "Walk multiple nested Ops",
@@ -87,13 +84,12 @@ func Test_WalkStatuses(t *testing.T) {
 				},
 			},
 			expect: map[Status]int{Success: 5},
-			result: make(map[Status]int, 0),
 		},
 	}
 
 	for _, tc := range testTable {
 		t.Run(tc.desc, func(t *testing.T) {
-			result := WalkStatuses(tc.result, tc.opMap)
+			result := WalkStatuses(tc.opMap)
 			assert.Equal(t, tc.expect, result)
 		})
 	}

--- a/op/op_test.go
+++ b/op/op_test.go
@@ -53,3 +53,48 @@ func Test_StatusCounts(t *testing.T) {
 		})
 	}
 }
+
+func Test_WalkStatuses(t *testing.T) {
+	testTable := []struct {
+		desc   string
+		opMap  map[string]any
+		expect map[Status]int
+		result map[Status]int
+	}{
+		{
+			desc:   "Empty case",
+			opMap:  map[string]any{},
+			expect: map[Status]int{},
+			result: make(map[Status]int, 0),
+		},
+		{
+			desc: "Walk a single nested Op",
+			opMap: map[string]any{
+				"1": map[string]any{"1-nested": Op{Status: Success, Result: map[string]any{"foo": "bar"}}}},
+			expect: map[Status]int{Success: 1},
+			result: make(map[Status]int, 0),
+		},
+		{
+			desc: "Walk multiple nested Ops",
+			opMap: map[string]any{
+				"0-flat": Op{Status: Success, Result: map[string]any{"already": "flat"}},
+				"1": map[string]any{
+					"1-nested": Op{Status: Success, Result: map[string]any{"foo": "bar"}},
+					"1-nested-2": Op{Status: Success, Result: map[string]any{
+						"2-nested":   Op{Status: Success, Result: map[string]any{"foo": "bar"}},
+						"2-nested-2": Op{Status: Success, Result: map[string]any{"qux": "schnarg"}},
+					}},
+				},
+			},
+			expect: map[Status]int{Success: 5},
+			result: make(map[Status]int, 0),
+		},
+	}
+
+	for _, tc := range testTable {
+		t.Run(tc.desc, func(t *testing.T) {
+			result := WalkStatuses(tc.result, tc.opMap)
+			assert.Equal(t, tc.expect, result)
+		})
+	}
+}


### PR DESCRIPTION
This change adds op.WalkStatuses(), which recursively walks a tree of result ops to get statuses.