### PR TITLE
Display Redaction ID String Instead of Bytes in results.json

### DIFF
--- a/changelog/266.txt
+++ b/changelog/266.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+redact: fix the redact.ID string so that it reads correctly in results.json
+```

--- a/redact/redact.go
+++ b/redact/redact.go
@@ -43,7 +43,7 @@ func New(cfg Config) (*Redact, error) {
 	}
 	if id == "" {
 		genID := md5.Sum([]byte(cfg.Matcher))
-		id = fmt.Sprint(genID)
+		id = fmt.Sprintf("%x", genID)
 	}
 	if replace == "" {
 		replace = DefaultReplace


### PR DESCRIPTION
Before:
```
"shell": {
  "command": "cat /etc/fstab",
  "redactions": [
      {
          "ID": "[143 248 116 208 123 195 112 34 115 100 70 180 244 97 215 253]",
          "replace": "REDACTED@REDACTED"
      }
  ],
...
```

After:
```
"shell": {
        "command": "cat /etc/fstab",
        "redactions": [
            {
                "ID": "8ff874d07bc37022736446b4f461d7fd",
                "replace": "REDACTED@REDACTED"
            }
        ],
...
```

This is the correct md5sum of the default email matcher string:
MD5 hex hash: ([a-zA-Z0-9_.+-]+)@([a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+)
`8ff874d07bc37022736446b4f461d7fd`

