### PR TITLE
Fix replicated support bundle generation command

### DIFF
--- a/changelog/327.txt
+++ b/changelog/327.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+TFE: Change replicated support bundle generation command to avoid the necessity for an app ID variable to be provided.
+```
+

--- a/product/tfe.go
+++ b/product/tfe.go
@@ -72,7 +72,7 @@ func tfeRunners(ctx context.Context, cfg Config, api *client.APIClient, l hclog.
 
 	// Set up the Replicated Support Bundle runners
 	supportBundleCmd, err := runner.NewCommandWithContext(ctx, runner.CommandConfig{
-		Command:    "replicated support-bundle",
+		Command:    "replicatedctl support-bundle",
 		Redactions: cfg.Redactions,
 	})
 	if err != nil {

--- a/product/tfe.go
+++ b/product/tfe.go
@@ -89,7 +89,7 @@ func tfeRunners(ctx context.Context, cfg Config, api *client.APIClient, l hclog.
 		return nil, err
 	}
 
-	// The support bundle that we copy is built by the `replicated support-bundle` command, so we need to ensure
+	// The support bundle that we copy is built by the `replicatedctl support-bundle` command, so we need to ensure
 	// that these run in sequence.
 	replicatedSeq := do.NewSeq(do.SeqConfig{
 		Runners: []runner.Runner{


### PR DESCRIPTION
The command as it stands currently does not work without the inclusion of an App ID. Instead of having to obtain and contain the App ID into a variable, that is then passed to this command, we can instead execute the command we in support typically execute, which is `replicatedctl support-bundle`

Current results of that command when executing `hcdiag -terraform-ent`:

```
"replicated support-bundle": {
                            "result": {
                                "text": "Error: Usage: replicated support-bundle \u003capp id\u003e\n"
                            },
```

What the output is if you tried to execute the command manually within a TFE installation:

```
root@ip-10-0-166-24:/var/snap/amazon-ssm-agent/6312# replicated support-bundle
Error: Usage: replicated support-bundle <app id>
```