### PR TITLE
add ~/bin/ directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@
 
 # Vagrant box files
 .vagrant
+
+# Built binaries, etc.
+bin/
+


### PR DESCRIPTION
Primary benefit: This will prevent accidental commits of built binaries.

Secondary benefit: It's also useful because it allows devs to mount the ~/bin directory into a test container, generate `hcdiag-$(date)` directories in there, and otherwise play around without having to worry about a subsequent `git add .` outside the container catching those files.