### PR TITLE
Add fstab timeouts and context

### DIFF
--- a/product/host.go
+++ b/product/host.go
@@ -81,7 +81,6 @@ func hostRunners(ctx context.Context, os string, redactions []*redact.Redact, l 
 		host.NewOSWithContext(ctx, host.OSConfig{OS: os, Redactions: redactions, Timeout: time.Duration(TimeoutTenSeconds)}),
 		host.NewDiskWithContext(ctx, host.DiskConfig{Redactions: redactions}),
 		host.NewInfoWithContext(ctx, host.InfoConfig{Redactions: redactions, Timeout: time.Duration(TimeoutTenSeconds)}),
-		// TODO(mkcp): Source the timeout value from agent/CLI params, or extract to a const.
 		host.NewMemoryWithContext(ctx, TimeoutThirtySeconds),
 		host.NewProcessWithContext(ctx, host.ProcessConfig{Redactions: redactions, Timeout: time.Duration(TimeoutTenSeconds)}),
 		host.NewNetworkWithContext(ctx, host.NetworkConfig{Redactions: redactions, Timeout: time.Duration(TimeoutTenSeconds)}),
@@ -93,7 +92,7 @@ func hostRunners(ctx context.Context, os string, redactions []*redact.Redact, l 
 		host.NewEtcHostsWithContext(ctx, host.EtcHostsConfig{
 			OS:         os,
 			Redactions: redactions,
-			Timeout:    TimeoutTenSeconds,
+			Timeout:    TimeoutThirtySeconds,
 		}),
 		host.NewProcFileWithContext(ctx, host.ProcFileConfig{
 			OS:         os,
@@ -104,7 +103,7 @@ func hostRunners(ctx context.Context, os string, redactions []*redact.Redact, l 
 
 	fsTab, err := host.NewFSTab(host.FSTabConfig{
 		OS:         os,
-		Timeout:    runner.Timeout(1 * time.Millisecond),
+		Timeout:    TimeoutTenSeconds,
 		Redactions: redactions,
 	})
 	// TODO(mkcp): Errors should propagate back from hostRunners().

--- a/product/host.go
+++ b/product/host.go
@@ -102,8 +102,15 @@ func hostRunners(ctx context.Context, os string, redactions []*redact.Redact, l 
 		}),
 	}
 
-	// FIXME(mkcp): handle this error
-	fsTab, _ := host.NewFSTab(os, redactions)
+	fsTab, err := host.NewFSTab(host.FSTabConfig{
+		OS:         os,
+		Timeout:    runner.Timeout(1 * time.Millisecond),
+		Redactions: redactions,
+	})
+	// TODO(mkcp): Errors should propagate back from hostRunners().
+	if err != nil {
+		l.Error("unable to create host.FSTab runner.", "err=", err)
+	}
 	r = append(r, fsTab)
 
 	runners := []runner.Runner{

--- a/runner/host/fstab_test.go
+++ b/runner/host/fstab_test.go
@@ -91,7 +91,7 @@ func TestFSTab_Run(t *testing.T) {
 				},
 			},
 			expected: response{
-				status:    op.Fail,
+				status:    op.Unknown,
 				expectErr: true,
 			},
 		},
@@ -125,7 +125,7 @@ func TestNewFSTab(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			fstab, err := NewFSTab(tc.os, nil)
+			fstab, err := NewFSTab(FSTabConfig{OS: tc.os})
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expected.OS, fstab.OS)
 		})


### PR DESCRIPTION
This PR adds an FSTab config struct with a Timeout field and adds a context constructor. The timeout value passes into the Shell runner and propages the `op.Status` and `op.Error` from the result op. 