### PR TITLE
Add Timeout & Cancellation to Host/Disk Runner

### DIFF
--- a/changelog/286.txt
+++ b/changelog/286.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+runners: The host disk runner now takes an optional Timeout value, so that long-running executions can be gracefully stopped.
+```

--- a/product/host.go
+++ b/product/host.go
@@ -79,7 +79,7 @@ func NewHostWithContext(ctx context.Context, logger hclog.Logger, cfg Config, hc
 func hostRunners(ctx context.Context, os string, redactions []*redact.Redact, l hclog.Logger) []runner.Runner {
 	r := []runner.Runner{
 		host.NewOS(os, redactions),
-		host.NewDisk(redactions),
+		host.NewDiskWithContext(ctx, host.DiskConfig{Redactions: redactions}),
 		host.NewInfo(redactions),
 		// TODO(mkcp): Source the timeout value from agent/CLI params, or extract to a const.
 		host.NewMemoryWithContext(ctx, TimeoutThirtySeconds),


### PR DESCRIPTION
This merge enables timeouts and cancellation in the host disk runner. Timeouts may be passed in via optional configuration. If the timeout expires, or if a context that has been passed into the runner when it was constructed is canceled, then the run will stop with an appropriate operation status type.