### PR TITLE
Rename DoSync to Seq and add context + timeouts

### DIFF
--- a/agent/manifest.go
+++ b/agent/manifest.go
@@ -19,7 +19,7 @@ type ManifestOp struct {
 }
 
 // WalkResultsForManifest translates maps of arbitrarily deeply nested op.Ops and flattens them into a slice of ManifestOp.
-// In the case of nested runners, such as in Do or DoSync blocks, outer Op will contain results for all of the inner
+// In the case of nested runners, such as in Do or Seq blocks, outer Op will contain results for all the inner
 // runners. This function allows for reporting on the total number of Ops rather than just the outer Op.
 func WalkResultsForManifest(results map[string]op.Op) []ManifestOp {
 	m := make(map[string]any, 0)

--- a/changelog/299.txt
+++ b/changelog/299.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+runners: The seq runner now takes an optional Timeout value, so that long-running executions can be gracefully stopped.
+```

--- a/changelog/299.txt
+++ b/changelog/299.txt
@@ -1,3 +1,6 @@
 ```release-note:improvement
+runners: Rename DoSync to Seq.
+```
+```release-note:improvement
 runners: The seq runner now takes an optional Timeout value, so that long-running executions can be gracefully stopped.
 ```

--- a/command/run.go
+++ b/command/run.go
@@ -84,7 +84,7 @@ func (c *RunCommand) init() {
 
 		// Deprecated options
 		includesUsageText      = "DEPRECATED: Files or directories to include (comma-separated, file-*-globbing available if 'wrapped-*-in-single-quotes'); e.g. '/var/log/consul-*,/var/log/nomad-*'. NOTE: This option will be removed in an upcoming version of hcdiag. Please use HCL copy blocks instead."
-		serialUsageText        = "DEPRECATED: Run products in sequence rather than concurrently. NOTE: This option will be removed in an upcoming version of hcdiag. Runners within products run concurrently beginning in 0.5.0. Please use HCL do-sync blocks instead."
+		serialUsageText        = "DEPRECATED: Run products in sequence rather than concurrently. NOTE: This option will be removed in an upcoming version of hcdiag. Runners within products run concurrently beginning in 0.5.0. Please use HCL seq blocks instead."
 		debugDurationUsageText = "DEPRECATED: How long to run product debug bundle commands. Provide a duration ex: '00h00m00s'. See: -duration in 'vault debug', 'consul debug', and 'nomad operator debug'. NOTE: This option will be removed in an upcoming version of hcdiag. Please use HCL debug blocks instead."
 		debugIntervalUsageText = "DEPRECATED: How long metrics collection intervals in product debug commands last. Provide a duration ex: '00h00m00s'. See: -interval in 'vault debug', 'consul debug', and 'nomad operator debug'. NOTE: This option will be removed in an upcoming version of hcdiag. Please use HCL debug blocks instead."
 	)

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -36,8 +36,8 @@ type Agent struct {
 
 type Host struct {
 	// Do
-	Do     []Do     `hcl:"do,block" json:"do,omitempty"`
-	DoSync []DoSync `hcl:"do-sync,block" json:"do-sync,omitempty"`
+	Do  []Do  `hcl:"do,block" json:"do,omitempty"`
+	Seq []Seq `hcl:"seq,block" json:"seq,omitempty"`
 
 	// Runners
 	Commands     []Command     `hcl:"command,block" json:"commands,omitempty"`
@@ -59,8 +59,8 @@ type Product struct {
 	Name string `hcl:"name,label" json:"name"`
 
 	// Do
-	Do     []Do     `hcl:"do,block" json:"do,omitempty"`
-	DoSync []DoSync `hcl:"do-sync,block" json:"do-sync,omitempty"`
+	Do  []Do  `hcl:"do,block" json:"do,omitempty"`
+	Seq []Seq `hcl:"seq,block" json:"seq,omitempty"`
 
 	// Runners
 	Commands     []Command     `hcl:"command,block" json:"commands,omitempty"`
@@ -81,9 +81,8 @@ type Do struct {
 	Label       string `hcl:"name,label" json:"label"`
 	Description string `hcl:"description,optional" json:"since"`
 
-	// Do
-	Do     []Do     `hcl:"do,block" json:"do,omitempty"`
-	DoSync []DoSync `hcl:"do-sync,block" json:"do-sync,omitempty"`
+	Do  []Do  `hcl:"do,block" json:"do,omitempty"`
+	Seq []Seq `hcl:"seq,block" json:"seq,omitempty"`
 
 	// Runners
 	Commands     []Command     `hcl:"command,block" json:"commands,omitempty"`
@@ -104,13 +103,13 @@ type Do struct {
 	// Redactions   []Redact      `hcl:"redact,block" json:"redactions,omitempty"`
 }
 
-type DoSync struct {
+type Seq struct {
 	Label       string `hcl:"name,label" json:"label"`
 	Description string `hcl:"description,optional" json:"since"`
 
 	// Do
-	Do     []Do     `hcl:"do,block" json:"do,omitempty"`
-	DoSync []DoSync `hcl:"do-sync,block" json:"do-sync,omitempty"`
+	Do  []Do  `hcl:"do,block" json:"do,omitempty"`
+	Seq []Seq `hcl:"seq,block" json:"seq,omitempty"`
 
 	// Runners
 	Commands     []Command     `hcl:"command,block" json:"commands,omitempty"`

--- a/hcl/hcl.go
+++ b/hcl/hcl.go
@@ -106,6 +106,7 @@ type Do struct {
 type Seq struct {
 	Label       string `hcl:"name,label" json:"label"`
 	Description string `hcl:"description,optional" json:"since"`
+	Timeout     string `hcl:"timeout,optional" json:"timeout,omitempty"`
 
 	// Do
 	Do  []Do  `hcl:"do,block" json:"do,omitempty"`
@@ -127,7 +128,6 @@ type Seq struct {
 	// Selects      []string      `hcl:"selects,optional" json:"selects,omitempty"`
 
 	// Params
-	// Redactions   []Redact      `hcl:"redact,block" json:"redactions,omitempty"`
 	// Redactions   []Redact      `hcl:"redact,block" json:"redactions,omitempty"`
 }
 

--- a/product/tfe.go
+++ b/product/tfe.go
@@ -89,14 +89,18 @@ func tfeRunners(ctx context.Context, cfg Config, api *client.APIClient, l hclog.
 		return nil, err
 	}
 
-	r = append(r,
-		do.NewSeq(l, "support-bundle", "replicated support bundle",
-			// The support bundle that we copy is built by the `replicated support-bundle` command, so we need to ensure
-			// that these run serially.
-			[]runner.Runner{
-				supportBundleCmd,
-				supportBundleCopy,
-			}))
+	// The support bundle that we copy is built by the `replicated support-bundle` command, so we need to ensure
+	// that these run in sequence.
+	replicatedSeq := do.NewSeq(do.SeqConfig{
+		Runners: []runner.Runner{
+			supportBundleCmd,
+			supportBundleCopy,
+		},
+		Label:       "support-bundle",
+		Description: "replicated support bundle",
+		Logger:      l,
+	})
+	r = append(r, replicatedSeq)
 
 	// Set up HTTP runners
 	for _, hc := range []runner.HttpConfig{

--- a/product/tfe.go
+++ b/product/tfe.go
@@ -90,7 +90,7 @@ func tfeRunners(ctx context.Context, cfg Config, api *client.APIClient, l hclog.
 	}
 
 	r = append(r,
-		do.NewSync(l, "support-bundle", "replicated support bundle",
+		do.NewSeq(l, "support-bundle", "replicated support bundle",
 			// The support bundle that we copy is built by the `replicated support-bundle` command, so we need to ensure
 			// that these run serially.
 			[]runner.Runner{

--- a/runner/do/seq.go
+++ b/runner/do/seq.go
@@ -67,7 +67,7 @@ func (s Seq) Run() op.Op {
 		s.ctx = context.Background()
 	}
 
-	resChan := make(chan op.Op, 0)
+	resChan := make(chan op.Op)
 
 	runCtx := s.ctx
 	var cancel context.CancelFunc
@@ -95,7 +95,6 @@ func (s Seq) Run() op.Op {
 	case result := <-resChan:
 		return result
 	}
-
 }
 
 func (s Seq) run() op.Op {

--- a/runner/do/seq.go
+++ b/runner/do/seq.go
@@ -25,7 +25,7 @@ type SeqConfig struct {
 }
 
 // Seq wraps a collection of runners and executes them in order, returning all of their Ops keyed by their ID(). If one
-// of the runners has a status other than Success, subsequent runners will not be executed and the do-sync will return
+// of the runners has a status other than Success, subsequent runners will not be executed and the Seq will return
 // a status.Fail.
 type Seq struct {
 	Runners     []runner.Runner `json:"runners"`
@@ -104,7 +104,7 @@ func (s Seq) run() op.Op {
 		o := r.Run()
 		// If any result op is not Success, abort and return all existing ops
 		if o.Status != op.Success {
-			// Add an op for this failed DoSync at the end of the slice
+			// Add an op for this failed Seq at the end of the slice
 			results[o.Identifier] = o
 			return op.New(s.ID(), results, op.Fail, ChildRunnerError{
 				Parent: s.ID(),
@@ -113,7 +113,7 @@ func (s Seq) run() op.Op {
 			}, runner.Params(s), time.Time{}, time.Now())
 		}
 	}
-	// Return runner ops, adding one at the end for our successful DoSync run
+	// Return runner ops, adding one at the end for our successful Seq run
 	return op.New(s.ID(), results, op.Success, nil, runner.Params(s), time.Time{}, time.Now())
 }
 

--- a/runner/do/seq.go
+++ b/runner/do/seq.go
@@ -16,6 +16,14 @@ import (
 
 var _ runner.Runner = Seq{}
 
+type SeqConfig struct {
+	Runners     []runner.Runner
+	Label       string
+	Description string
+	Timeout     runner.Timeout
+	Logger      hclog.Logger
+}
+
 // Seq wraps a collection of runners and executes them in order, returning all of their Ops keyed by their ID(). If one
 // of the runners has a status other than Success, subsequent runners will not be executed and the do-sync will return
 // a status.Fail.
@@ -23,25 +31,27 @@ type Seq struct {
 	Runners     []runner.Runner `json:"runners"`
 	Label       string          `json:"label"`
 	Description string          `json:"description"`
+	Timeout     runner.Timeout  `json:"timeout"`
 	log         hclog.Logger
 	ctx         context.Context
 }
 
 // NewSeq initializes a Seq runner.
-func NewSeq(l hclog.Logger, label, description string, runners []runner.Runner) *Seq {
-	return NewSeqWithContext(context.Background(), l, label, description, runners)
+func NewSeq(cfg SeqConfig) *Seq {
+	return NewSeqWithContext(context.Background(), cfg)
 }
 
-func NewSeqWithContext(ctx context.Context, l hclog.Logger, label, description string, runners []runner.Runner) *Seq {
+func NewSeqWithContext(ctx context.Context, cfg SeqConfig) *Seq {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	return &Seq{
 		ctx:         ctx,
-		Label:       label,
-		Description: description,
-		Runners:     runners,
-		log:         l,
+		Label:       cfg.Label,
+		Description: cfg.Description,
+		Runners:     cfg.Runners,
+		Timeout:     cfg.Timeout,
+		log:         cfg.Logger,
 	}
 }
 


### PR DESCRIPTION
This PR moves do-sync to a file and type called Seq, introduces SeqConfig, allows for Seq to be constructed with a context, and enables the entire block to be timed out at the Seq level interrupting all runners.