### PR TITLE
Add Timeout & Cancellation to Host/Info Runner

### DIFF
--- a/changelog/289.txt
+++ b/changelog/289.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+runners: The host info runner now takes an optional Timeout value, so that long-running executions can be gracefully stopped.
+```

--- a/product/host.go
+++ b/product/host.go
@@ -80,7 +80,7 @@ func hostRunners(ctx context.Context, os string, redactions []*redact.Redact, l 
 	r := []runner.Runner{
 		host.NewOS(os, redactions),
 		host.NewDiskWithContext(ctx, host.DiskConfig{Redactions: redactions}),
-		host.NewInfo(redactions),
+		host.NewInfoWithContext(ctx, host.InfoConfig{Redactions: redactions}),
 		// TODO(mkcp): Source the timeout value from agent/CLI params, or extract to a const.
 		host.NewMemoryWithContext(ctx, TimeoutThirtySeconds),
 		host.NewProcess(redactions),


### PR DESCRIPTION
This merge enables timeouts and cancellation in the host info runner. Timeouts may be passed in via optional configuration. If the timeout expires, or if a context that has been passed into the runner when it was constructed is canceled, then the run will stop with an appropriate operation status type.