### PR TITLE
Add Timeout & Cancelation to HTTP Runner

### DIFF
--- a/changelog/274.txt
+++ b/changelog/274.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+runners: The HTTP / GET runner now takes an optional Timeout value, so that long-running executions can be gracefully stopped.
+```

--- a/runner/command.go
+++ b/runner/command.go
@@ -112,7 +112,6 @@ func (c Command) Run() op.Op {
 
 	runCtx := c.ctx
 	var runCancelFunc context.CancelFunc
-	// c.cancelFunc helps us know whether our existing context is cancelable
 	if c.Timeout > 0 {
 		runCtx, runCancelFunc = context.WithTimeout(c.ctx, time.Duration(c.Timeout))
 		defer runCancelFunc()

--- a/runner/http.go
+++ b/runner/http.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -80,12 +81,32 @@ func (h HTTP) ID() string {
 
 // Run executes a GET request to the Path using the Client
 func (h HTTP) Run() op.Op {
+	// protect from accidental nil reference panics
+	if h.ctx == nil {
+		h.ctx = context.Background()
+	}
+
+	runCtx := h.ctx
+	var runCancelFunc context.CancelFunc
+	if h.Timeout > 0 {
+		runCtx, runCancelFunc = context.WithTimeout(h.ctx, time.Duration(h.Timeout))
+		defer runCancelFunc()
+	}
+
 	startTime := time.Now()
 
-	redactedResponse, err := h.Client.RedactGet(h.Path, h.Redactions)
+	redactedResponse, err := h.Client.RedactGetWithContext(runCtx, h.Path, h.Redactions)
 	result := map[string]any{"response": redactedResponse}
 	if err != nil {
-		op.New(h.ID(), result, op.Fail, err, Params(h), startTime, time.Now())
+		var failureType op.Status
+		if errors.Is(err, context.DeadlineExceeded) {
+			failureType = op.Timeout
+		} else if errors.Is(err, context.Canceled) {
+			failureType = op.Canceled
+		} else {
+			failureType = op.Fail
+		}
+		return op.New(h.ID(), result, failureType, err, Params(h), startTime, time.Now())
 	}
 
 	return op.New(h.ID(), result, op.Success, nil, Params(h), startTime, time.Now())


### PR DESCRIPTION
This merge enables timeouts and cancellation in the HTTP runner. Timeouts may be passed in via optional configuration. If the timeout expires, or if a context that has been passed into the runner when it was constructed is canceled, then the run will stop with an appropriate operation status type.