### PR TITLE
Warn for Missing Vault Tokens Instead of Failing

### DIFF
--- a/changelog/294.txt
+++ b/changelog/294.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+vault: When a Vault token can't be found with the VAULT_TOKEN environment variable or in the ~/.vault-token file, we now log a warning without stopping the diagnostic run short. This allows users to still gather useful information about their Vault instance, while the warning indicates that the information may be incomplete due to the missing token.
+```

--- a/client/vault.go
+++ b/client/vault.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/hashicorp/go-hclog"
 	home "github.com/mitchellh/go-homedir"
 )
 
@@ -48,7 +49,7 @@ func NewVaultAPI() (*APIClient, error) {
 		token = string(bts)
 	}
 	if token == "" {
-		return nil, errors.New("unable to find VAULT_TOKEN env or ~/.vault-token")
+		hclog.L().Error("missing Vault client token; diagnostic information may be incomplete (please set VAULT_TOKEN environment variable or add it to ~/.vault-token file to gather all information)")
 	}
 	headers["X-Vault-Token"] = token
 


### PR DESCRIPTION
This merge allows hcdiag to execute a diagnostic run for Vault even when the Vault token cannot be found. Previously, this pre-flight check would stop the entire hcdiag execute, however some useful information could still be gleaned even without the token. Now, we write a warning (an error-level log message, which should make it red in terminals that support color) to inform users that the data will be incomplete and to suggest how they might address this. But, we still create a bundle, so that we can collect some information to provide to Support.