### PR TITLE
add list-nodes to TFE runner

### DIFF
--- a/changelog/247.txt
+++ b/changelog/247.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+runner: Add a TFE command to collect the list of active nodes
+```

--- a/product/tfe.go
+++ b/product/tfe.go
@@ -81,6 +81,7 @@ func tfeRunners(cfg Config, api *client.APIClient) ([]runner.Runner, error) {
 		runner.NewCommander("replicatedctl app-config view -o json --group blob", "json", cfg.Redactions),
 		runner.NewCommander("replicatedctl app-config view -o json --group worker_image", "json", cfg.Redactions),
 		runner.NewCommander("replicatedctl params export --template '{{.Airgap}}'", "string", cfg.Redactions),
+		runner.NewCommander("replicated --no-tty admin list-nodes", "json", cfg.Redactions),
 
 		runner.NewSheller("getenforce", cfg.Redactions),
 		runner.NewSheller("env | grep -i proxy", cfg.Redactions),


### PR DESCRIPTION
[Jira TF-553](https://hashicorp.atlassian.net/browse/TF-553)
This branch adds a new runner to tfeRunners to collect the list of active nodes on the TFE installation.

Big thanks to @nwchandler for troubleshooting the issue #187 on a TFE instance to [get to the bottom of it](https://hashicorp.atlassian.net/browse/DIAG-48?focusedCommentId=105567)! Much appreciated!! 

The output now looks like I'd expect it to:

```json
        "replicated --no-tty admin list-nodes": {
            "result": {
                "json": [
                    "10.0.32.4"
                ]
            },
            "error": "",
            "status": "success",
            "params": {
                "command": "replicated --no-tty admin list-nodes",
                "format": "json",
                "redactions": [
                    { <truncated> }
                ]
            },
            "start": "2022-10-10T20:48:30.169414448Z",
            "end": "2022-10-10T20:48:30.516962671Z"
        },
```