### PR TITLE
Migrate HTTP Runner Constructors to Use Config Objects

### DIFF
--- a/changelog/273.txt
+++ b/changelog/273.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+runners: Update HTTP runner instantiation to use configuration objects, in order to simplify future feature additions.
+```

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -140,6 +140,7 @@ type Shell struct {
 type GET struct {
 	Path       string   `hcl:"path" json:"path"`
 	Redactions []Redact `hcl:"redact,block" json:"redactions,omitempty"`
+	Timeout    string   `hcl:"timeout,optional" json:"timeout,omitempty"`
 }
 
 type Copy struct {
@@ -353,10 +354,17 @@ func mapProductGETs(ctx context.Context, cfgs []GET, redactions []*redact.Redact
 		}
 		// Prepend runner-level redactions to those passed in
 		runnerRedacts = append(runnerRedacts, redactions...)
+		var timeout time.Duration
+		if g.Timeout != "" {
+			timeout, err = time.ParseDuration(g.Timeout)
+			if err != nil {
+				return nil, err
+			}
+		}
 		r, err := runner.NewHTTPWithContext(ctx, runner.HttpConfig{
 			Client:     c,
 			Path:       g.Path,
-			Timeout:    0,
+			Timeout:    timeout,
 			Redactions: runnerRedacts,
 		})
 		if err != nil {

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -353,7 +353,16 @@ func mapProductGETs(ctx context.Context, cfgs []GET, redactions []*redact.Redact
 		}
 		// Prepend runner-level redactions to those passed in
 		runnerRedacts = append(runnerRedacts, redactions...)
-		runners[i] = runner.NewHTTP(c, g.Path, runnerRedacts)
+		r, err := runner.NewHTTPWithContext(ctx, runner.HttpConfig{
+			Client:     c,
+			Path:       g.Path,
+			Timeout:    0,
+			Redactions: runnerRedacts,
+		})
+		if err != nil {
+			return nil, err
+		}
+		runners[i] = r
 	}
 	return runners, nil
 }

--- a/runner/http.go
+++ b/runner/http.go
@@ -41,12 +41,8 @@ type HttpConfig struct {
 	Redactions []*redact.Redact
 }
 
-func NewHTTP(client *client.APIClient, path string, redactions []*redact.Redact) *HTTP {
-	return &HTTP{
-		Client:     client,
-		Path:       path,
-		Redactions: redactions,
-	}
+func NewHTTP(cfg HttpConfig) (*HTTP, error) {
+	return NewHTTPWithContext(context.Background(), cfg)
 }
 
 func NewHTTPWithContext(ctx context.Context, cfg HttpConfig) (*HTTP, error) {
@@ -54,6 +50,14 @@ func NewHTTPWithContext(ctx context.Context, cfg HttpConfig) (*HTTP, error) {
 		return nil, HTTPConfigError{
 			config: cfg,
 			err:    fmt.Errorf("client must be non-nil when creating an HTTP runner"),
+		}
+	}
+
+	timeout := cfg.Timeout
+	if timeout < 0 {
+		return nil, HTTPConfigError{
+			config: cfg,
+			err:    fmt.Errorf("timeout must be a nonnegative value, but got '%s'", timeout.String()),
 		}
 	}
 

--- a/runner/http.go
+++ b/runner/http.go
@@ -20,8 +20,8 @@ type HTTP struct {
 
 	// Parameters that are common across runner types
 	ctx context.Context
-	// TODO(nwc) change this once PR 270 is merged into main and this branch is rebased onto main
-	Timeout    time.Duration    `json:"timeout"`
+
+	Timeout    Timeout          `json:"timeout"`
 	Redactions []*redact.Redact `json:"redactions"`
 }
 
@@ -69,6 +69,7 @@ func NewHTTPWithContext(ctx context.Context, cfg HttpConfig) (*HTTP, error) {
 		ctx:        ctx,
 		Client:     cfg.Client,
 		Path:       cfg.Path,
+		Timeout:    Timeout(cfg.Timeout),
 		Redactions: cfg.Redactions,
 	}, nil
 }

--- a/runner/http_test.go
+++ b/runner/http_test.go
@@ -1,0 +1,57 @@
+package runner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/hcdiag/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewHTTPWithContext(t *testing.T) {
+	t.Parallel()
+
+	c, err := client.NewAPIClient(client.APIConfig{
+		Product:   "consul",
+		BaseURL:   "https://someplace.local",
+		TLSConfig: client.TLSConfig{},
+	})
+	require.NoError(t, err)
+
+	tt := []struct {
+		desc      string
+		cfg       HttpConfig
+		expect    *HTTP
+		expectErr bool
+	}{
+		{
+			desc:      "empty config causes an error",
+			cfg:       HttpConfig{},
+			expectErr: true,
+		},
+		{
+			desc: "test defaults",
+			cfg:  HttpConfig{Client: c},
+			expect: &HTTP{
+				Path:       "",
+				Client:     c,
+				ctx:        context.Background(),
+				Timeout:    0,
+				Redactions: nil,
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.desc, func(t *testing.T) {
+			c, err := NewHTTPWithContext(context.Background(), tc.cfg)
+			if tc.expectErr {
+				assert.ErrorAs(t, err, &HTTPConfigError{})
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expect, c)
+			}
+		})
+	}
+}

--- a/runner/http_test.go
+++ b/runner/http_test.go
@@ -3,13 +3,14 @@ package runner
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/hcdiag/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewHTTPWithContext(t *testing.T) {
+func TestNewHTTP(t *testing.T) {
 	t.Parallel()
 
 	c, err := client.NewAPIClient(client.APIConfig{
@@ -41,11 +42,19 @@ func TestNewHTTPWithContext(t *testing.T) {
 				Redactions: nil,
 			},
 		},
+		{
+			desc: "negative timeout duration causes an error",
+			cfg: HttpConfig{
+				Client:  c,
+				Timeout: -10 * time.Second,
+			},
+			expectErr: true,
+		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.desc, func(t *testing.T) {
-			c, err := NewHTTPWithContext(context.Background(), tc.cfg)
+			c, err := NewHTTP(tc.cfg)
 			if tc.expectErr {
 				assert.ErrorAs(t, err, &HTTPConfigError{})
 			} else {

--- a/tests/integration/consul.hcl
+++ b/tests/integration/consul.hcl
@@ -6,6 +6,7 @@ addresses = {
 
 ports {
   https = 8501 # recommended to use 8501 if enabling tls
+  grpc_tls = 8503 # TLS port must be set beginning in Consul 1.14.0
   http  = 8888 # change from default to expose any breakage from clients' default addrs
 }
 


### PR DESCRIPTION
This merge updates the HTTP constructors to leverage a new HttpConfig object, rather than parameters. The intention is to simplify future feature additions by limiting changes to the function signatures of these constructors.

Unrelated to the primary change, a configuration setting required updating for integration tests to pass using a new version of Consul that was recently released, version 1.14.0. This change to Consul does not impact hcdiag, but prevented the dev Consul server from starting during integration tests.