### PR TITLE
Add Command Metadata to Manifest

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -45,6 +45,18 @@ type Config struct {
 	DebugDuration time.Duration `json:"debug_duration"`
 	// DebugInterval
 	DebugInterval time.Duration `json:"debug_interval"`
+	// We omit this from JSON to avoid duplicates in manifest.json; it is copied and serialized in Agent instead.
+	Environment Environment `json:"-"`
+}
+
+// Environment describes runtime details about the execution environment of the Agent.
+type Environment struct {
+	// Command is the CLI command entered to execute a Run.
+	Command string `json:"command"`
+	// Username is the username of the process that started a Run.
+	Username string `json:"username"`
+	// Hostname is the hostname of the machine where the Run was executed.
+	Hostname string `json:"hostname"`
 }
 
 // Agent stores the runtime state that we use throughout the Agent's lifecycle.
@@ -67,6 +79,8 @@ type Agent struct {
 	ManifestOps map[string][]ManifestOp `json:"ops"`
 	// Agent-level redactions are passed through to all products
 	Redactions []*redact.Redact `json:"redactions"`
+	// Environment describes details about the process that constructed the agent
+	Environment Environment `json:"environment"`
 }
 
 // NewAgent produces a new Agent, initialized for subsequent running.
@@ -99,6 +113,7 @@ func NewAgentWithContext(ctx context.Context, config Config, logger hclog.Logger
 		ManifestOps: make(map[string][]ManifestOp),
 		Version:     version.GetVersion(),
 		Redactions:  redacts,
+		Environment: config.Environment,
 	}, nil
 }
 

--- a/changelog/301.txt
+++ b/changelog/301.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+manifest: manifest.json now includes environment metadata, including the command entered to run hcdiag, the username of the user who ran it, and the hostname where it was run.
+```

--- a/command/run.go
+++ b/command/run.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/user"
 	"path"
 	"sort"
 	"strconv"
@@ -180,6 +181,21 @@ func (c *RunCommand) Run(args []string) int {
 	since := pickSinceVsIncludeSince(l, c.since, c.includeSince)
 	cfg = setTime(cfg, now, since)
 	l.Debug("merged cfg", "cfg", fmt.Sprintf("%+v", cfg))
+
+	environment := agent.Environment{
+		Command: strings.Join(os.Args, " "),
+	}
+
+	hostname, err := os.Hostname()
+	if err == nil {
+		environment.Hostname = hostname
+	}
+
+	u, err := user.Current()
+	if err == nil {
+		environment.Username = u.Username
+	}
+	cfg.Environment = environment
 
 	// Create agent
 	a, err := agent.NewAgent(cfg, l)


### PR DESCRIPTION
This merge adds metadata to manifest.json, which includes the command entered to start hcdiag, the user who ran it, and the hostname of the system where it ran.