### PR TITLE
Traverse Nested Runners for ManifestOps

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -364,20 +364,12 @@ func (a *Agent) RunProducts() error {
 
 // RecordManifest writes additional data to the agent to serialize into manifest.json
 func (a *Agent) RecordManifest() {
-	for name, ops := range a.results {
-		for _, o := range ops {
-			// duration string, in nanoseconds
-			dur := fmt.Sprintf("%d nanoseconds", o.End.Sub(o.Start).Nanoseconds())
-
-			m := ManifestOp{
-				ID:       o.Identifier,
-				Error:    o.ErrString,
-				Status:   o.Status,
-				Duration: dur,
-			}
-			a.ManifestOps[string(name)] = append(a.ManifestOps[string(name)], m)
-		}
+	result := make(map[string][]ManifestOp)
+	for productName, ops := range a.results {
+		manifestOps := WalkResultsForManifest(ops)
+		result[string(productName)] = manifestOps
 	}
+	a.ManifestOps = result
 }
 
 // WriteOutput renders the manifest and results of the diagnostics run and writes the compressed archive.

--- a/agent/manifest.go
+++ b/agent/manifest.go
@@ -18,7 +18,7 @@ type ManifestOp struct {
 	Duration string    `json:"duration"`
 }
 
-// WalkResultsForManifest translates arbitrarily deeply nested op.Ops and flattens them into a slice of ManifestOp.
+// WalkResultsForManifest translates maps of arbitrarily deeply nested op.Ops and flattens them into a slice of ManifestOp.
 // In the case of nested runners, such as in Do or DoSync blocks, outer Op will contain results for all of the inner
 // runners. This function allows for reporting on the total number of Ops rather than just the outer Op.
 func WalkResultsForManifest(results map[string]op.Op) []ManifestOp {

--- a/agent/manifest.go
+++ b/agent/manifest.go
@@ -18,6 +18,9 @@ type ManifestOp struct {
 	Duration string    `json:"duration"`
 }
 
+// WalkResultsForManifest translates arbitrarily deeply nested op.Ops and flattens them into a slice of ManifestOp.
+// In the case of nested runners, such as in Do or DoSync blocks, outer Op will contain results for all of the inner
+// runners. This function allows for reporting on the total number of Ops rather than just the outer Op.
 func WalkResultsForManifest(results map[string]op.Op) []ManifestOp {
 	m := make(map[string]any, 0)
 	for k, v := range results {

--- a/agent/manifest.go
+++ b/agent/manifest.go
@@ -6,8 +6,6 @@ package agent
 import (
 	"fmt"
 
-	"github.com/davecgh/go-spew/spew"
-
 	"github.com/hashicorp/hcdiag/op"
 )
 
@@ -26,10 +24,10 @@ func WalkResultsForManifest(results map[string]op.Op) []ManifestOp {
 		m[k] = any(v)
 	}
 	acc := make([]ManifestOp, 0)
-	return walk(m, acc)
+	return walk(m, &acc)
 }
 
-func walk(res map[string]any, acc []ManifestOp) []ManifestOp {
+func walk(res map[string]any, acc *[]ManifestOp) []ManifestOp {
 	for _, v := range res {
 		switch o := v.(type) {
 		case op.Op:
@@ -39,13 +37,11 @@ func walk(res map[string]any, acc []ManifestOp) []ManifestOp {
 				Status:   o.Status,
 				Duration: fmt.Sprintf("%d", o.End.Sub(o.Start).Nanoseconds()),
 			}
-			acc = append(acc, manifestOp)
-			spew.Dump("iterate", acc)
+			*acc = append(*acc, manifestOp)
 			walk(o.Result, acc)
 		default:
-			spew.Dump("return", acc)
 			continue
 		}
 	}
-	return acc
+	return *acc
 }

--- a/agent/manifest.go
+++ b/agent/manifest.go
@@ -4,6 +4,10 @@
 package agent
 
 import (
+	"fmt"
+
+	"github.com/davecgh/go-spew/spew"
+
 	"github.com/hashicorp/hcdiag/op"
 )
 
@@ -14,4 +18,34 @@ type ManifestOp struct {
 	Error    string    `json:"error"`
 	Status   op.Status `json:"status"`
 	Duration string    `json:"duration"`
+}
+
+func WalkResultsForManifest(results map[string]op.Op) []ManifestOp {
+	m := make(map[string]any, 0)
+	for k, v := range results {
+		m[k] = any(v)
+	}
+	acc := make([]ManifestOp, 0)
+	return walk(m, acc)
+}
+
+func walk(res map[string]any, acc []ManifestOp) []ManifestOp {
+	for _, v := range res {
+		switch o := v.(type) {
+		case op.Op:
+			manifestOp := ManifestOp{
+				ID:       o.Identifier,
+				Error:    o.ErrString,
+				Status:   o.Status,
+				Duration: fmt.Sprintf("%d", o.End.Sub(o.Start).Nanoseconds()),
+			}
+			acc = append(acc, manifestOp)
+			spew.Dump("iterate", acc)
+			walk(o.Result, acc)
+		default:
+			spew.Dump("return", acc)
+			continue
+		}
+	}
+	return acc
 }

--- a/agent/manifest_test.go
+++ b/agent/manifest_test.go
@@ -1,0 +1,98 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/hashicorp/hcdiag/op"
+)
+
+func TestWalkResultsForManifest(t *testing.T) {
+	testTable := []struct {
+		desc          string
+		ops           map[string]op.Op
+		expectedCount int
+	}{
+		{
+			desc:          "Empty map produces empty slice of ManifestOp",
+			ops:           map[string]op.Op{},
+			expectedCount: 0,
+		},
+		{
+			desc: "Simple result value types are extracted",
+			ops: map[string]op.Op{
+				"opname": {
+					Result: map[string]any{
+						"result1": "string result",
+					},
+				},
+			},
+			expectedCount: 1,
+		},
+		{
+			desc: "Shallow nested result value types are extracted",
+			ops: map[string]op.Op{
+				// Outer Op should be counted
+				"do host": {
+					Result: map[string]any{
+						// Inner Op Level 1 should be counted
+						"/etc/hosts": op.Op{
+							Result: map[string]any{
+								"shell": "##\nHost Database...",
+							},
+						},
+						// Inner Op Level 1 should be counted
+						"memory": op.Op{
+							Result: map[string]any{
+								"memoryInfo": "Memory Info",
+							},
+						},
+					},
+				},
+			},
+			expectedCount: 3,
+		},
+		{
+			desc: "Deeply nested result value types are extracted",
+			ops: map[string]op.Op{
+				// Outer Op should be counted
+				"do host": {
+					Result: map[string]any{
+						// Inner Op Level 1 should be counted
+						"level1InnerOp1": op.Op{
+							Result: map[string]any{
+								// Inner Op Level 2 should be counted
+								"level2InnerOp1": op.Op{
+									Result: map[string]any{
+										// Inner Op Level 3 should be counted
+										"level3InnerOp1": op.Op{
+											Result: map[string]any{
+												"result": "value",
+											},
+										},
+										"result": "value",
+									},
+								},
+								// Inner Op Level 2 should be counted
+								"level2InnerOp2": op.Op{
+									Result: map[string]any{
+										"result": "value",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCount: 5,
+		},
+	}
+
+	for _, tc := range testTable {
+		t.Run(tc.desc, func(t *testing.T) {
+			manifestOps := WalkResultsForManifest(tc.ops)
+			assert.Equal(t, tc.expectedCount, len(manifestOps))
+		})
+	}
+}


### PR DESCRIPTION
This merge addresses an issue with reporting that was introduced when product runners were wrapped inside Do blocks. Previous reporting, both in manifest.json and in the end-of-run results summary, did not account for nested runners, so they would only show 1 runner (the Do runner) instead of indicating all of the nested runner counts. This is now addressed, with a new function that walks arbitrarily nested Op maps and produces a slice of ManifestOp that incorporates each one.