### PR TITLE
Add timeouts to shell runner

### DIFF
--- a/changelog/277.txt
+++ b/changelog/277.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+runner: Shell now takes an optional Timeout value in Go duration form so that long-running executions can be gracefully stopped.
+```

--- a/product/host.go
+++ b/product/host.go
@@ -80,8 +80,10 @@ func hostRunners(ctx context.Context, os string, redactions []*redact.Redact, l 
 		host.NewEtcHosts(redactions),
 		host.NewIPTables(os, redactions),
 		host.NewProcFile(os, redactions),
-		host.NewFSTab(os, redactions),
 	}
+	// FIXME(mkcp): handle this error
+	fsTab, _ := host.NewFSTab(os, redactions)
+	r = append(r, fsTab)
 
 	runners := []runner.Runner{
 		do.New(l, "host", "host runners", r),

--- a/product/tfe.go
+++ b/product/tfe.go
@@ -124,11 +124,11 @@ func tfeRunners(ctx context.Context, cfg Config, api *client.APIClient, l hclog.
 	}
 
 	// Set up Shell runners
-	for _, ss := range []runner.ShellConfig{
+	for _, sc := range []runner.ShellConfig{
 		{Command: "getenforce", Redactions: cfg.Redactions},
 		{Command: "env | grep -i proxy", Redactions: cfg.Redactions},
 	} {
-		s, err := runner.NewShellWithContext(ctx, ss)
+		s, err := runner.NewShellWithContext(ctx, sc)
 		if err != nil {
 			return nil, err
 		}

--- a/product/tfe.go
+++ b/product/tfe.go
@@ -124,10 +124,16 @@ func tfeRunners(ctx context.Context, cfg Config, api *client.APIClient, l hclog.
 	}
 
 	// Set up Shell runners
-	r = append(r,
-		runner.NewShell("getenforce", cfg.Redactions),
-		runner.NewShell("env | grep -i proxy", cfg.Redactions),
-	)
+	for _, ss := range []runner.ShellConfig{
+		{Command: "getenforce", Redactions: cfg.Redactions},
+		{Command: "env | grep -i proxy", Redactions: cfg.Redactions},
+	} {
+		s, err := runner.NewShellWithContext(ctx, ss)
+		if err != nil {
+			return nil, err
+		}
+		r = append(r, s)
+	}
 
 	runners := []runner.Runner{
 		do.New(l, "tfe", "tfe runners", r),

--- a/runner/host/etc_hosts.go
+++ b/runner/host/etc_hosts.go
@@ -37,9 +37,18 @@ func (r EtcHosts) Run() op.Op {
 		err := fmt.Errorf(" EtcHosts.Run() not available on os, os=%s", r.OS)
 		return op.New(r.ID(), nil, op.Skip, err, runner.Params(r), startTime, time.Now())
 	}
-	s := runner.NewShell("cat /etc/hosts", r.Redactions).Run()
-	if s.Error != nil {
-		return op.New(r.ID(), s.Result, op.Fail, s.Error, runner.Params(r), startTime, time.Now())
+
+	s, err := runner.NewShell(runner.ShellConfig{
+		Command:    "cat /etc/hosts",
+		Redactions: r.Redactions,
+	})
+	if err != nil {
+		return op.New(r.ID(), map[string]any{}, op.Fail, err, runner.Params(r), startTime, time.Now())
 	}
-	return op.New(r.ID(), s.Result, op.Success, nil, runner.Params(r), startTime, time.Now())
+
+	o := s.Run()
+	if o.Error != nil {
+		return op.New(r.ID(), o.Result, op.Fail, o.Error, runner.Params(r), startTime, time.Now())
+	}
+	return op.New(r.ID(), o.Result, op.Success, nil, runner.Params(r), startTime, time.Now())
 }

--- a/runner/host/fstab.go
+++ b/runner/host/fstab.go
@@ -17,11 +17,18 @@ type FSTab struct {
 	Shell runner.Runner `json:"shell"`
 }
 
-func NewFSTab(os string, redactions []*redact.Redact) *FSTab {
+func NewFSTab(os string, redactions []*redact.Redact) (*FSTab, error) {
+	shell, err := runner.NewShell(runner.ShellConfig{
+		Command:    "cat /etc/fstab",
+		Redactions: redactions,
+	})
+	if err != nil {
+		return nil, err
+	}
 	return &FSTab{
 		OS:    os,
-		Shell: runner.NewShell("cat /etc/fstab", redactions),
-	}
+		Shell: shell,
+	}, nil
 }
 
 func (r FSTab) ID() string {

--- a/runner/host/fstab_test.go
+++ b/runner/host/fstab_test.go
@@ -122,7 +122,8 @@ func TestNewFSTab(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			fstab := NewFSTab(tc.os, nil)
+			fstab, err := NewFSTab(tc.os, nil)
+			assert.NoError(t, err)
 			assert.Equal(t, tc.expected.OS, fstab.OS)
 		})
 	}

--- a/runner/shell_test.go
+++ b/runner/shell_test.go
@@ -18,7 +18,10 @@ func TestShell(t *testing.T) {
 	os.Setenv("SHELL", "/bin/sh")
 
 	// features pipe "|" and file redirection ">"
-	c := NewShell("echo hiii | grep hi > cooltestfile", nil)
+	c, err := NewShell(ShellConfig{
+		Command: "echo hiii | grep hi > cooltestfile",
+	})
+	assert.NoError(t, err)
 	defer os.Remove("cooltestfile")
 	o := c.Run()
 	assert.Equal(t, map[string]any{"shell": ""}, o.Result)

--- a/runner/shell_test.go
+++ b/runner/shell_test.go
@@ -1,9 +1,12 @@
 package runner
 
 import (
+	"context"
 	"os"
 	"runtime"
 	"testing"
+
+	"github.com/hashicorp/hcdiag/op"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -30,4 +33,33 @@ func TestShell(t *testing.T) {
 	bts, err := os.ReadFile("cooltestfile")
 	assert.Equal(t, "hiii\n", string(bts))
 	assert.NoError(t, err)
+}
+
+func TestShell_RunTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Set to a short timeout, and sleep briefly to ensure it passes before we try to run the command
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 0)
+	defer cancelFunc()
+
+	sh, err := NewShellWithContext(ctx, ShellConfig{Command: "status-unknown-if-this-completes-lkshjajflks"})
+	assert.NoError(t, err)
+
+	result := sh.Run()
+	assert.Equal(t, op.Timeout, result.Status)
+	assert.ErrorIs(t, result.Error, context.DeadlineExceeded)
+}
+
+func TestShell_RunCancel(t *testing.T) {
+	t.Parallel()
+
+	// Set to a short timeout, and sleep briefly to ensure it passes before we try to run the command
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	sh, err := NewShellWithContext(ctx, ShellConfig{Command: "status-unknown-if-this-completes-lkshjajflks"})
+	result := sh.Run()
+
+	assert.NoError(t, err)
+	assert.Equal(t, op.Canceled, result.Status)
+	assert.ErrorIs(t, result.Error, context.Canceled)
 }


### PR DESCRIPTION
Adds context and timeout support to `runner.Shell`. Includes HCL support and updates to all dependencies calling `runner.Shell`. 