### PR TITLE
Skip Displaying Run Summary on Dry Runs

### DIFF
--- a/command/run.go
+++ b/command/run.go
@@ -189,10 +189,12 @@ func (c *RunCommand) Run(args []string) int {
 		return AgentExecutionError
 	}
 
-	resultsFile := a.ResultsDest()
-	if err = writeSummary(os.Stdout, resultsFile, a.ManifestOps); err != nil {
-		l.Warn("failed to generate report summary; please review output files to ensure everything expected is present", "err", err)
-		return RunError
+	if !c.dryrun {
+		resultsFile := a.ResultsDest()
+		if err = writeSummary(os.Stdout, resultsFile, a.ManifestOps); err != nil {
+			l.Warn("failed to generate report summary; please review output files to ensure everything expected is present", "err", err)
+			return RunError
+		}
 	}
 
 	return Success

--- a/command/run.go
+++ b/command/run.go
@@ -189,12 +189,15 @@ func (c *RunCommand) Run(args []string) int {
 		return AgentExecutionError
 	}
 
-	if !c.dryrun {
-		resultsFile := a.ResultsDest()
-		if err = writeSummary(os.Stdout, resultsFile, a.ManifestOps); err != nil {
-			l.Warn("failed to generate report summary; please review output files to ensure everything expected is present", "err", err)
-			return RunError
-		}
+	// Skip any post-processing/reporting on dry runs because there are no results to handle
+	if c.dryrun {
+		return Success
+	}
+
+	resultsFile := a.ResultsDest()
+	if err = writeSummary(os.Stdout, resultsFile, a.ManifestOps); err != nil {
+		l.Warn("failed to generate report summary; please review output files to ensure everything expected is present", "err", err)
+		return RunError
 	}
 
 	return Success


### PR DESCRIPTION
This merge addresses a UX bug introduced in #222 . With the changes introduced there, we began displaying a summary report at the end of dry runs, however the output was nonsensical because no runners had executed, and no results were written to disk. This change puts some condition checking in place to ensure we do not write the output summary when a user does a dry run.