### PR TITLE
add timeouts to host/memory

### DIFF
--- a/product/host.go
+++ b/product/host.go
@@ -73,6 +73,7 @@ func hostRunners(ctx context.Context, os string, redactions []*redact.Redact, l 
 		host.NewOS(os, redactions),
 		host.NewDisk(redactions),
 		host.NewInfo(redactions),
+		// TODO(mkcp): Source the timeout value from agent/CLI params, or extract to a const.
 		host.NewMemoryWithContext(ctx, runner.Timeout(30*time.Second)),
 		host.NewProcess(redactions),
 		host.NewNetwork(redactions),

--- a/product/host.go
+++ b/product/host.go
@@ -3,6 +3,7 @@ package product
 import (
 	"context"
 	"runtime"
+	"time"
 
 	"github.com/hashicorp/hcdiag/runner/do"
 	"github.com/hashicorp/hcdiag/runner/host"
@@ -72,7 +73,7 @@ func hostRunners(ctx context.Context, os string, redactions []*redact.Redact, l 
 		host.NewOS(os, redactions),
 		host.NewDisk(redactions),
 		host.NewInfo(redactions),
-		host.Memory{},
+		host.NewMemoryWithContext(ctx, runner.Timeout(30*time.Second)),
 		host.NewProcess(redactions),
 		host.NewNetwork(redactions),
 		host.NewEtcHosts(redactions),

--- a/runner/host/memory.go
+++ b/runner/host/memory.go
@@ -15,7 +15,7 @@ var _ runner.Runner = Memory{}
 
 type Memory struct {
 	ctx     context.Context
-	Timeout runner.Timeout
+	Timeout runner.Timeout `json:"timeout"`
 }
 
 func (m Memory) ID() string {
@@ -48,9 +48,9 @@ func (m Memory) Run() op.Op {
 		defer cancel()
 	}
 
-	go func(resChan chan op.Op, startTime time.Time) {
+	go func(resChan chan op.Op, start time.Time) {
 		o := m.run()
-		o.Start = startTime
+		o.Start = start
 		resChan <- o
 	}(resChan, startTime)
 

--- a/runner/host/memory.go
+++ b/runner/host/memory.go
@@ -23,7 +23,7 @@ func (m Memory) ID() string {
 }
 
 func NewMemory(timeout runner.Timeout) *Memory {
-	return NewMemoryWithContext(nil, timeout)
+	return NewMemoryWithContext(context.Background(), timeout)
 }
 
 func NewMemoryWithContext(ctx context.Context, timeout runner.Timeout) *Memory {

--- a/runner/host/memory.go
+++ b/runner/host/memory.go
@@ -1,32 +1,80 @@
 package host
 
 import (
+	"context"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/shirou/gopsutil/v3/mem"
+
 	"github.com/hashicorp/hcdiag/op"
 	"github.com/hashicorp/hcdiag/runner"
-	"github.com/shirou/gopsutil/v3/mem"
 )
 
 var _ runner.Runner = Memory{}
 
-type Memory struct{}
+type Memory struct {
+	ctx     context.Context
+	Timeout runner.Timeout
+}
 
 func (m Memory) ID() string {
 	return "memory"
 }
 
+func NewMemory(timeout runner.Timeout) *Memory {
+	return NewMemoryWithContext(nil, timeout)
+}
+
+func NewMemoryWithContext(ctx context.Context, timeout runner.Timeout) *Memory {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return &Memory{
+		ctx:     ctx,
+		Timeout: timeout,
+	}
+}
+
 // Run calls out to mem.VirtualMemory
 func (m Memory) Run() op.Op {
 	startTime := time.Now()
+	resChan := make(chan op.Op, 1)
 
-	memoryInfo, err := mem.VirtualMemory()
-	result := map[string]any{"memoryInfo": memoryInfo}
-	if err != nil {
-		hclog.L().Trace("runner/host.Memory.Run()", "error", err)
-		return op.New(m.ID(), result, op.Fail, err, runner.Params(m), startTime, time.Now())
+	var runCtx context.Context
+	var cancel context.CancelFunc
+	if 0 < m.Timeout {
+		runCtx, cancel = context.WithTimeout(m.ctx, time.Duration(m.Timeout))
+		defer cancel()
 	}
 
-	return op.New(m.ID(), result, op.Success, nil, runner.Params(m), startTime, time.Now())
+	go func(resChan chan op.Op, startTime time.Time) {
+		o := m.run()
+		o.Start = startTime
+		resChan <- o
+	}(resChan, startTime)
+
+	select {
+	case <-runCtx.Done():
+		switch runCtx.Err() {
+		case context.Canceled:
+			return op.New(m.ID(), nil, op.Canceled, runCtx.Err(), runner.Params(m), startTime, time.Now())
+		case context.DeadlineExceeded:
+			return op.New(m.ID(), nil, op.Timeout, runCtx.Err(), runner.Params(m), startTime, time.Now())
+		default:
+			return op.New(m.ID(), nil, op.Unknown, runCtx.Err(), runner.Params(m), startTime, time.Now())
+		}
+	case o := <-resChan:
+		return o
+	}
+}
+
+func (m Memory) run() op.Op {
+	memoryInfo, err := mem.VirtualMemory()
+	res := map[string]any{"memoryInfo": memoryInfo}
+	if err != nil {
+		hclog.L().Trace("runner/host.Memory.Run()", "error", err)
+		return op.New(m.ID(), res, op.Fail, err, runner.Params(m), time.Time{}, time.Now())
+	}
+	return op.New(m.ID(), res, op.Success, nil, runner.Params(m), time.Time{}, time.Now())
 }


### PR DESCRIPTION
More or less modeled after runner.Command. Tested by setting the default timeout in the host runners to `Timeout(1*time.Nanosecond)` and seeing +1 runner of status.Timeout in the product complete list. We should really fix nested status rendering soon.