### PR TITLE
Add Timeout & Cancellation to Host/GET Runner

### DIFF
--- a/changelog/285.txt
+++ b/changelog/285.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+runners: The host get runner now takes an optional Timeout value, so that long-running executions can be gracefully stopped.
+```

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -474,9 +474,23 @@ func mapHostGets(ctx context.Context, cfgs []GET, redactions []*redact.Redact) (
 		}
 		// Prepend runner-level redactions to those passed in
 		runnerRedacts = append(runnerRedacts, redactions...)
+		var timeout time.Duration
+		if g.Timeout != "" {
+			timeout, err = time.ParseDuration(g.Timeout)
+			if err != nil {
+				return nil, err
+			}
+		}
+		r, err := host.NewGetWithContext(ctx, host.GetConfig{
+			Path:       g.Path,
+			Timeout:    timeout,
+			Redactions: runnerRedacts,
+		})
+		if err != nil {
+			return nil, err
+		}
 
-		// TODO(mkcp): add redactions to host Get
-		runners[i] = host.NewGet(g.Path, runnerRedacts)
+		runners[i] = r
 	}
 	return runners, nil
 }

--- a/runner/host/get.go
+++ b/runner/host/get.go
@@ -4,6 +4,7 @@
 package host
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -16,16 +17,34 @@ import (
 
 var _ runner.Runner = Get{}
 
-type Get struct {
-	Path       string           `json:"path"`
-	Redactions []*redact.Redact `json:"redactions"`
+type GetConfig struct {
+	Path string
+	// Redactions includes any redactions to apply to the output of the runner.
+	Redactions []*redact.Redact
+	// Timeout specifies the amount of time that the runner should be allowed to execute before cancellation.
+	Timeout time.Duration
 }
 
-func NewGet(path string, redactions []*redact.Redact) *Get {
+type Get struct {
+	ctx context.Context
+
+	Path string `json:"path"`
+	// Redactions includes any redactions to apply to the output of the runner.
+	Redactions []*redact.Redact `json:"redactions"`
+	// Timeout specifies the amount of time that the runner should be allowed to execute before cancellation.
+	Timeout runner.Timeout `json:"timeout"`
+}
+
+func NewGet(cfg GetConfig) (*Get, error) {
+	return NewGetWithContext(context.Background(), cfg)
+}
+
+func NewGetWithContext(ctx context.Context, cfg GetConfig) (*Get, error) {
 	return &Get{
-		Path:       path,
-		Redactions: redactions,
-	}
+		Path:       cfg.Path,
+		Redactions: cfg.Redactions,
+		Timeout:    runner.Timeout(cfg.Timeout),
+	}, nil
 }
 
 func (g Get) ID() string {
@@ -35,6 +54,40 @@ func (g Get) ID() string {
 func (g Get) Run() op.Op {
 	startTime := time.Now()
 
+	if g.ctx == nil {
+		g.ctx = context.Background()
+	}
+
+	runCtx := g.ctx
+	var cancel context.CancelFunc
+	resultChan := make(chan op.Op, 1)
+	if 0 < g.Timeout {
+		runCtx, cancel = context.WithTimeout(g.ctx, time.Duration(g.Timeout))
+		defer cancel()
+	}
+
+	go func(ch chan op.Op) {
+		o := g.run()
+		o.Start = startTime
+		ch <- o
+	}(resultChan)
+
+	select {
+	case <-runCtx.Done():
+		switch runCtx.Err() {
+		case context.Canceled:
+			return runner.CancelOp(g, runCtx.Err(), startTime)
+		case context.DeadlineExceeded:
+			return runner.TimeoutOp(g, runCtx.Err(), startTime)
+		default:
+			return op.New(g.ID(), nil, op.Unknown, runCtx.Err(), runner.Params(g), startTime, time.Now())
+		}
+	case o := <-resultChan:
+		return o
+	}
+}
+
+func (g Get) run() op.Op {
 	cmd := strings.Join([]string{"curl -s", g.Path}, " ")
 	// NOTE(mkcp): We will get JSON back from a lot of requests, so this can be improved
 	format := "string"
@@ -45,8 +98,8 @@ func (g Get) Run() op.Op {
 	}
 	cmdRunner, err := runner.NewCommand(cmdCfg)
 	if err != nil {
-		return op.New(g.ID(), nil, op.Fail, err, runner.Params(g), startTime, time.Now())
+		return op.New(g.ID(), nil, op.Fail, err, runner.Params(g), time.Time{}, time.Now())
 	}
 	o := cmdRunner.Run()
-	return op.New(g.ID(), o.Result, o.Status, o.Error, runner.Params(g), startTime, time.Now())
+	return op.New(g.ID(), o.Result, o.Status, o.Error, runner.Params(g), time.Time{}, time.Now())
 }


### PR DESCRIPTION
This merge enables timeouts and cancellation in the host GET runner. Timeouts may be passed in via optional configuration. If the timeout expires, or if a context that has been passed into the runner when it was constructed is canceled, then the run will stop with an appropriate operation status type.