### PR TITLE
Add EtcHosts + Bugfixes and helpers

### DIFF
--- a/changelog/278.txt
+++ b/changelog/278.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+runner/host: EtcHosts can now timeout with a default of ten seconds.
+```

--- a/op/op.go
+++ b/op/op.go
@@ -61,10 +61,12 @@ func New(id string, result map[string]any, status Status, err error, params map[
 	}
 }
 
+// NewCancel takes the minimum required fields to build and return an Op with status Canceled
 func NewCancel(id string, err error, params map[string]any, start time.Time) Op {
 	return New(id, map[string]any{}, Canceled, err, params, start, time.Now())
 }
 
+// NewTimeout takes the minimum required fields to build and return an Op with status Timeout
 func NewTimeout(id string, err error, params map[string]any, start time.Time) Op {
 	return New(id, map[string]any{}, Timeout, err, params, start, time.Now())
 }

--- a/op/op.go
+++ b/op/op.go
@@ -61,6 +61,14 @@ func New(id string, result map[string]any, status Status, err error, params map[
 	}
 }
 
+func NewCancel(id string, err error, params map[string]any, start time.Time) Op {
+	return New(id, map[string]any{}, Canceled, err, params, start, time.Now())
+}
+
+func NewTimeout(id string, err error, params map[string]any, start time.Time) Op {
+	return New(id, map[string]any{}, Timeout, err, params, start, time.Now())
+}
+
 // StatusCounts takes a slice of op references and returns a map containing sums of each Status
 func StatusCounts(ops map[string]Op) (map[Status]int, error) {
 	// copy our input into a new map that conforms to our Walk input type

--- a/runner/command.go
+++ b/runner/command.go
@@ -193,11 +193,11 @@ func (c Command) Run() op.Op {
 	case <-runCtx.Done():
 		switch runCtx.Err() {
 		case context.Canceled:
-			return op.New(c.ID(), nil, op.Canceled, c.ctx.Err(), Params(c), startTime, time.Now())
+			return op.New(c.ID(), nil, op.Canceled, runCtx.Err(), Params(c), startTime, time.Now())
 		case context.DeadlineExceeded:
-			return op.New(c.ID(), nil, op.Timeout, c.ctx.Err(), Params(c), startTime, time.Now())
+			return op.New(c.ID(), nil, op.Timeout, runCtx.Err(), Params(c), startTime, time.Now())
 		default:
-			return op.New(c.ID(), nil, op.Unknown, c.ctx.Err(), Params(c), startTime, time.Now())
+			return op.New(c.ID(), nil, op.Unknown, runCtx.Err(), Params(c), startTime, time.Now())
 		}
 	case result := <-resultsChannel:
 		return result

--- a/runner/host/etc_hosts.go
+++ b/runner/host/etc_hosts.go
@@ -1,6 +1,7 @@
 package host
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 	"time"
@@ -13,15 +14,33 @@ import (
 
 var _ runner.Runner = EtcHosts{}
 
-type EtcHosts struct {
-	OS         string           `json:"os"`
-	Redactions []*redact.Redact `json:"redactions"`
+type EtcHostsConfig struct {
+	OS         string
+	Redactions []*redact.Redact
+	Timeout    runner.Timeout
 }
 
-func NewEtcHosts(redactions []*redact.Redact) *EtcHosts {
+type EtcHosts struct {
+	ctx        context.Context
+	OS         string           `json:"os"`
+	Redactions []*redact.Redact `json:"redactions"`
+	Timeout    runner.Timeout   `json:"timeout"`
+}
+
+func NewEtcHosts(cfg EtcHostsConfig) *EtcHosts {
+	return NewEtcHostsWithContext(context.Background(), cfg)
+}
+
+func NewEtcHostsWithContext(ctx context.Context, cfg EtcHostsConfig) *EtcHosts {
+	os := cfg.OS
+	if os == "" {
+		os = runtime.GOOS
+	}
 	return &EtcHosts{
-		OS:         runtime.GOOS,
-		Redactions: redactions,
+		ctx:        ctx,
+		OS:         os,
+		Redactions: cfg.Redactions,
+		Timeout:    cfg.Timeout,
 	}
 }
 
@@ -32,23 +51,58 @@ func (r EtcHosts) ID() string {
 func (r EtcHosts) Run() op.Op {
 	startTime := time.Now()
 
+	if r.ctx == nil {
+		r.ctx = context.Background()
+	}
+
+	runCtx := r.ctx
+	var cancel context.CancelFunc
+	resultChan := make(chan op.Op, 1)
+	if 0 < r.Timeout {
+		runCtx, cancel = context.WithTimeout(r.ctx, time.Duration(r.Timeout))
+		defer cancel()
+	}
+
+	go func(ch chan op.Op) {
+		o := r.run()
+		o.Start = startTime
+		ch <- o
+	}(resultChan)
+
+	select {
+	case <-runCtx.Done():
+		switch runCtx.Err() {
+		case context.Canceled:
+			return runner.CancelOp(r, runCtx.Err(), startTime)
+		case context.DeadlineExceeded:
+			return runner.TimeoutOp(r, runCtx.Err(), startTime)
+		default:
+			return op.New(r.ID(), nil, op.Unknown, runCtx.Err(), runner.Params(r), startTime, time.Now())
+		}
+	case o := <-resultChan:
+		return o
+	}
+}
+
+func (r EtcHosts) run() op.Op {
 	// Not compatible with windows
 	if r.OS == "windows" {
 		err := fmt.Errorf(" EtcHosts.Run() not available on os, os=%s", r.OS)
-		return op.New(r.ID(), nil, op.Skip, err, runner.Params(r), startTime, time.Now())
+		return op.New(r.ID(), nil, op.Skip, err, runner.Params(r), time.Time{}, time.Now())
 	}
 
 	s, err := runner.NewShell(runner.ShellConfig{
 		Command:    "cat /etc/hosts",
 		Redactions: r.Redactions,
+		Timeout:    time.Duration(r.Timeout),
 	})
 	if err != nil {
-		return op.New(r.ID(), map[string]any{}, op.Fail, err, runner.Params(r), startTime, time.Now())
+		return op.New(r.ID(), map[string]any{}, op.Fail, err, runner.Params(r), time.Time{}, time.Now())
 	}
 
 	o := s.Run()
 	if o.Error != nil {
-		return op.New(r.ID(), o.Result, op.Fail, o.Error, runner.Params(r), startTime, time.Now())
+		return o
 	}
-	return op.New(r.ID(), o.Result, op.Success, nil, runner.Params(r), startTime, time.Now())
+	return op.New(r.ID(), o.Result, op.Success, nil, runner.Params(r), time.Time{}, time.Now())
 }

--- a/runner/host/etc_hosts.go
+++ b/runner/host/etc_hosts.go
@@ -91,7 +91,7 @@ func (r EtcHosts) run() op.Op {
 		return op.New(r.ID(), nil, op.Skip, err, runner.Params(r), time.Time{}, time.Now())
 	}
 
-	s, err := runner.NewShell(runner.ShellConfig{
+	s, err := runner.NewShellWithContext(r.ctx, runner.ShellConfig{
 		Command:    "cat /etc/hosts",
 		Redactions: r.Redactions,
 		Timeout:    time.Duration(r.Timeout),

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"time"
 
 	"github.com/hashicorp/go-hclog"
 
@@ -80,4 +81,13 @@ func Params(r Runner) map[string]interface{} {
 	}
 	_ = json.Unmarshal(inrec, &inInterface)
 	return inInterface
+}
+
+// CancelOp is a helper that wraps some defaults
+func CancelOp(r Runner, err error, start time.Time) op.Op {
+	return op.NewCancel(r.ID(), err, Params(r), start)
+}
+
+func TimeoutOp(r Runner, err error, start time.Time) op.Op {
+	return op.NewTimeout(r.ID(), err, Params(r), start)
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -83,11 +83,12 @@ func Params(r Runner) map[string]interface{} {
 	return inInterface
 }
 
-// CancelOp is a helper that wraps some defaults
+// CancelOp wraps op.NewCancel to resolve the Runner.ID() and Params into concrete types.
 func CancelOp(r Runner, err error, start time.Time) op.Op {
 	return op.NewCancel(r.ID(), err, Params(r), start)
 }
 
+// TimeoutOp wraps op.NewTimeout to resolve the Runner.ID() and Params into concrete types.
 func TimeoutOp(r Runner, err error, start time.Time) op.Op {
 	return op.NewTimeout(r.ID(), err, Params(r), start)
 }

--- a/runner/shell.go
+++ b/runner/shell.go
@@ -83,11 +83,11 @@ func (s Shell) Run() op.Op {
 	case <-runCtx.Done():
 		switch runCtx.Err() {
 		case context.Canceled:
-			return op.New(s.ID(), nil, op.Canceled, s.ctx.Err(), Params(s), startTime, time.Now())
+			return op.NewCancel(s.ID(), runCtx.Err(), Params(s), startTime)
 		case context.DeadlineExceeded:
-			return op.New(s.ID(), nil, op.Timeout, s.ctx.Err(), Params(s), startTime, time.Now())
+			return op.NewTimeout(s.ID(), runCtx.Err(), Params(s), startTime)
 		default:
-			return op.New(s.ID(), nil, op.Unknown, s.ctx.Err(), Params(s), startTime, time.Now())
+			return op.New(s.ID(), nil, op.Unknown, runCtx.Err(), Params(s), startTime, time.Now())
 		}
 	case result := <-resChan:
 		return result


### PR DESCRIPTION
This PR adds config, ctx, and timeouts to `EtcHosts` by passing through to the Shell runner it wraps. As I was checking that the timeouts worked correctly, I found that we were getting back an empty error from the wrapped Shell. This is because we were returning the error on the wrong context in the op return. This bug also existed on Command so I addressed it there.

Alongside this, I was experimenting with some helper functions that fill in the commonly used fields in Timeout and Cancel status ops, so those are also deployed here.