### PR TITLE
Add Timeout & Cancellation to Journald Log Runner

### DIFF
--- a/changelog/284.txt
+++ b/changelog/284.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+runners: The Journald log runner now takes an optional Timeout value, so that long-running executions can be gracefully stopped.
+```

--- a/product/consul.go
+++ b/product/consul.go
@@ -134,7 +134,13 @@ func consulRunners(ctx context.Context, cfg Config, api *client.APIClient, l hcl
 				Since:      cfg.Since,
 				Redactions: cfg.Redactions,
 			}),
-		logs.NewJournald("consul", cfg.TmpDir, cfg.Since, cfg.Until, cfg.Redactions),
+		logs.NewJournaldWithContext(ctx,
+			logs.JournaldConfig{
+				Service:    "consul",
+				DestDir:    cfg.TmpDir,
+				Since:      cfg.Since,
+				Until:      cfg.Until,
+				Redactions: cfg.Redactions}),
 	)
 
 	// try to detect log location to copy

--- a/product/nomad.go
+++ b/product/nomad.go
@@ -140,7 +140,13 @@ func nomadRunners(ctx context.Context, cfg Config, api *client.APIClient, l hclo
 				Since:      cfg.Since,
 				Redactions: cfg.Redactions,
 			}),
-		logs.NewJournald("nomad", cfg.TmpDir, cfg.Since, cfg.Until, cfg.Redactions),
+		logs.NewJournaldWithContext(ctx,
+			logs.JournaldConfig{
+				Service:    "nomad",
+				DestDir:    cfg.TmpDir,
+				Since:      cfg.Since,
+				Until:      cfg.Until,
+				Redactions: cfg.Redactions}),
 	)
 
 	// try to detect log location to copy

--- a/product/vault.go
+++ b/product/vault.go
@@ -119,7 +119,13 @@ func vaultRunners(ctx context.Context, cfg Config, api *client.APIClient, l hclo
 				Since:      cfg.Since,
 				Redactions: cfg.Redactions,
 			}),
-		logs.NewJournald("vault", cfg.TmpDir, cfg.Since, cfg.Until, cfg.Redactions),
+		logs.NewJournaldWithContext(ctx,
+			logs.JournaldConfig{
+				Service:    "vault",
+				DestDir:    cfg.TmpDir,
+				Since:      cfg.Since,
+				Until:      cfg.Until,
+				Redactions: cfg.Redactions}),
 	)
 
 	// try to detect log location to copy

--- a/runner/log/journald_test.go
+++ b/runner/log/journald_test.go
@@ -13,54 +13,58 @@ import (
 
 func TestJournalctlGetLogsCmd(t *testing.T) {
 	testTable := []struct {
-		desc       string
-		name       string
-		destDir    string
-		since      time.Time
-		until      time.Time
-		expect     string
-		redactions []*redact.Redact
+		desc   string
+		expect string
+		cfg    JournaldConfig
 	}{
 		{
-			desc:       "No since or until",
-			name:       "nomad",
-			destDir:    "/testing/test",
-			since:      time.Time{},
-			until:      time.Time{},
-			expect:     "journalctl -x -u nomad --no-pager > /testing/test/journald-nomad.log",
-			redactions: make([]*redact.Redact, 0),
+			desc: "No since or until",
+			cfg: JournaldConfig{
+				Service:    "nomad",
+				DestDir:    "/testing/test",
+				Since:      time.Time{},
+				Until:      time.Time{},
+				Redactions: make([]*redact.Redact, 0),
+			},
+			expect: "journalctl -x -u nomad --no-pager > /testing/test/journald-nomad.log",
 		},
 		{
-			desc:       "With since but not until",
-			name:       "nomad",
-			destDir:    "/testing/test",
-			since:      time.Date(1, 1, 1, 1, 1, 1, 1, &time.Location{}),
-			until:      time.Time{},
-			expect:     "journalctl -x -u nomad --since \"0001-01-01 01:01:01\" --no-pager > /testing/test/journald-nomad.log",
-			redactions: []*redact.Redact{},
+			desc: "With since but not until",
+			cfg: JournaldConfig{
+				Service:    "nomad",
+				DestDir:    "/testing/test",
+				Since:      time.Date(1, 1, 1, 1, 1, 1, 1, &time.Location{}),
+				Until:      time.Time{},
+				Redactions: []*redact.Redact{},
+			},
+			expect: "journalctl -x -u nomad --since \"0001-01-01 01:01:01\" --no-pager > /testing/test/journald-nomad.log",
 		},
 		{
-			desc:       "With until but not since",
-			name:       "nomad",
-			destDir:    "/testing/test",
-			since:      time.Time{},
-			until:      time.Date(2, 1, 1, 1, 1, 1, 1, &time.Location{}),
-			expect:     "journalctl -x -u nomad --until \"0002-01-01 01:01:01\" --no-pager > /testing/test/journald-nomad.log",
-			redactions: nil,
+			desc: "With until but not since",
+			cfg: JournaldConfig{
+				Service:    "nomad",
+				DestDir:    "/testing/test",
+				Since:      time.Time{},
+				Until:      time.Date(2, 1, 1, 1, 1, 1, 1, &time.Location{}),
+				Redactions: nil,
+			},
+			expect: "journalctl -x -u nomad --until \"0002-01-01 01:01:01\" --no-pager > /testing/test/journald-nomad.log",
 		},
 		{
-			desc:       "with since and until",
-			name:       "nomad",
-			destDir:    "/testing/test",
-			since:      time.Date(1, 1, 1, 1, 1, 1, 1, &time.Location{}),
-			until:      time.Date(2, 1, 1, 1, 1, 1, 1, &time.Location{}),
-			expect:     "journalctl -x -u nomad --since \"0001-01-01 01:01:01\" --until \"0002-01-01 01:01:01\" --no-pager > /testing/test/journald-nomad.log",
-			redactions: nil,
+			desc: "with since and until",
+			cfg: JournaldConfig{
+				Service:    "nomad",
+				DestDir:    "/testing/test",
+				Since:      time.Date(1, 1, 1, 1, 1, 1, 1, &time.Location{}),
+				Until:      time.Date(2, 1, 1, 1, 1, 1, 1, &time.Location{}),
+				Redactions: nil,
+			},
+			expect: "journalctl -x -u nomad --since \"0001-01-01 01:01:01\" --until \"0002-01-01 01:01:01\" --no-pager > /testing/test/journald-nomad.log",
 		},
 	}
 
 	for _, tc := range testTable {
-		j := NewJournald(tc.name, tc.destDir, tc.since, tc.until, tc.redactions)
+		j := NewJournald(tc.cfg)
 		result := j.LogsCmd()
 		assert.Equal(t, tc.expect, result)
 	}


### PR DESCRIPTION
This merge enables timeouts and cancellation in the Journald Log runner. Timeouts may be passed in via optional configuration. If the timeout expires, or if a context that has been passed into the runner when it was constructed is canceled, then the run will stop with an appropriate operation status type.