### PR TITLE
Enable Context Propagation from Agent to Products

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -472,7 +472,7 @@ func (a *Agent) Setup() error {
 	if a.Config.Consul {
 		cfg := baseCfg
 		cfg.HCL = hclProducts["consul"]
-		newConsul, err := product.NewConsul(a.l, cfg)
+		newConsul, err := product.NewConsulWithContext(a.ctx, a.l, cfg)
 		if err != nil {
 			return err
 		}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -492,7 +492,7 @@ func (a *Agent) Setup() error {
 	if a.Config.TFE {
 		cfg := baseCfg
 		cfg.HCL = hclProducts["terraform-ent"]
-		newTFE, err := product.NewTFE(a.l, cfg)
+		newTFE, err := product.NewTFEWithContext(a.ctx, a.l, cfg)
 		if err != nil {
 			return err
 		}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -510,7 +510,7 @@ func (a *Agent) Setup() error {
 	}
 
 	// Build host and assign it to the product map.
-	newHost, err := product.NewHost(a.l, baseCfg, a.Config.HCL.Host)
+	newHost, err := product.NewHostWithContext(a.ctx, a.l, baseCfg, a.Config.HCL.Host)
 	if err != nil {
 		return err
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -424,13 +424,13 @@ func (a *Agent) WriteOutput() (err error) {
 // CheckAvailable runs healthchecks for each enabled product
 func (a *Agent) CheckAvailable() error {
 	if a.Config.Consul {
-		err := product.CommandHealthCheck(product.ConsulClientCheck, product.ConsulAgentCheck)
+		err := product.CommandHealthCheckWithContext(a.ctx, product.ConsulClientCheck, product.ConsulAgentCheck)
 		if err != nil {
 			return err
 		}
 	}
 	if a.Config.Nomad {
-		err := product.CommandHealthCheck(product.NomadClientCheck, product.NomadAgentCheck)
+		err := product.CommandHealthCheckWithContext(a.ctx, product.NomadClientCheck, product.NomadAgentCheck)
 		if err != nil {
 			return err
 		}
@@ -439,7 +439,7 @@ func (a *Agent) CheckAvailable() error {
 	// if cfg.TFE {
 	// }
 	if a.Config.Vault {
-		err := product.CommandHealthCheck(product.VaultClientCheck, product.VaultAgentCheck)
+		err := product.CommandHealthCheckWithContext(a.ctx, product.VaultClientCheck, product.VaultAgentCheck)
 		if err != nil {
 			return err
 		}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -502,7 +502,7 @@ func (a *Agent) Setup() error {
 	if a.Config.Vault {
 		cfg := baseCfg
 		cfg.HCL = hclProducts["vault"]
-		newVault, err := product.NewVault(a.l, cfg)
+		newVault, err := product.NewVaultWithContext(a.ctx, a.l, cfg)
 		if err != nil {
 			return err
 		}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -482,7 +482,7 @@ func (a *Agent) Setup() error {
 	if a.Config.Nomad {
 		cfg := baseCfg
 		cfg.HCL = hclProducts["nomad"]
-		newNomad, err := product.NewNomad(a.l, cfg)
+		newNomad, err := product.NewNomadWithContext(a.ctx, a.l, cfg)
 		if err != nil {
 			return err
 		}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -36,7 +36,9 @@ func TestNewAgentIncludesBackgroundContext(t *testing.T) {
 }
 
 func TestNewAgentWithContext(t *testing.T) {
-	ctx, _ := context.WithTimeout(context.Background(), 20*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
 	a, err := NewAgentWithContext(ctx, Config{}, hclog.Default())
 	require.NoError(t, err, "Error new test Agent with context")
 	require.NotNil(t, a)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -156,7 +156,7 @@ func TestRunProducts(t *testing.T) {
 	a := newTestAgent(t)
 
 	a.products = p
-	h, err := product.NewHost(l, pCfg, &hcl.Host{})
+	h, err := product.NewHostWithContext(context.Background(), l, pCfg, &hcl.Host{})
 	assert.NoError(t, err)
 	p[product.Host] = h
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1,9 +1,11 @@
 package agent
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/hcdiag/hcl"
 
@@ -26,6 +28,19 @@ func newTestAgent(t *testing.T) *Agent {
 	require.NoError(t, err, "Error new test Agent")
 	require.NotNil(t, a)
 	return a
+}
+
+func TestNewAgentIncludesBackgroundContext(t *testing.T) {
+	a := newTestAgent(t)
+	assert.Equal(t, context.Background(), a.ctx)
+}
+
+func TestNewAgentWithContext(t *testing.T) {
+	ctx, _ := context.WithTimeout(context.Background(), 20*time.Second)
+	a, err := NewAgentWithContext(ctx, Config{}, hclog.Default())
+	require.NoError(t, err, "Error new test Agent with context")
+	require.NotNil(t, a)
+	require.Equal(t, ctx, a.ctx)
 }
 
 func TestStartAndEnd(t *testing.T) {

--- a/changelog/263.txt
+++ b/changelog/263.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+agent: Enable context propagation from agent down through to products, as enablement for runner timeouts/cancellation support.
+```

--- a/hcl/hcl_test.go
+++ b/hcl/hcl_test.go
@@ -1,6 +1,7 @@
 package hcl
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -273,7 +274,7 @@ func TestMapDockerLogs(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		runners, err := mapDockerLogs(tc.config, defaultDest, defaultSince, nil)
+		runners, err := mapDockerLogs(context.Background(), tc.config, defaultDest, defaultSince, nil)
 		assert.NoError(t, err)
 		assert.Len(t, runners, tc.expected)
 	}
@@ -337,7 +338,7 @@ func TestMapJournaldLogs(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		runners, err := mapJournaldLogs(tc.config, defaultDest, defaultSince, defaultUntil, tc.redactions)
+		runners, err := mapJournaldLogs(context.Background(), tc.config, defaultDest, defaultSince, defaultUntil, tc.redactions)
 		assert.NoError(t, err)
 		assert.Len(t, runners, tc.expected)
 	}

--- a/product/consul.go
+++ b/product/consul.go
@@ -1,6 +1,7 @@
 package product
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 
@@ -22,6 +23,11 @@ const (
 
 // NewConsul takes a logger and product config, and it creates a Product with all of Consul's default runners.
 func NewConsul(logger hclog.Logger, cfg Config) (*Product, error) {
+	return NewConsulWithContext(context.Background(), logger, cfg)
+}
+
+// NewConsulWithContext takes a context, a logger and product config, and it creates a Product with all of Consul's default runners.
+func NewConsulWithContext(ctx context.Context, logger hclog.Logger, cfg Config) (*Product, error) {
 	// Prepend product-specific redactions to agent-level redactions from cfg
 	defaultRedactions, err := consulRedactions()
 	if err != nil {
@@ -49,7 +55,7 @@ func NewConsul(logger hclog.Logger, cfg Config) (*Product, error) {
 		// Prepend product HCL redactions to our product defaults
 		cfg.Redactions = redact.Flatten(hclProductRedactions, cfg.Redactions)
 
-		hclRunners, err := hcl.BuildRunners(cfg.HCL, cfg.TmpDir, api, cfg.Since, cfg.Until, cfg.Redactions)
+		hclRunners, err := hcl.BuildRunnersWithContext(ctx, cfg.HCL, cfg.TmpDir, api, cfg.Since, cfg.Until, cfg.Redactions)
 		if err != nil {
 			return nil, err
 		}
@@ -59,7 +65,7 @@ func NewConsul(logger hclog.Logger, cfg Config) (*Product, error) {
 	}
 
 	// Add built-in runners
-	builtInRunners, err := consulRunners(cfg, api, logger)
+	builtInRunners, err := consulRunners(ctx, cfg, api, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +75,7 @@ func NewConsul(logger hclog.Logger, cfg Config) (*Product, error) {
 }
 
 // consulRunners generates a slice of runners to inspect consul.
-func consulRunners(cfg Config, api *client.APIClient, l hclog.Logger) ([]runner.Runner, error) {
+func consulRunners(ctx context.Context, cfg Config, api *client.APIClient, l hclog.Logger) ([]runner.Runner, error) {
 	r := []runner.Runner{
 		runner.NewCommand("consul version", "string", cfg.Redactions),
 		runner.NewCommand(fmt.Sprintf("consul debug -output=%s/ConsulDebug -duration=%s -interval=%s", cfg.TmpDir, cfg.DebugDuration, cfg.DebugInterval), "string", cfg.Redactions),

--- a/product/consul.go
+++ b/product/consul.go
@@ -26,7 +26,7 @@ func NewConsul(logger hclog.Logger, cfg Config) (*Product, error) {
 	return NewConsulWithContext(context.Background(), logger, cfg)
 }
 
-// NewConsulWithContext takes a context, a logger and product config, and it creates a Product with all of Consul's default runners.
+// NewConsulWithContext takes a context, a logger, and product config, and it creates a Product with all of Consul's default runners.
 func NewConsulWithContext(ctx context.Context, logger hclog.Logger, cfg Config) (*Product, error) {
 	// Prepend product-specific redactions to agent-level redactions from cfg
 	defaultRedactions, err := consulRedactions()

--- a/product/product.go
+++ b/product/product.go
@@ -1,6 +1,7 @@
 package product
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -109,6 +110,11 @@ func (p *Product) Filter() error {
 
 // CommandHealthCheck employs the CLI to check if the client and then the agent are available.
 func CommandHealthCheck(client, agent string) error {
+	return CommandHealthCheckWithContext(context.Background(), client, agent)
+}
+
+// CommandHealthCheckWithContext employs the CLI to check if the client and then the agent are available.
+func CommandHealthCheckWithContext(ctx context.Context, client, agent string) error {
 	checkClient := runner.NewCommand(client, "string", nil).Run()
 	if checkClient.Error != nil {
 		return fmt.Errorf("client not available, healthcheck=%v, result=%v, error=%v", client, checkClient.Result, checkClient.Error)


### PR DESCRIPTION
This merge adds a context field to Agent, which is then propagated downward to products. This sets the stage for implementation of context and timeouts/cancelation within runners. It also allows us to set custom timeouts/context within the CLI as well, by enabling custom context to be set on Agent.

Wherever exported methods/functions were updated to support context, the merge does this by migrating most logic to a "`WithContext`" function and then simply wrapping it with a background context in the previously existing function. This was done intentionally to maintain backwards compatibility.

Where unexported functions were updated, the function signatures were simply updated to now include a context.