### PR TITLE
Support timeouts and cancellation in host/iptables

### DIFF
--- a/changelog/288.txt
+++ b/changelog/288.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+runners: The host IPTables runner now takes an optional Timeout value, so that long-running executions can be gracefully stopped.
+```

--- a/product/host.go
+++ b/product/host.go
@@ -85,7 +85,11 @@ func hostRunners(ctx context.Context, os string, redactions []*redact.Redact, l 
 		host.NewMemoryWithContext(ctx, TimeoutThirtySeconds),
 		host.NewProcess(redactions),
 		host.NewNetwork(redactions),
-		host.NewIPTables(os, redactions),
+		host.NewIPTablesWithContext(ctx, host.IPTablesConfig{
+			OS:         os,
+			Redactions: redactions,
+			Timeout:    TimeoutThirtySeconds,
+		}),
 		host.NewEtcHostsWithContext(ctx, host.EtcHostsConfig{
 			OS:         os,
 			Redactions: redactions,

--- a/runner/host/iptables.go
+++ b/runner/host/iptables.go
@@ -4,6 +4,7 @@
 package host
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 	"time"
@@ -16,22 +17,39 @@ import (
 
 var _ runner.Runner = IPTables{}
 
+type IPTablesConfig struct {
+	OS         string
+	Redactions []*redact.Redact
+	Timeout    runner.Timeout
+}
+
 type IPTables struct {
+	ctx context.Context
+
+	OS         string           `json:"os"`
 	Commands   []string         `json:"commands"`
 	Redactions []*redact.Redact `json:"redactions"`
-	OS         string           `json:"os"`
+	Timeout    runner.Timeout   `json:"timeout"`
 }
 
 // NewIPTables returns a runner configured to run several iptables commands
-func NewIPTables(os string, redactions []*redact.Redact) *IPTables {
+func NewIPTables(cfg IPTablesConfig) *IPTables {
+	return NewIPTablesWithContext(context.Background(), cfg)
+}
+
+// NewIPTablesWithContext returns a runner configured to run several iptables commands
+func NewIPTablesWithContext(ctx context.Context, cfg IPTablesConfig) *IPTables {
+	commands := []string{
+		"iptables -L -n -v",
+		"iptables -L -n -v -t nat",
+		"iptables -L -n -v -t mangle",
+	}
 	return &IPTables{
-		OS: os,
-		Commands: []string{
-			"iptables -L -n -v",
-			"iptables -L -n -v -t nat",
-			"iptables -L -n -v -t mangle",
-		},
-		Redactions: redactions,
+		ctx:        ctx,
+		OS:         cfg.OS,
+		Commands:   commands,
+		Redactions: cfg.Redactions,
+		Timeout:    cfg.Timeout,
 	}
 }
 
@@ -41,8 +59,43 @@ func (r IPTables) ID() string {
 
 func (r IPTables) Run() op.Op {
 	startTime := time.Now()
+
+	if r.ctx == nil {
+		r.ctx = context.Background()
+	}
+
+	runCtx := r.ctx
+	var cancel context.CancelFunc
+	resultChan := make(chan op.Op, 1)
+	if 0 < r.Timeout {
+		runCtx, cancel = context.WithTimeout(r.ctx, time.Duration(r.Timeout))
+		defer cancel()
+	}
+
+	go func(ctx context.Context, ch chan op.Op) {
+		o := r.run(ctx)
+		o.Start = startTime
+		ch <- o
+	}(runCtx, resultChan)
+
+	select {
+	case <-runCtx.Done():
+		switch runCtx.Err() {
+		case context.Canceled:
+			return runner.CancelOp(r, runCtx.Err(), startTime)
+		case context.DeadlineExceeded:
+			return runner.TimeoutOp(r, runCtx.Err(), startTime)
+		default:
+			return op.New(r.ID(), nil, op.Unknown, runCtx.Err(), runner.Params(r), startTime, time.Now())
+		}
+	case o := <-resultChan:
+		return o
+	}
+}
+
+func (r IPTables) run(ctx context.Context) op.Op {
 	if r.OS != "linux" {
-		return op.New(r.ID(), nil, op.Skip, fmt.Errorf("os not linux, skipping, os=%s", runtime.GOOS), runner.Params(r), startTime, time.Now())
+		return op.New(r.ID(), nil, op.Skip, fmt.Errorf("os not linux, skipping, os=%s", runtime.GOOS), runner.Params(r), time.Time{}, time.Now())
 	}
 	result := make(map[string]any)
 	for _, c := range r.Commands {
@@ -50,13 +103,14 @@ func (r IPTables) Run() op.Op {
 			Command:    c,
 			Format:     "string",
 			Redactions: r.Redactions,
+			Timeout:    time.Duration(r.Timeout),
 		}
-		cmdRunner, err := runner.NewCommand(cmdCfg)
+		cmdRunner, err := runner.NewCommandWithContext(ctx, cmdCfg)
 		if err != nil {
-			return op.New(r.ID(), nil, op.Fail, err, runner.Params(r), startTime, time.Now())
+			return op.New(r.ID(), nil, op.Fail, err, runner.Params(r), time.Time{}, time.Now())
 		}
 		o := cmdRunner.Run()
 		result[c] = o.Result
 	}
-	return op.New(r.ID(), result, op.Success, nil, runner.Params(r), startTime, time.Now())
+	return op.New(r.ID(), result, op.Success, nil, runner.Params(r), time.Time{}, time.Now())
 }


### PR DESCRIPTION
This PR updates host/iptables to support timeouts and cancellations in its Run fn, as well as passing through the context and timeout value to each sub-runner. 