### PR TITLE
Add Timeout & Cancellation to Copy Runner

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -310,7 +310,16 @@ func (a *Agent) CopyIncludes() (err error) {
 		}
 
 		a.l.Debug("getting Copy", "path", f)
-		o := runner.NewCopy(f, dest, a.Config.Since, a.Config.Until, nil).Run()
+		c, err := runner.NewCopyWithContext(a.ctx, runner.CopyConfig{
+			Path:    f,
+			DestDir: dest,
+			Since:   a.Config.Since,
+			Until:   a.Config.Until,
+		})
+		if err != nil {
+			return err
+		}
+		o := c.Run()
 		if o.Error != nil {
 			return o.Error
 		}

--- a/changelog/292.txt
+++ b/changelog/292.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+runners: The Copy runner now takes an optional Timeout value, so that long-running executions can be gracefully stopped.
+```

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -432,9 +432,12 @@ func mapCopies(ctx context.Context, cfgs []Copy, redactions []*redact.Redact, de
 			// FIXME(mkcp): "Now" should be sourced from the agent to avoid clock sync issues
 			since = time.Now().Add(-sinceDur)
 		}
-		timeout, err := time.ParseDuration(c.Timeout)
-		if err != nil {
-			return nil, err
+		var timeout time.Duration
+		if c.Timeout != "" {
+			timeout, err = time.ParseDuration(c.Timeout)
+			if err != nil {
+				return nil, err
+			}
 		}
 		r, err := runner.NewCopy(runner.CopyConfig{
 			Path:       c.Path,

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -162,6 +162,7 @@ type Copy struct {
 	Path       string   `hcl:"path" json:"path"`
 	Since      string   `hcl:"since,optional" json:"since"`
 	Redactions []Redact `hcl:"redact,block" json:"redactions,omitempty"`
+	Timeout    string   `hcl:"timeout,optional" json:"timeout,omitempty"`
 }
 
 type DockerLog struct {
@@ -431,7 +432,22 @@ func mapCopies(ctx context.Context, cfgs []Copy, redactions []*redact.Redact, de
 			// FIXME(mkcp): "Now" should be sourced from the agent to avoid clock sync issues
 			since = time.Now().Add(-sinceDur)
 		}
-		runners[i] = runner.NewCopy(c.Path, dest, since, time.Time{}, runnerRedacts)
+		timeout, err := time.ParseDuration(c.Timeout)
+		if err != nil {
+			return nil, err
+		}
+		r, err := runner.NewCopy(runner.CopyConfig{
+			Path:       c.Path,
+			DestDir:    dest,
+			Since:      since,
+			Until:      time.Time{},
+			Redactions: runnerRedacts,
+			Timeout:    timeout,
+		})
+		if err != nil {
+			return nil, err
+		}
+		runners[i] = r
 	}
 	return runners, nil
 }

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -439,7 +439,7 @@ func mapCopies(ctx context.Context, cfgs []Copy, redactions []*redact.Redact, de
 				return nil, err
 			}
 		}
-		r, err := runner.NewCopy(runner.CopyConfig{
+		r, err := runner.NewCopyWithContext(ctx, runner.CopyConfig{
 			Path:       c.Path,
 			DestDir:    dest,
 			Since:      since,

--- a/product/consul.go
+++ b/product/consul.go
@@ -146,7 +146,16 @@ func consulRunners(ctx context.Context, cfg Config, api *client.APIClient, l hcl
 	// try to detect log location to copy
 	if logPath, err := client.GetConsulLogPath(api); err == nil {
 		dest := filepath.Join(cfg.TmpDir, "logs/consul")
-		logCopy := runner.NewCopy(logPath, dest, cfg.Since, cfg.Until, cfg.Redactions)
+		logCopy, err := runner.NewCopyWithContext(ctx, runner.CopyConfig{
+			Path:       logPath,
+			DestDir:    dest,
+			Since:      cfg.Since,
+			Until:      cfg.Until,
+			Redactions: cfg.Redactions,
+		})
+		if err != nil {
+			return nil, err
+		}
 		r = append([]runner.Runner{logCopy}, r...)
 	}
 

--- a/product/nomad.go
+++ b/product/nomad.go
@@ -152,7 +152,16 @@ func nomadRunners(ctx context.Context, cfg Config, api *client.APIClient, l hclo
 	// try to detect log location to copy
 	if logPath, err := client.GetNomadLogPath(api); err == nil {
 		dest := filepath.Join(cfg.TmpDir, "logs", "nomad")
-		logCopy := runner.NewCopy(logPath, dest, cfg.Since, cfg.Until, cfg.Redactions)
+		logCopy, err := runner.NewCopyWithContext(ctx, runner.CopyConfig{
+			Path:       logPath,
+			DestDir:    dest,
+			Since:      cfg.Since,
+			Until:      cfg.Until,
+			Redactions: cfg.Redactions,
+		})
+		if err != nil {
+			return nil, err
+		}
 		r = append([]runner.Runner{logCopy}, r...)
 	}
 

--- a/product/tfe.go
+++ b/product/tfe.go
@@ -78,13 +78,24 @@ func tfeRunners(ctx context.Context, cfg Config, api *client.APIClient, l hclog.
 	if err != nil {
 		return nil, err
 	}
+	supportBundleCopy, err := runner.NewCopyWithContext(ctx, runner.CopyConfig{
+		Path:       "/var/lib/replicated/support-bundles/replicated-support*.tar.gz",
+		DestDir:    cfg.TmpDir,
+		Since:      cfg.Since,
+		Until:      cfg.Until,
+		Redactions: cfg.Redactions,
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	r = append(r,
 		do.NewSync(l, "support-bundle", "replicated support bundle",
 			// The support bundle that we copy is built by the `replicated support-bundle` command, so we need to ensure
 			// that these run serially.
 			[]runner.Runner{
 				supportBundleCmd,
-				runner.NewCopy("/var/lib/replicated/support-bundles/replicated-support*.tar.gz", cfg.TmpDir, cfg.Since, cfg.Until, cfg.Redactions),
+				supportBundleCopy,
 			}))
 
 	// Set up HTTP runners

--- a/product/vault.go
+++ b/product/vault.go
@@ -131,7 +131,16 @@ func vaultRunners(ctx context.Context, cfg Config, api *client.APIClient, l hclo
 	// try to detect log location to copy
 	if logPath, err := client.GetVaultAuditLogPath(api); err == nil {
 		dest := filepath.Join(cfg.TmpDir, "logs/vault")
-		logCopy := runner.NewCopy(logPath, dest, cfg.Since, cfg.Until, cfg.Redactions)
+		logCopy, err := runner.NewCopyWithContext(ctx, runner.CopyConfig{
+			Path:       logPath,
+			DestDir:    dest,
+			Since:      cfg.Since,
+			Until:      cfg.Until,
+			Redactions: cfg.Redactions,
+		})
+		if err != nil {
+			return nil, err
+		}
 		r = append([]runner.Runner{logCopy}, r...)
 	}
 

--- a/util/util.go
+++ b/util/util.go
@@ -139,7 +139,7 @@ func JSONToFile(JSON []byte, outFile string) error {
 }
 
 // SplitFilepath takes a full path string and turns it into directory and file parts.
-// In particular, it's useful for passing into runner.NewCopier()
+// In particular, it's useful for passing into runner.NewCopy()
 func SplitFilepath(path string) (dir string, file string) {
 	dir, file = filepath.Split(path)
 	// this enables a path like "somedir" (which filepath.Split() would call the "file")


### PR DESCRIPTION
This merge enables timeouts and cancellation in the Copy runner. Timeouts may be passed in via optional configuration. If the timeout expires, or if a context that has been passed into the runner when it was constructed is canceled, then the run will stop with an appropriate operation status type.