### PR TITLE
Deprecate Debug Duration and Debug Interval Flags & Document Their Alternatives

### DIFF
--- a/changelog/293.txt
+++ b/changelog/293.txt
@@ -1,0 +1,6 @@
+```release-note:deprecation
+deprecation: -debug-interval and -debug-duration flags will be removed in a future release in favor of HCL configuration for debug overrides. These flags are now marked as deprecated in CLI help output.
+```
+```release-note:improvement
+docs: Add example usage details for new Consul, Vault, and Nomad debug runners.
+```

--- a/command/run.go
+++ b/command/run.go
@@ -69,24 +69,24 @@ type RunCommand struct {
 
 func (c *RunCommand) init() {
 	const (
-		consulUsageText        = "Run Consul diagnostics"
-		nomadUsageText         = "Run Nomad diagnostics"
-		terraformEntUsageText  = "Run Terraform Enterprise diagnostics"
-		vaultUsageText         = "Run Vault diagnostics"
-		autodetectUsageText    = "Auto-Detect installed products; any provided product flags will override this setting"
-		dryrunUsageText        = "Displays all runners that would be executed during a normal run without actually executing them."
-		includeSinceUsageText  = "Alias for -since, will be overridden if -since is also provided, usage examples: '72h', '25m', '45s', '120h1m90s'"
-		sinceUsageText         = "Collect information within this time. Takes a 'go-formatted' duration, usage examples: '72h', '25m', '45s', '120h1m90s'"
-		debugDurationUsageText = "How long to run product debug bundle commands. Provide a duration ex: '00h00m00s'. See: -duration in 'vault debug', 'consul debug', and 'nomad operator debug'"
-		debugIntervalUsageText = "How long metrics collection intervals in product debug commands last. Provide a duration ex: '00h00m00s'. See: -interval in 'vault debug', 'consul debug', and 'nomad operator debug'"
-		osUsageText            = "Override operating system detection"
-		destinationUsageText   = "Path to the directory the bundle should be written in"
-		destUsageText          = "Shorthand for -destination"
-		configUsageText        = "Path to HCL configuration file"
+		consulUsageText       = "Run Consul diagnostics"
+		nomadUsageText        = "Run Nomad diagnostics"
+		terraformEntUsageText = "Run Terraform Enterprise diagnostics"
+		vaultUsageText        = "Run Vault diagnostics"
+		autodetectUsageText   = "Auto-Detect installed products; any provided product flags will override this setting"
+		dryrunUsageText       = "Displays all runners that would be executed during a normal run without actually executing them."
+		includeSinceUsageText = "Alias for -since, will be overridden if -since is also provided, usage examples: '72h', '25m', '45s', '120h1m90s'"
+		sinceUsageText        = "Collect information within this time. Takes a 'go-formatted' duration, usage examples: '72h', '25m', '45s', '120h1m90s'"
+		osUsageText           = "Override operating system detection"
+		destinationUsageText  = "Path to the directory the bundle should be written in"
+		destUsageText         = "Shorthand for -destination"
+		configUsageText       = "Path to HCL configuration file"
 
 		// Deprecated options
-		includesUsageText = "DEPRECATED: Files or directories to include (comma-separated, file-*-globbing available if 'wrapped-*-in-single-quotes'); e.g. '/var/log/consul-*,/var/log/nomad-*'. NOTE: This option will be removed in an upcoming version of hcdiag. Please use HCL copy blocks instead"
-		serialUsageText   = "DEPRECATED: Run products in sequence rather than concurrently. NOTE: This option will be removed in an upcoming version of hcdiag. Runners within products run concurrently beginning in 0.5.0. Please use HCL do-sync blocks instead."
+		includesUsageText      = "DEPRECATED: Files or directories to include (comma-separated, file-*-globbing available if 'wrapped-*-in-single-quotes'); e.g. '/var/log/consul-*,/var/log/nomad-*'. NOTE: This option will be removed in an upcoming version of hcdiag. Please use HCL copy blocks instead."
+		serialUsageText        = "DEPRECATED: Run products in sequence rather than concurrently. NOTE: This option will be removed in an upcoming version of hcdiag. Runners within products run concurrently beginning in 0.5.0. Please use HCL do-sync blocks instead."
+		debugDurationUsageText = "DEPRECATED: How long to run product debug bundle commands. Provide a duration ex: '00h00m00s'. See: -duration in 'vault debug', 'consul debug', and 'nomad operator debug'. NOTE: This option will be removed in an upcoming version of hcdiag. Please use HCL debug blocks instead."
+		debugIntervalUsageText = "DEPRECATED: How long metrics collection intervals in product debug commands last. Provide a duration ex: '00h00m00s'. See: -interval in 'vault debug', 'consul debug', and 'nomad operator debug'. NOTE: This option will be removed in an upcoming version of hcdiag. Please use HCL debug blocks instead."
 	)
 
 	// flag.ContinueOnError allows flag.Parse to return an error if one comes up, rather than doing an `os.Exit(2)`

--- a/docs/custom-config.md
+++ b/docs/custom-config.md
@@ -143,3 +143,55 @@ hcdiag -nomad -debug-duration=0 -config hcdiag.hcl
 This will point hcdiag at your custom config file and execute your custom command.
 
 **NOTE** The -debug-duration flag is here to suppress the built-in nomad debug command, preventing the built-in version of the `nomad operator debug` command from being run, and a second nomad-debug archive being created in your hcdiag bundle.
+
+### Customizing Debug Runners
+
+Beginning in `hcdiag` `0.5.0`, you may customize how you execute product debug commands using HCL. Previously, there were two command line flags (`debug-duration` and `debug-interval`), which affected debugs for all products. Now, these can be customized extensively using HCL. The following snippet shows options for each product, along with the corresponding flag that you would provide to the product's debug command.
+
+```
+product "consul" {
+  consul-debug {
+    // The consul-debug block has fields corresponding to the `consul debug` command.
+    // See https://developer.hashicorp.com/consul/commands/debug for details.
+
+    archive = "true" // corresponds to -archive flag
+    duration = "2m" // corresponds to -duration flag
+    interval = "30s" // corresponds to -interval flag
+    captures = [] // set of targets, matching the -capture flag
+  }
+}
+
+product "vault" {
+  vault-debug {
+    // The vault-debug block has fields corresponding to the `vault debug` command.
+    // See https://developer.hashicorp.com/vault/docs/commands/debug for details.
+
+    compress = "true" // corresponds to -compress flag
+    duration = "2m" // corresponds to -duration flag
+    interval = "30s" // corresponds to -interval flag
+    log-format = "standard" // corresponds to -log-format flag
+    metrics-interval = "10s" // corresponds to -metrics-interval flag
+    targets = [] // set of targets, matching the -target flag
+  }
+}
+
+product "nomad" {
+  nomad-debug {
+    // The nomad-debug block has fields corresponding to the `nomad operator debug` command.
+    // See https://developer.hashicorp.com/nomad/docs/commands/operator/debug for details.
+
+    duration = "2m" // corresponds to -duration flag
+    interval = "30s" // corresponds to -interval flag
+    log-level = "DEBUG" // corresponds to -log-level flag
+    max-nodes = 0 // corresponds to -max-nodes flag
+    node-class = "my-class" // corresponds to -node-class flag
+    node-id = "all" // corresponds to -node-id flag
+    pprof-duration = "1s" // corresponds to -pprof-duration flag
+    pprof-interval = "250ms" // corresponds to -pprof-interval flag
+    server-id = "all" // corresponds to -server-id flag
+    stale = false // corresponds to -stale flag
+    verbose = true // corresponds to -verbose flag
+    targets = [] // set of event topics, matching the -event-topic flag
+  }
+}
+```


### PR DESCRIPTION
This merge marks the -debug-duration and -debug-interval flags as deprecated, as we want to encourage users to leverage custom configuration. To that end, the merge also provides documentation about the new product-specific debug runners' configuration via HCL.