### PR TITLE
Remove command-based debug calls from Vault and Consul

### DIFF
--- a/product/consul.go
+++ b/product/consul.go
@@ -5,7 +5,6 @@ package product
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 
 	"github.com/hashicorp/hcdiag/hcl"
@@ -85,7 +84,6 @@ func consulRunners(ctx context.Context, cfg Config, api *client.APIClient, l hcl
 	// Set up Command runners
 	for _, cc := range []runner.CommandConfig{
 		{Command: "consul version", Redactions: cfg.Redactions},
-		{Command: fmt.Sprintf("consul debug -output=%s/ConsulDebug -duration=%s -interval=%s", cfg.TmpDir, cfg.DebugDuration, cfg.DebugInterval), Redactions: cfg.Redactions},
 		{Command: "consul operator raft list-peers -stale=true", Redactions: cfg.Redactions},
 	} {
 		c, err := runner.NewCommandWithContext(ctx, cc)

--- a/product/vault.go
+++ b/product/vault.go
@@ -5,7 +5,6 @@ package product
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 
 	"github.com/hashicorp/hcdiag/hcl"
@@ -89,7 +88,6 @@ func vaultRunners(ctx context.Context, cfg Config, api *client.APIClient, l hclo
 		{Command: "vault read sys/health -format=json", Format: "json", Redactions: cfg.Redactions},
 		{Command: "vault read sys/seal-status -format=json", Format: "json", Redactions: cfg.Redactions},
 		{Command: "vault read sys/host-info -format=json", Format: "json", Redactions: cfg.Redactions},
-		{Command: fmt.Sprintf("vault debug -output=%s/VaultDebug.tar.gz -duration=%s -interval=%s", cfg.TmpDir, cfg.DebugDuration, cfg.DebugInterval), Redactions: cfg.Redactions},
 	} {
 		c, err := runner.NewCommandWithContext(ctx, cc)
 		if err != nil {

--- a/tests/integration/functional_test.go
+++ b/tests/integration/functional_test.go
@@ -67,7 +67,7 @@ func TestFunctional(t *testing.T) {
 				},
 				"consul": {
 					flags:    []string{"-consul"},
-					outFiles: []string{"ConsulDebug*/ConsulDebug.tar.gz"},
+					outFiles: []string{filepath.Join("ConsulDebug*", "ConsulDebug.tar.gz")},
 					skip:     false,
 				},
 				"nomad": {
@@ -79,7 +79,7 @@ func TestFunctional(t *testing.T) {
 				},
 				"vault-unix": {
 					flags:    []string{"-vault"},
-					outFiles: []string{"VaultDebug*/VaultDebug.tar.gz"},
+					outFiles: []string{filepath.Join("VaultDebug*", "VaultDebug.tar.gz")},
 					// TODO(gulducat): de-unique-ize when `vault debug` is fixed on windows
 					// dave's pr: https://github.com/hashicorp/vault/pull/14399
 					skip: runtime.GOOS == "windows",
@@ -87,9 +87,9 @@ func TestFunctional(t *testing.T) {
 				"autodetect-unix": {
 					flags: []string{},
 					outFiles: []string{
-						"ConsulDebug*.tar.gz",
+						filepath.Join("ConsulDebug*", "ConsulDebug.tar.gz"),
 						filepath.Join("NomadDebug*", "NomadDebug", "nomad*", "index.json"),
-						"VaultDebug*.tar.gz",
+						filepath.Join("VaultDebug*", "VaultDebug.tar.gz"),
 					},
 					skip: runtime.GOOS == "windows",
 				},

--- a/tests/integration/functional_test.go
+++ b/tests/integration/functional_test.go
@@ -67,7 +67,7 @@ func TestFunctional(t *testing.T) {
 				},
 				"consul": {
 					flags:    []string{"-consul"},
-					outFiles: []string{"ConsulDebug*.tar.gz"},
+					outFiles: []string{"ConsulDebug*/ConsulDebug.tar.gz"},
 					skip:     false,
 				},
 				"nomad": {
@@ -79,7 +79,7 @@ func TestFunctional(t *testing.T) {
 				},
 				"vault-unix": {
 					flags:    []string{"-vault"},
-					outFiles: []string{"VaultDebug*.tar.gz"},
+					outFiles: []string{"VaultDebug*/VaultDebug.tar.gz"},
 					// TODO(gulducat): de-unique-ize when `vault debug` is fixed on windows
 					// dave's pr: https://github.com/hashicorp/vault/pull/14399
 					skip: runtime.GOOS == "windows",


### PR DESCRIPTION
We had a few extra calls to the Command-based calls to <product debug>. This PR removes them in favor of the new Debug Runners.

Skipping changelog because this is a follow up to a partial prior migration and is already covered by the new debug runners logs.