### PR TITLE
Add Timeout & Cancelation to Docker Log Runner

### DIFF
--- a/changelog/281.txt
+++ b/changelog/281.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+runners: The Docker log runner now takes an optional Timeout value, so that long-running executions can be gracefully stopped.
+```

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -165,6 +165,7 @@ type DockerLog struct {
 	Container  string   `hcl:"container" json:"container"`
 	Since      string   `hcl:"since,optional" json:"since"`
 	Redactions []Redact `hcl:"redact,block" json:"redactions,omitempty"`
+	Timeout    string   `hcl:"timeout,optional" json:"timeout,omitempty"`
 }
 
 type JournaldLog struct {
@@ -497,7 +498,20 @@ func mapDockerLogs(ctx context.Context, cfgs []DockerLog, dest string, since tim
 			// bug: different runners have different now values but it's unlikely to ever cause an issues for users.
 			since = time.Now().Add(-dur)
 		}
-		runners[i] = log.NewDocker(d.Container, dest, since, runnerRedacts)
+		var timeout time.Duration
+		if d.Timeout != "" {
+			timeout, err = time.ParseDuration(d.Timeout)
+			if err != nil {
+				return nil, err
+			}
+		}
+		runners[i] = log.NewDockerWithContext(ctx, log.DockerConfig{
+			Container:  d.Container,
+			DestDir:    dest,
+			Since:      since,
+			Redactions: runnerRedacts,
+			Timeout:    timeout,
+		})
 	}
 	return runners, nil
 }

--- a/product/consul.go
+++ b/product/consul.go
@@ -124,7 +124,13 @@ func consulRunners(ctx context.Context, cfg Config, api *client.APIClient, l hcl
 	}
 
 	r = append(r,
-		logs.NewDocker("consul", cfg.TmpDir, cfg.Since, cfg.Redactions),
+		logs.NewDockerWithContext(ctx,
+			logs.DockerConfig{
+				Container:  "consul",
+				DestDir:    cfg.TmpDir,
+				Since:      cfg.Since,
+				Redactions: cfg.Redactions,
+			}),
 		logs.NewJournald("consul", cfg.TmpDir, cfg.Since, cfg.Until, cfg.Redactions),
 	)
 

--- a/product/nomad.go
+++ b/product/nomad.go
@@ -130,7 +130,13 @@ func nomadRunners(ctx context.Context, cfg Config, api *client.APIClient, l hclo
 	}
 
 	r = append(r,
-		logs.NewDocker("nomad", cfg.TmpDir, cfg.Since, cfg.Redactions),
+		logs.NewDockerWithContext(ctx,
+			logs.DockerConfig{
+				Container:  "nomad",
+				DestDir:    cfg.TmpDir,
+				Since:      cfg.Since,
+				Redactions: cfg.Redactions,
+			}),
 		logs.NewJournald("nomad", cfg.TmpDir, cfg.Since, cfg.Until, cfg.Redactions),
 	)
 

--- a/product/vault.go
+++ b/product/vault.go
@@ -109,7 +109,13 @@ func vaultRunners(ctx context.Context, cfg Config, api *client.APIClient, l hclo
 	r = append(r, dbg)
 
 	r = append(r,
-		logs.NewDocker("vault", cfg.TmpDir, cfg.Since, cfg.Redactions),
+		logs.NewDockerWithContext(ctx,
+			logs.DockerConfig{
+				Container:  "vault",
+				DestDir:    cfg.TmpDir,
+				Since:      cfg.Since,
+				Redactions: cfg.Redactions,
+			}),
 		logs.NewJournald("vault", cfg.TmpDir, cfg.Since, cfg.Until, cfg.Redactions),
 	)
 

--- a/runner/log/docker.go
+++ b/runner/log/docker.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -12,24 +13,49 @@ import (
 
 var _ runner.Runner = Docker{}
 
+type DockerConfig struct {
+	// Container is the name of the docker container to get logs from
+	Container string
+	// DestDir is the directory we will write the logs to
+	DestDir string
+	// Since marks the beginning of the time range to include logs
+	Since time.Time
+	// Redactions includes any redactions to apply to the output of the runner.
+	Redactions []*redact.Redact
+	// Timeout specifies the amount of time that the runner should be allowed to execute before cancellation.
+	Timeout time.Duration
+}
+
 // Docker allows logs to be retrieved for a docker container
 type Docker struct {
+	ctx context.Context
+
 	// Container is the name of the docker container to get logs from
 	Container string `json:"container"`
 	// DestDir is the directory we will write the logs to
 	DestDir string `json:"destDir"`
 	// Since marks the beginning of the time range to include logs
-	Since      time.Time        `json:"since"`
+	Since time.Time `json:"since"`
+	// Redactions includes any redactions to apply to the output of the runner.
 	Redactions []*redact.Redact `json:"redactions"`
+	// Timeout specifies the amount of time that the runner should be allowed to execute before cancellation.
+	Timeout runner.Timeout `json:"timeout"`
 }
 
 // NewDocker returns a runner with an identifier and fully configured docker runner
-func NewDocker(container, destDir string, since time.Time, redactions []*redact.Redact) *Docker {
+func NewDocker(cfg DockerConfig) *Docker {
+	return NewDockerWithContext(context.Background(), cfg)
+}
+
+// NewDockerWithContext returns a runner with an identifier and fully configured docker runner, which includes a provided context.
+func NewDockerWithContext(ctx context.Context, cfg DockerConfig) *Docker {
 	return &Docker{
-		Container:  container,
-		DestDir:    destDir,
-		Since:      since,
-		Redactions: redactions,
+		ctx:        ctx,
+		Container:  cfg.Container,
+		DestDir:    cfg.DestDir,
+		Since:      cfg.Since,
+		Redactions: cfg.Redactions,
+		Timeout:    runner.Timeout(cfg.Timeout),
 	}
 }
 
@@ -41,13 +67,47 @@ func (d Docker) ID() string {
 func (d Docker) Run() op.Op {
 	startTime := time.Now()
 
+	if d.ctx == nil {
+		d.ctx = context.Background()
+	}
+
+	runCtx := d.ctx
+	var cancel context.CancelFunc
+	resultChan := make(chan op.Op, 1)
+	if 0 < d.Timeout {
+		runCtx, cancel = context.WithTimeout(d.ctx, time.Duration(d.Timeout))
+		defer cancel()
+	}
+
+	go func(ch chan op.Op) {
+		o := d.run()
+		o.Start = startTime
+		ch <- o
+	}(resultChan)
+
+	select {
+	case <-runCtx.Done():
+		switch runCtx.Err() {
+		case context.Canceled:
+			return op.New(d.ID(), nil, op.Canceled, runCtx.Err(), runner.Params(d), startTime, time.Now())
+		case context.DeadlineExceeded:
+			return op.New(d.ID(), nil, op.Timeout, runCtx.Err(), runner.Params(d), startTime, time.Now())
+		default:
+			return op.New(d.ID(), nil, op.Unknown, runCtx.Err(), runner.Params(d), startTime, time.Now())
+		}
+	case o := <-resultChan:
+		return o
+	}
+}
+
+func (d Docker) run() op.Op {
 	// Check that docker exists
 	version, err := runner.NewShell(runner.ShellConfig{
 		Command:    "docker version",
 		Redactions: d.Redactions,
 	})
 	if err != nil {
-		return op.New(d.ID(), map[string]any{}, op.Fail, err, runner.Params(d), startTime, time.Now())
+		return op.New(d.ID(), map[string]any{}, op.Fail, err, runner.Params(d), time.Time{}, time.Now())
 	}
 	versionOp := version.Run()
 	if versionOp.Error != nil {
@@ -55,19 +115,19 @@ func (d Docker) Run() op.Op {
 			container: d.Container,
 			err:       versionOp.Error,
 		},
-			runner.Params(d), startTime, time.Now())
+			runner.Params(d), time.Time{}, time.Now())
 	}
 
 	// Check whether the container can be found on the system
 	ok, err := d.containerExists()
 	if err != nil {
-		return op.New(d.ID(), map[string]any{}, op.Fail, err, runner.Params(d), startTime, time.Now())
+		return op.New(d.ID(), map[string]any{}, op.Fail, err, runner.Params(d), time.Time{}, time.Now())
 	}
 	if !ok {
 		return op.New(d.ID(), map[string]any{}, op.Skip, ContainerNotFoundError{
 			container: d.Container,
 		},
-			runner.Params(d), startTime, time.Now())
+			runner.Params(d), time.Time{}, time.Now())
 	}
 
 	// Retrieve logs
@@ -76,14 +136,14 @@ func (d Docker) Run() op.Op {
 		Redactions: d.Redactions,
 	})
 	if err != nil {
-		return op.New(d.ID(), map[string]any{}, op.Fail, err, runner.Params(d), startTime, time.Now())
+		return op.New(d.ID(), map[string]any{}, op.Fail, err, runner.Params(d), time.Time{}, time.Now())
 	}
 	logOp := logShell.Run()
 	if logOp.Error != nil {
-		return op.New(d.ID(), logOp.Result, logOp.Status, logOp.Error, runner.Params(d), startTime, time.Now())
+		return op.New(d.ID(), logOp.Result, logOp.Status, logOp.Error, runner.Params(d), time.Time{}, time.Now())
 	}
 
-	return op.New(d.ID(), logOp.Result, op.Success, nil, runner.Params(d), startTime, time.Now())
+	return op.New(d.ID(), logOp.Result, op.Success, nil, runner.Params(d), time.Time{}, time.Now())
 }
 
 func DockerLogCmd(container, destDir string, since time.Time) string {

--- a/runner/log/docker.go
+++ b/runner/log/docker.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/hcdiag/op"
 	"github.com/hashicorp/hcdiag/redact"
+	"github.com/hashicorp/hcdiag/util"
 
 	"github.com/hashicorp/hcdiag/runner"
 )
@@ -128,6 +129,12 @@ func (d Docker) run() op.Op {
 			container: d.Container,
 		},
 			runner.Params(d), time.Time{}, time.Now())
+	}
+
+	// Ensure the destination directory exists
+	err = util.EnsureDirectory(d.DestDir)
+	if err != nil {
+		return op.New(d.ID(), nil, op.Fail, err, runner.Params(d), time.Time{}, time.Now())
 	}
 
 	// Retrieve logs

--- a/runner/log/docker.go
+++ b/runner/log/docker.go
@@ -89,9 +89,9 @@ func (d Docker) Run() op.Op {
 	case <-runCtx.Done():
 		switch runCtx.Err() {
 		case context.Canceled:
-			return op.New(d.ID(), nil, op.Canceled, runCtx.Err(), runner.Params(d), startTime, time.Now())
+			return runner.CancelOp(d, runCtx.Err(), startTime)
 		case context.DeadlineExceeded:
-			return op.New(d.ID(), nil, op.Timeout, runCtx.Err(), runner.Params(d), startTime, time.Now())
+			return runner.TimeoutOp(d, runCtx.Err(), startTime)
 		default:
 			return op.New(d.ID(), nil, op.Unknown, runCtx.Err(), runner.Params(d), startTime, time.Now())
 		}


### PR DESCRIPTION
This merge enables timeouts and cancellation in the Docker Log runner. Timeouts may be passed in via optional configuration. If the timeout expires, or if a context that has been passed into the runner when it was constructed is canceled, then the run will stop with an appropriate operation status type.