### PR TITLE
WIP: migrate fstab to context and timeouts

### DIFF
--- a/runner/host/fstab.go
+++ b/runner/host/fstab.go
@@ -1,6 +1,7 @@
 package host
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -15,12 +16,32 @@ var _ runner.Runner = FSTab{}
 type FSTab struct {
 	OS    string        `json:"os"`
 	Shell runner.Runner `json:"shell"`
+
+	ctx        context.Context
+	Timeout    runner.Timeout   `json:"timeout"`
+	Redactions []*redact.Redact `json:"redactions"`
 }
 
-func NewFSTab(os string, redactions []*redact.Redact) *FSTab {
+type FSTabConfig struct {
+	OS         string
+	Timeout    runner.Timeout
+	Redactions []*redact.Redact
+}
+
+func NewFSTab(cfg FSTabConfig) *FSTab {
+	return NewFSTabWithContext(nil, cfg)
+}
+
+func NewFSTabWithContext(ctx context.Context, cfg FSTabConfig) *FSTab {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	return &FSTab{
-		OS:    os,
-		Shell: runner.NewShell("cat /etc/fstab", redactions),
+		ctx:        ctx,
+		OS:         cfg.OS,
+		Timeout:    cfg.Timeout,
+		Redactions: cfg.Redactions,
 	}
 }
 
@@ -31,14 +52,46 @@ func (r FSTab) ID() string {
 func (r FSTab) Run() op.Op {
 	startTime := time.Now()
 
-	// Only Linux is supported currently; Windows is unsupported, and Darwin doesn't use /etc/fstab by default.
-	if r.OS != "linux" {
-		return op.New(r.ID(), nil, op.Skip, fmt.Errorf("FSTab.Run() not available on os, os=%s", r.OS), runner.Params(r), startTime, time.Now())
-	}
-	o := r.Shell.Run()
-	if o.Error != nil {
-		return op.New(r.ID(), o.Result, op.Fail, o.Error, runner.Params(r), startTime, time.Now())
+	var cancel context.CancelFunc
+	var runCtx context.Context
+	runCtx = r.ctx
+	if r.Timeout > 0 {
+		runCtx, cancel = context.WithTimeout(r.ctx, time.Duration(r.Timeout))
+		defer cancel()
 	}
 
-	return op.New(r.ID(), o.Result, op.Success, nil, runner.Params(r), startTime, time.Now())
+	res := make(chan op.Op, 1)
+	go func(results chan<- op.Op) {
+		o := r.run()
+		o.Start = startTime
+		results <- o
+	}(res)
+	select {
+	case <-runCtx.Done():
+		switch runCtx.Err() {
+		case context.Canceled:
+			return op.New(r.ID(), nil, op.Canceled, r.ctx.Err(), runner.Params(r), startTime, time.Now())
+		case context.DeadlineExceeded:
+			return op.New(r.ID(), nil, op.Timeout, r.ctx.Err(), runner.Params(r), startTime, time.Now())
+		default:
+			return op.New(r.ID(), nil, op.Unknown, r.ctx.Err(), runner.Params(r), startTime, time.Now())
+		}
+
+	case o := <-res:
+		return o
+	}
+}
+
+func (r FSTab) run() op.Op {
+	// Only Linux is supported currently; Windows is unsupported, and Darwin doesn't use /etc/fstab by default.
+	if r.OS != "linux" {
+		return op.New(r.ID(), nil, op.Skip, fmt.Errorf("FSTab.Run() not available on os, os=%s", r.OS), runner.Params(r), time.Time{}, time.Now())
+	}
+
+	shell := runner.NewShell("cat /etc/fstab", r.Redactions)
+	o := shell.Run()
+	if o.Error != nil {
+		return op.New(r.ID(), o.Result, op.Fail, o.Error, runner.Params(r), time.Time{}, time.Now())
+	}
+	return op.New(r.ID(), o.Result, op.Success, nil, runner.Params(r), time.Time{}, time.Now())
 }

--- a/runner/host/fstab_test.go
+++ b/runner/host/fstab_test.go
@@ -58,7 +58,7 @@ func TestFSTab_Run(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			expected := tc.expected
-			r := NewFSTab(nil, tc.cfg)
+			r := NewFSTab(tc.cfg)
 			o := r.Run()
 			assert.Equal(t, expected.result, o.Result)
 			assert.Equal(t, expected.status, o.Status)
@@ -84,7 +84,7 @@ func TestNewFSTab(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			fstab := NewFSTab(nil, tc.cfg)
+			fstab := NewFSTab(tc.cfg)
 			assert.Equal(t, tc.expected.OS, fstab.OS)
 		})
 	}


### PR DESCRIPTION
The tests are very broken - there's a shorter path to completion once Shell supports timeouts, but there's still an open question about whether DI and mocking out nested-runners is something we want to maintain going forward. The intent is to return to this Runner later in the timeout migration.