### PR TITLE
Fix Empty Timeout Error in HCL Shell Runner

### DIFF
--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -394,7 +394,13 @@ func mapShells(ctx context.Context, cfgs []Shell, redactions []*redact.Redact) (
 		}
 		// Prepend runner-level redactions to those passed in
 		runnerRedacts = append(runnerRedacts, redactions...)
-		timeout, err := time.ParseDuration(c.Timeout)
+		var timeout time.Duration
+		if c.Timeout != "" {
+			timeout, err = time.ParseDuration(c.Timeout)
+			if err != nil {
+				return nil, err
+			}
+		}
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This merge addresses an issue where the timeout parameter was essentially required for the Shell runner in HCL. Without it being set, an error was returned in converting nil to a duration.