### PR TITLE
Add Timeout & Cancellation to Host OS Runner

### DIFF
--- a/changelog/295.txt
+++ b/changelog/295.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+runners: The host os runner now takes an optional Timeout value, so that long-running executions can be gracefully stopped.
+```

--- a/product/host.go
+++ b/product/host.go
@@ -78,7 +78,7 @@ func NewHostWithContext(ctx context.Context, logger hclog.Logger, cfg Config, hc
 // hostRunners generates a slice of runners to inspect the host.
 func hostRunners(ctx context.Context, os string, redactions []*redact.Redact, l hclog.Logger) []runner.Runner {
 	r := []runner.Runner{
-		host.NewOS(os, redactions),
+		host.NewOSWithContext(ctx, host.OSConfig{OS: os, Redactions: redactions, Timeout: time.Duration(TimeoutTenSeconds)}),
 		host.NewDiskWithContext(ctx, host.DiskConfig{Redactions: redactions}),
 		host.NewInfoWithContext(ctx, host.InfoConfig{Redactions: redactions, Timeout: time.Duration(TimeoutTenSeconds)}),
 		// TODO(mkcp): Source the timeout value from agent/CLI params, or extract to a const.


### PR DESCRIPTION
This merge enables timeouts and cancellation in the Host OS runner, with a default of 10 seconds. If the timeout expires, or if a context that has been passed into the runner when it was constructed is canceled, then the run will stop with an appropriate operation status type.