### PR TITLE
Include hcdiag-ext in core of hcdiag

### DIFF
--- a/changelog/325.txt
+++ b/changelog/325.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+seeker: add hcdiag-ext seekers/runners into hcdiag core due to lightweight improvement and benefit to customer experience
+```

--- a/product/tfe.go
+++ b/product/tfe.go
@@ -104,6 +104,7 @@ func tfeRunners(ctx context.Context, cfg Config, api *client.APIClient, l hclog.
 
 	// Set up HTTP runners
 	for _, hc := range []runner.HttpConfig{
+		{Client: api, Path: "/api/v2/admin/release", Redactions: cfg.Redactions},
 		{Client: api, Path: "/api/v2/admin/customization-settings", Redactions: cfg.Redactions},
 		{Client: api, Path: "/api/v2/admin/general-settings", Redactions: cfg.Redactions},
 		{Client: api, Path: "/api/v2/admin/organizations", Redactions: cfg.Redactions},
@@ -126,6 +127,7 @@ func tfeRunners(ctx context.Context, cfg Config, api *client.APIClient, l hclog.
 		{Command: "docker -v", Redactions: cfg.Redactions},
 		{Command: "replicatedctl app status --output json", Format: "json", Redactions: cfg.Redactions},
 		{Command: "lsblk --json", Format: "json", Redactions: cfg.Redactions},
+		{Command: "replicatedctl license inspect", Format: "json", Redactions: cfg.Redactions},
 		{Command: "replicatedctl app-config view -o json --group capacity", Format: "json", Redactions: cfg.Redactions},
 		{Command: "replicatedctl app-config view -o json --group production_type", Format: "json", Redactions: cfg.Redactions},
 		{Command: "replicatedctl app-config view -o json --group log_forwarding", Format: "json", Redactions: cfg.Redactions},

--- a/product/vault.go
+++ b/product/vault.go
@@ -102,6 +102,11 @@ func vaultRunners(ctx context.Context, cfg Config, api *client.APIClient, l hclo
 		{Client: api, Path: "/v1/sys/version-history?list=true", Redactions: cfg.Redactions},
 		{Client: api, Path: "/v1/sys/license/status", Redactions: cfg.Redactions},
 		{Client: api, Path: "/v1/sys/replication/status", Redactions: cfg.Redactions},
+		{Client: api, Path: "/v1/sys/health", Redactions: cfg.Redactions},
+		{Client: api, Path: "/v1/sys/internal/counters/activity", Redactions: cfg.Redactions},
+		{Client: api, Path: "/v1/sys/storage/raft/autopilot/configuration", Redactions: cfg.Redactions},
+		{Client: api, Path: "/v1/sys/storage/raft/autopilot/state", Redactions: cfg.Redactions},
+		{Client: api, Path: "/v1/sys/storage/raft/snapshot-auto/config?list=true", Redactions: cfg.Redactions},
 	} {
 		h, err := runner.NewHTTPWithContext(ctx, hc)
 		if err != nil {


### PR DESCRIPTION
Requesting we add the checks from hcdiag-ext into hcdiag "core" since these are very lightweight and would reduce customer confusion and complexity when we ask customers to run the hcdiag-ext workflow today. This would allow customers to just run hcdiag if they find that easier.