### PR TITLE
Bump Development Branch to 0.6

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -15,6 +15,8 @@ project "hcdiag" {
     release_branches = [
       "main",
       "release/0.3.x",
+      "release/0.4.x",
+      "release/0.5.x",
     ]
   }
 }

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ const (
 var (
 	// version is the main version number that is being run at the moment.
 	// version must be of the format <MAJOR>.<MINOR>.<PATCH>, as described in the semantic versioning specification.
-	version = "0.5.0"
+	version = "0.6.0"
 
 	// prerelease is a pre-release marker for the version. If this is "" (empty string) then it means that
 	// it is a final release. Otherwise, this is a pre-release such as "dev" (in development),


### PR DESCRIPTION
Following the split of release/0.5.x, this merge bumps the development version to 0.6.0 and updates ci.hcl to include all existing release branches.