### PR TITLE
Add Timeout Runner Meta Struct

### DIFF
--- a/changelog/258.txt
+++ b/changelog/258.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+runners: Add a Timeout meta struct, which other runners can embed. This is in support of implementing timeouts on runners.
+```

--- a/runner/timeout.go
+++ b/runner/timeout.go
@@ -1,0 +1,18 @@
+package runner
+
+import (
+	"context"
+	"time"
+)
+
+// Timeout is an embeddable struct that includes the structural elements required for an embedding runner
+// to implement cancellation/timeouts. The embedding struct still needs to use this data to implement such
+// functionality, but the intention is for this struct to help ensure that runners that support timeouts will use
+// similar field names, which are reported consistently in result output.
+type Timeout struct {
+	// Context is the base context that the runner should use.
+	Context context.Context `json:"-"`
+
+	// Timeout is the maximum duration that the runner should run.
+	Timeout time.Duration `json:"timeout"`
+}


### PR DESCRIPTION
This adds the Timeout runner struct, which can be embedded in other runners in support of implementing timeout functionality.