### PR TITLE
Add Timeout & Cancellation to Host Process Runner

### DIFF
--- a/changelog/296.txt
+++ b/changelog/296.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+runners: The host process runner now takes an optional Timeout value, so that long-running executions can be gracefully stopped.
+```

--- a/product/host.go
+++ b/product/host.go
@@ -83,7 +83,7 @@ func hostRunners(ctx context.Context, os string, redactions []*redact.Redact, l 
 		host.NewInfoWithContext(ctx, host.InfoConfig{Redactions: redactions, Timeout: time.Duration(TimeoutTenSeconds)}),
 		// TODO(mkcp): Source the timeout value from agent/CLI params, or extract to a const.
 		host.NewMemoryWithContext(ctx, TimeoutThirtySeconds),
-		host.NewProcess(redactions),
+		host.NewProcessWithContext(ctx, host.ProcessConfig{Redactions: redactions, Timeout: time.Duration(TimeoutTenSeconds)}),
 		host.NewNetworkWithContext(ctx, host.NetworkConfig{Redactions: redactions, Timeout: time.Duration(TimeoutTenSeconds)}),
 		host.NewIPTablesWithContext(ctx, host.IPTablesConfig{
 			OS:         os,

--- a/runner/host/processes.go
+++ b/runner/host/processes.go
@@ -4,6 +4,7 @@
 package host
 
 import (
+	"context"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
@@ -15,14 +16,32 @@ import (
 
 var _ runner.Runner = &Process{}
 
-// Process represents a single OS Process
-type Process struct {
-	Redactions []*redact.Redact `json:"redactions"`
+type ProcessConfig struct {
+	// Redactions includes any redactions to apply to the output of the runner.
+	Redactions []*redact.Redact
+	// Timeout specifies the amount of time that the runner should be allowed to execute before cancellation.
+	Timeout time.Duration
 }
 
-func NewProcess(redactions []*redact.Redact) *Process {
+// Process represents a single OS Process
+type Process struct {
+	ctx context.Context
+
+	// Redactions includes any redactions to apply to the output of the runner.
+	Redactions []*redact.Redact `json:"redactions"`
+	// Timeout specifies the amount of time that the runner should be allowed to execute before cancellation.
+	Timeout runner.Timeout `json:"timeout"`
+}
+
+func NewProcess(cfg ProcessConfig) *Process {
+	return NewProcessWithContext(context.Background(), cfg)
+}
+
+func NewProcessWithContext(ctx context.Context, cfg ProcessConfig) *Process {
 	return &Process{
-		Redactions: redactions,
+		ctx:        ctx,
+		Redactions: cfg.Redactions,
+		Timeout:    runner.Timeout(cfg.Timeout),
 	}
 }
 
@@ -39,23 +58,58 @@ func (p Process) ID() string {
 
 func (p Process) Run() op.Op {
 	startTime := time.Now()
+
+	if p.ctx == nil {
+		p.ctx = context.Background()
+	}
+
+	resChan := make(chan op.Op, 1)
+	runCtx := p.ctx
+	var cancel context.CancelFunc
+	if 0 < p.Timeout {
+		runCtx, cancel = context.WithTimeout(p.ctx, time.Duration(p.Timeout))
+		defer cancel()
+	}
+
+	go func(resChan chan op.Op) {
+		o := p.run()
+		o.Start = startTime
+		resChan <- o
+	}(resChan)
+
+	select {
+	case <-runCtx.Done():
+		switch runCtx.Err() {
+		case context.Canceled:
+			return runner.CancelOp(p, runCtx.Err(), startTime)
+		case context.DeadlineExceeded:
+			return runner.TimeoutOp(p, runCtx.Err(), startTime)
+		default:
+			return op.New(p.ID(), nil, op.Unknown, runCtx.Err(), runner.Params(p), startTime, time.Now())
+		}
+	case o := <-resChan:
+		return o
+	}
+}
+
+func (p Process) run() op.Op {
 	var procs []Proc
 
 	psProcs, err := ps.Processes()
 	if err != nil {
 		hclog.L().Trace("runner/host.Process.Run()", "error", err)
 		results := map[string]any{"procs": psProcs}
-		return op.New(p.ID(), results, op.Fail, err, runner.Params(p), startTime, time.Now())
+		return op.New(p.ID(), results, op.Fail, err, runner.Params(p), time.Time{}, time.Now())
 	}
 
 	procs, err = p.procs(psProcs)
 	results := map[string]any{"procs": procs}
 	if err != nil {
 		hclog.L().Trace("runner/host.Process.Run()", "error", err)
-		return op.New(p.ID(), results, op.Fail, err, runner.Params(p), startTime, time.Now())
+		return op.New(p.ID(), results, op.Fail, err, runner.Params(p), time.Time{}, time.Now())
 	}
 
-	return op.New(p.ID(), results, op.Success, nil, runner.Params(p), startTime, time.Now())
+	return op.New(p.ID(), results, op.Success, nil, runner.Params(p), time.Time{}, time.Now())
 }
 
 func (p Process) procs(psProcs []ps.Process) ([]Proc, error) {


### PR DESCRIPTION
This merge enables timeouts and cancellation in the Host Process runner, with a default of 10 seconds. If the timeout expires, or if a context that has been passed into the runner when it was constructed is canceled, then the run will stop with an appropriate operation status type.