### PR TITLE
Improve Feature Formatting in Changelogs

### DIFF
--- a/changelog/changelog.tmpl
+++ b/changelog/changelog.tmpl
@@ -18,7 +18,7 @@ BREAKING CHANGES:
 FEATURES:
 
 {{range .NotesByType.feature | sort -}}
-* {{ template "note" . }}
+* {{ template "feature" . }}
 {{ end -}}
 {{- end -}}
 

--- a/changelog/changelog.tmpl
+++ b/changelog/changelog.tmpl
@@ -14,7 +14,7 @@ BREAKING CHANGES:
 {{ end -}}
 {{- end -}}
 
-{{- if .NotesByType.feature -}}
+{{- if .NotesByType.feature }}
 FEATURES:
 
 {{range .NotesByType.feature | sort -}}

--- a/changelog/note.tmpl
+++ b/changelog/note.tmpl
@@ -1,3 +1,7 @@
 {{- define "note" -}}
     {{.Body}} [[GH-{{- .Issue -}}](https://github.com/hashicorp/hcdiag/pull/{{- .Issue -}})]
 {{- end -}}
+
+{{- define "feature" -}}
+    {{.Body}}
+{{- end -}}


### PR DESCRIPTION
This merge addresses a whitespace issue around Features in changelogs. It also avoids adding GitHub issue IDs to release notes for features.