### PR TITLE
Add Timeout & Cancelation to Command Runner

### DIFF
--- a/changelog/270.txt
+++ b/changelog/270.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+runners: The Command runner now takes an optional Timeout value, so that long-running executions can be gracefully stopped.
+```

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -25,8 +25,8 @@ type Blocks interface {
 	*Host | *Product | *Agent
 }
 
-// NOTE(dcohen) this is currently a separate config block, as opposed to a parent block of the others
 type Agent struct {
+	// NOTE(dcohen) this is currently a separate config block, as opposed to a parent block of the others
 	Redactions []Redact `hcl:"redact,block" json:"redactions,omitempty"`
 }
 
@@ -130,6 +130,7 @@ type Command struct {
 	Run        string   `hcl:"run" json:"run"`
 	Format     string   `hcl:"format" json:"format"`
 	Redactions []Redact `hcl:"redact,block" json:"redactions,omitempty"`
+	Timeout    string   `hcl:"timeout,optional" json:"timeout,omitempty"`
 }
 
 type Shell struct {
@@ -291,9 +292,17 @@ func mapCommands(ctx context.Context, cfgs []Command, redactions []*redact.Redac
 		}
 		// Prepend runner-level redactions to those passed in
 		runnerRedacts = append(runnerRedacts, redactions...)
+		var timeout time.Duration
+		if c.Timeout != "" {
+			timeout, err = time.ParseDuration(c.Timeout)
+			if err != nil {
+				return nil, err
+			}
+		}
 		r, err := runner.NewCommandWithContext(ctx, runner.CommandConfig{
 			Command:    c.Run,
 			Format:     c.Format,
+			Timeout:    timeout,
 			Redactions: runnerRedacts,
 		})
 		if err != nil {

--- a/runner/command.go
+++ b/runner/command.go
@@ -24,9 +24,10 @@ type Command struct {
 	Format  string `json:"format"`
 
 	// Parameters that are common across runner types
-	ctx context.Context
-	// TODO(nwchandler) - Make sure this displays properly in results.json
-	Timeout    time.Duration    `json:"timeout"`
+	ctx        context.Context
+	cancelFunc context.CancelFunc
+
+	Timeout    Timeout          `json:"timeout"`
 	Redactions []*redact.Redact `json:"redactions"`
 }
 
@@ -94,6 +95,7 @@ func NewCommandWithContext(ctx context.Context, cfg CommandConfig) (*Command, er
 		ctx:        ctx,
 		Command:    cmd,
 		Format:     format,
+		Timeout:    Timeout(timeout),
 		Redactions: cfg.Redactions,
 	}, nil
 }
@@ -104,73 +106,100 @@ func (c Command) ID() string {
 
 // Run executes the Command
 func (c Command) Run() op.Op {
+	// protect from accidental nil reference panics
+	if c.ctx == nil {
+		c.ctx = context.Background()
+	}
+
+	// c.cancelFunc helps us know whether our existing context is cancelable
+	if c.Timeout > 0 && c.cancelFunc == nil {
+		c.ctx, c.cancelFunc = context.WithTimeout(c.ctx, time.Duration(c.Timeout))
+	}
+
 	startTime := time.Now()
 
-	p, err := parseCommand(c.Command)
-	if err != nil {
-		return op.New(c.ID(), nil, op.Fail, err, Params(c), startTime, time.Now())
-	}
-
-	// Exit early with a wrapped error if the command isn't found on this system
-	_, err = util.HostCommandExists(p.cmd)
-	if err != nil {
-		return op.New(c.ID(), nil, op.Skip, err, Params(c), startTime, time.Now())
-	}
-
-	// Execute command
-	bts, err := exec.Command(p.cmd, p.args...).CombinedOutput()
-	if err != nil {
-		err1 := CommandExecError{command: c.Command, format: c.Format, err: err}
-		result := map[string]any{"text": string(bts)}
-		return op.New(c.ID(), result, op.Unknown, err1, Params(c), startTime, time.Now())
-	}
-
-	// Parse result format
-	// TODO(mkcp): This can be detected rather than branching on user input
-	switch {
-	case c.Format == "string":
-		redBts, err := redact.Bytes(bts, c.Redactions)
+	resultsChannel := make(chan op.Op, 1)
+	go func(results chan<- op.Op) {
+		p, err := parseCommand(c.Command)
 		if err != nil {
-			return op.New(c.ID(), nil, op.Fail, err, Params(c), startTime, time.Now())
+			results <- op.New(c.ID(), nil, op.Fail, err, Params(c), startTime, time.Now())
 		}
-		redResult := strings.TrimSuffix(string(redBts), "\n")
 
-		result := map[string]any{"text": redResult}
-		return op.New(c.ID(), result, op.Success, nil, Params(c), startTime, time.Now())
+		// Exit early with a wrapped error if the command isn't found on this system
+		_, err = util.HostCommandExists(p.cmd)
+		if err != nil {
+			results <- op.New(c.ID(), nil, op.Skip, err, Params(c), startTime, time.Now())
+		}
 
-	case c.Format == "json":
-		var obj any
-		marshErr := json.Unmarshal(bts, &obj)
-		if marshErr != nil {
-			// Redact the string to return the failed-to-parse JSON
+		// Execute command
+		bts, err := exec.Command(p.cmd, p.args...).CombinedOutput()
+		if err != nil {
+			err1 := CommandExecError{command: c.Command, format: c.Format, err: err}
+			result := map[string]any{"text": string(bts)}
+			results <- op.New(c.ID(), result, op.Unknown, err1, Params(c), startTime, time.Now())
+		}
+
+		// Parse result format
+		// TODO(mkcp): This can be detected rather than branching on user input
+		switch {
+		case c.Format == "string":
+			redBts, err := redact.Bytes(bts, c.Redactions)
+			if err != nil {
+				results <- op.New(c.ID(), nil, op.Fail, err, Params(c), startTime, time.Now())
+			}
+			redResult := strings.TrimSuffix(string(redBts), "\n")
+
+			result := map[string]any{"text": redResult}
+			results <- op.New(c.ID(), result, op.Success, nil, Params(c), startTime, time.Now())
+
+		case c.Format == "json":
+			var obj any
+			marshErr := json.Unmarshal(bts, &obj)
+			if marshErr != nil {
+				// Redact the string to return the failed-to-parse JSON
+				redBts, redErr := redact.Bytes(bts, c.Redactions)
+				if redErr != nil {
+					results <- op.New(c.ID(), nil, op.Fail, redErr, Params(c), startTime, time.Now())
+				}
+				result := map[string]any{"json": string(redBts)}
+				results <- op.New(c.ID(), result, op.Unknown,
+					UnmarshalError{
+						command: c.Command,
+						err:     marshErr,
+					}, Params(c), startTime, time.Now())
+			}
+			redResult, redErr := redact.JSON(obj, c.Redactions)
+			if redErr != nil {
+				results <- op.New(c.ID(), nil, op.Fail, redErr, Params(c), startTime, time.Now())
+			}
+			result := map[string]any{"json": redResult}
+			results <- op.New(c.ID(), result, op.Success, nil, Params(c), startTime, time.Now())
+		default:
 			redBts, redErr := redact.Bytes(bts, c.Redactions)
 			if redErr != nil {
-				return op.New(c.ID(), nil, op.Fail, redErr, Params(c), startTime, time.Now())
+				results <- op.New(c.ID(), nil, op.Fail, redErr, Params(c), startTime, time.Now())
 			}
-			result := map[string]any{"json": string(redBts)}
-			return op.New(c.ID(), result, op.Unknown,
-				UnmarshalError{
+			result := map[string]any{"out": string(redBts)}
+			results <- op.New(c.ID(), result, op.Fail,
+				FormatUnknownError{
 					command: c.Command,
-					err:     marshErr,
+					format:  c.Format,
 				}, Params(c), startTime, time.Now())
 		}
-		redResult, redErr := redact.JSON(obj, c.Redactions)
-		if redErr != nil {
-			return op.New(c.ID(), nil, op.Fail, redErr, Params(c), startTime, time.Now())
+	}(resultsChannel)
+
+	select {
+	case <-c.ctx.Done():
+		switch c.ctx.Err() {
+		case context.Canceled:
+			return op.New(c.ID(), nil, op.Canceled, c.ctx.Err(), Params(c), startTime, time.Now())
+		case context.DeadlineExceeded:
+			return op.New(c.ID(), nil, op.Timeout, c.ctx.Err(), Params(c), startTime, time.Now())
+		default:
+			return op.New(c.ID(), nil, op.Unknown, c.ctx.Err(), Params(c), startTime, time.Now())
 		}
-		result := map[string]any{"json": redResult}
-		return op.New(c.ID(), result, op.Success, nil, Params(c), startTime, time.Now())
-	default:
-		redBts, redErr := redact.Bytes(bts, c.Redactions)
-		if redErr != nil {
-			return op.New(c.ID(), nil, op.Fail, redErr, Params(c), startTime, time.Now())
-		}
-		result := map[string]any{"out": string(redBts)}
-		return op.New(c.ID(), result, op.Fail,
-			FormatUnknownError{
-				command: c.Command,
-				format:  c.Format,
-			}, Params(c), startTime, time.Now())
+	case result := <-resultsChannel:
+		return result
 	}
 }
 

--- a/runner/command_test.go
+++ b/runner/command_test.go
@@ -166,10 +166,9 @@ func TestCommand_RunCanceled(t *testing.T) {
 	cancelFunc()
 
 	cmd := Command{
-		Command:    "bogus-command",
-		Format:     "string",
-		ctx:        ctx,
-		cancelFunc: cancelFunc,
+		Command: "bogus-command",
+		Format:  "string",
+		ctx:     ctx,
 	}
 
 	result := cmd.Run()
@@ -186,10 +185,9 @@ func TestCommand_RunTimeout(t *testing.T) {
 	time.Sleep(1 * time.Nanosecond)
 
 	cmd := Command{
-		Command:    "bogus-command",
-		Format:     "string",
-		ctx:        ctx,
-		cancelFunc: cancelFunc,
+		Command: "bogus-command",
+		Format:  "string",
+		ctx:     ctx,
 	}
 
 	result := cmd.Run()

--- a/runner/command_test.go
+++ b/runner/command_test.go
@@ -167,7 +167,6 @@ func TestCommand_RunCanceled(t *testing.T) {
 
 	cmd := Command{
 		Command: "bogus-command",
-		Format:  "string",
 		ctx:     ctx,
 	}
 
@@ -186,7 +185,6 @@ func TestCommand_RunTimeout(t *testing.T) {
 
 	cmd := Command{
 		Command: "bogus-command",
-		Format:  "string",
 		ctx:     ctx,
 	}
 

--- a/runner/command_test.go
+++ b/runner/command_test.go
@@ -159,6 +159,44 @@ func TestCommand_RunError(t *testing.T) {
 	}
 }
 
+func TestCommand_RunCanceled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	cancelFunc()
+
+	cmd := Command{
+		Command:    "bogus-command",
+		Format:     "string",
+		ctx:        ctx,
+		cancelFunc: cancelFunc,
+	}
+
+	result := cmd.Run()
+	assert.Equal(t, op.Canceled, result.Status)
+	assert.ErrorIs(t, result.Error, context.Canceled)
+}
+
+func TestCommand_RunTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Set to a short timeout, and sleep briefly to ensure it passes before we try to run the command
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+	defer cancelFunc()
+	time.Sleep(1 * time.Nanosecond)
+
+	cmd := Command{
+		Command:    "bogus-command",
+		Format:     "string",
+		ctx:        ctx,
+		cancelFunc: cancelFunc,
+	}
+
+	result := cmd.Run()
+	assert.Equal(t, op.Timeout, result.Status)
+	assert.ErrorIs(t, result.Error, context.DeadlineExceeded)
+}
+
 func Test_parseCommand(t *testing.T) {
 	tt := []struct {
 		desc    string

--- a/runner/timeout.go
+++ b/runner/timeout.go
@@ -1,0 +1,14 @@
+package runner
+
+import (
+	"fmt"
+	"time"
+)
+
+// Timeout is a time.Duration, which allows for custom JSON marshalling. When marshalled, it will be converted into
+// a duration string, rather than an integer representing nanoseconds. For example, 3000000000 becomes "3s".
+type Timeout time.Duration
+
+func (t Timeout) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, time.Duration(t).String())), nil
+}

--- a/runner/timeout_test.go
+++ b/runner/timeout_test.go
@@ -1,0 +1,41 @@
+package runner
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// ExampleTimeout_MarshalJSON provides some examples to demonstrate the usefulness of the Timeout
+// struct as it relates to marshalling to JSON. Because results from diagnostic runs are written
+// as JSON, this provides a more human-readable format than what the time.Duration type provides.
+func ExampleTimeout_MarshalJSON() {
+	var (
+		b        []byte
+		duration time.Duration
+		timeout  Timeout
+	)
+
+	// When a time.Duration is marshalled to JSON, it renders as an integer,
+	// representing the number of nanoseconds in the duration.
+	duration = 3 * time.Second
+	b, _ = json.Marshal(duration)
+	fmt.Println(string(b)) // 3000000000
+
+	// When a Timeout is marshalled to JSON, it renders in the same format
+	// that Go uses to parse from strings into time.Duration, providing a
+	// more human-readable output format.
+	timeout = Timeout(duration)
+	b, _ = json.Marshal(timeout)
+	fmt.Println(string(b)) // "3s"
+
+	// More complex time durations are also supported for human-readable output.
+	timeout = Timeout((2 * time.Hour) + (31 * time.Minute) + (12 * time.Second))
+	b, _ = json.Marshal(timeout)
+	fmt.Println(string(b)) // "2h31m12s"
+
+	// Output:
+	// 3000000000
+	// "3s"
+	// "2h31m12s"
+}


### PR DESCRIPTION
This merge enables timeouts and cancellation in the Command runner. Timeouts may be passed in via optional configuration. If the timeout expires, or if a context that has been passed into the Command runner when it was constructed is canceled, then the run will stop with an appropriate operation status type.