### PR TITLE
Add Timeout and Canceled Statuses

### DIFF
--- a/changelog/259.txt
+++ b/changelog/259.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+op: Add op statuses "Canceled" and "Timeout" to support the addition of runner cancellation/timeout.
+```

--- a/command/run.go
+++ b/command/run.go
@@ -330,6 +330,8 @@ func writeSummary(writer io.Writer, resultsFile string, manifestOps map[string][
 		string(op.Success),
 		string(op.Fail),
 		string(op.Skip),
+		string(op.Canceled),
+		string(op.Timeout),
 		string(op.Unknown),
 		"total",
 	}
@@ -348,7 +350,7 @@ func writeSummary(writer io.Writer, resultsFile string, manifestOps map[string][
 	sort.Strings(products)
 
 	for _, prod := range products {
-		var success, fail, skip, unknown int
+		var success, fail, skip, unknown, canceled, timeout int
 		ops := manifestOps[prod]
 
 		for _, o := range ops {
@@ -359,6 +361,10 @@ func writeSummary(writer io.Writer, resultsFile string, manifestOps map[string][
 				fail++
 			case op.Skip:
 				skip++
+			case op.Canceled:
+				canceled++
+			case op.Timeout:
+				timeout++
 			default:
 				unknown++
 			}
@@ -369,6 +375,8 @@ func writeSummary(writer io.Writer, resultsFile string, manifestOps map[string][
 			strconv.Itoa(success),
 			strconv.Itoa(fail),
 			strconv.Itoa(skip),
+			strconv.Itoa(canceled),
+			strconv.Itoa(timeout),
 			strconv.Itoa(unknown),
 			strconv.Itoa(len(ops))))
 		if err != nil {

--- a/command/run_test.go
+++ b/command/run_test.go
@@ -67,6 +67,12 @@ func Test_writeSummary(t *testing.T) {
 					{
 						Status: op.Unknown,
 					},
+					{
+						Status: op.Timeout,
+					},
+					{
+						Status: op.Timeout,
+					},
 				},
 				"nomad": {
 					{
@@ -77,6 +83,9 @@ func Test_writeSummary(t *testing.T) {
 					},
 					{
 						Status: op.Skip,
+					},
+					{
+						Status: op.Canceled,
 					},
 				},
 			},

--- a/command/testdata/writeSummary/Test Header Only.golden
+++ b/command/testdata/writeSummary/Test Header Only.golden
@@ -1,2 +1,2 @@
 The diagnostic run has completed. The results bundle can be found at <unknown>.
-product  success  fail  skip  unknown  total  
+product  success  fail  skip  canceled  timeout  unknown  total  

--- a/command/testdata/writeSummary/Test with Products.golden
+++ b/command/testdata/writeSummary/Test with Products.golden
@@ -1,4 +1,4 @@
 The diagnostic run has completed. The results bundle can be found at /this/is/a/test/path/bundle.tar.gz.
-product  success  fail  skip  unknown  total  
-consul   2        1     1     1        5      
-nomad    0        1     1     1        3      
+product  success  fail  skip  canceled  timeout  unknown  total  
+consul   2        1     1     0         2        1        7      
+nomad    0        1     1     1         0        1        4      

--- a/op/op.go
+++ b/op/op.go
@@ -22,6 +22,12 @@ const (
 
 	// Skip means that this Op was intentionally not run
 	Skip Status = "skip"
+
+	// Timeout means that an operation timed out during execution.
+	Timeout Status = "timeout"
+
+	// Canceled means that an operation was canceled during execution.
+	Canceled Status = "canceled"
 )
 
 // Op seeks information via its Runner then stores the results.


### PR DESCRIPTION
This merge adds two new op.Status constants, to prepare for timeouts: op.Timeout and op.Canceled. Additionally, the end-of-run report has been updated to include these new statuses as well so that they don't get displayed as "unknown."