### PR TITLE
Remove Includes Flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,6 @@ Terraform Enterprise historically uses replicated to provide similar functionali
 - Gather diagnostics and write bundle to a specific location. (default is `$PWD`)
   - `hcdiag -vault -dest /tmp/hcdiag`
 
-- Gather diagnostics and use the CLI to copy individual files or whole directories
-  - `hcdiag -vault -includes "/var/log/dmesg,/var/log/vault-"`
-
 - Gather only host diagnostics (prior to `0.4.0`, this was the behavior of running `hcdiag` with no flags).
   - `hcdiag -autodetect=false`
   - *Note:* The `=` is required here because it is a boolean flag.
@@ -110,7 +107,6 @@ Terraform Enterprise historically uses replicated to provide similar functionali
 | `autodetect`    | Automatically detect which product CLIs are installed and gather diagnostics for each. If any product flags are provided, they override this one.                   | bool   | true          |
 | `since`         | Collect information within this time. Takes a 'go-formatted' duration, usage examples: `72h`, `25m`, `45s`, `120h1m90s`                                             | string | "72h"         |
 | `include-since` | Alias for -since, will be overridden if -since is also provided, usage examples: `72h`, `25m`, `45s`, `120h1m90s`                                                   | string | "72h"         |
-| `includes`      | (DEPRECATED) Files or directories to include (comma-separated, file-*-globbing available if 'wrapped-*-in-single-quotes') e.g. '/var/log/consul-*,/var/log/nomad-*' | string | ""            |
 | `destination`   | Path to the directory the bundle should be written in                                                                                                               | string | "."           |
 | `dest`          | Shorthand for -destination                                                                                                                                          | string | "."           |
 | `config`        | Path to HCL configuration file                                                                                                                                      | string | ""            |

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -103,55 +103,6 @@ func TestCreateTempAndCleanup(t *testing.T) {
 	}
 }
 
-func TestCopyIncludes(t *testing.T) {
-	// set up a table of test cases
-	// these dirs/files are checked in to this repo under tests/resources/
-	testTable := []map[string]string{
-		{
-			"path":   "file.0",
-			"expect": "file.0",
-		},
-		{
-			"path":   "dir1",
-			"expect": filepath.Join("dir1", "file.1"),
-		},
-		{
-			"path":   filepath.Join("dir2", "file*"),
-			"expect": filepath.Join("dir2", "file.2"),
-		},
-	}
-
-	var includeStr []string
-	for _, data := range testTable {
-		path := filepath.Join("../", "tests", "resources", data["path"])
-		absPath, err := filepath.Abs(path)
-		assert.NoError(t, err)
-		includeStr = append(includeStr, absPath)
-	}
-
-	cfg := Config{Includes: includeStr}
-	a, err := NewAgent(cfg, hclog.Default())
-	assert.NoError(t, err, "Error creating agent")
-	err = a.CreateTemp()
-	assert.NoError(t, err, "Error creating tmpDir")
-	defer cleanupHelper(t, a)
-
-	// execute what we're aiming to test
-	err = a.CopyIncludes()
-	assert.NoError(t, err, "Could not copy includes")
-
-	// verify expected file locations
-	for _, data := range testTable {
-		path := filepath.Join("../", "tests", "resources", data["expect"])
-		absPath, err := filepath.Abs(path)
-		assert.NoError(t, err)
-		expect := filepath.Join(a.tmpDir, "includes", absPath)
-		if _, err := os.Stat(expect); err != nil {
-			t.Errorf("Expect %s to exist, got error: %s", expect, err)
-		}
-	}
-}
-
 func TestRunProducts(t *testing.T) {
 	l := hclog.Default()
 	pCfg := product.Config{OS: "auto"}

--- a/changelog/331.txt
+++ b/changelog/331.txt
@@ -1,0 +1,4 @@
+```release-note:breaking
+cli: The -includes flag has been removed, after having been deprecated in version 0.5.0. HCL configuration and the Copy runner should be used instead.
+```
+

--- a/command/run.go
+++ b/command/run.go
@@ -51,9 +51,6 @@ type RunCommand struct {
 	// includeSince provides a time range for ops to work from
 	includeSince time.Duration
 
-	// includes
-	includes []string
-
 	// Bundle write location
 	destination string
 
@@ -106,7 +103,6 @@ func (c *RunCommand) init() {
 	c.flags.StringVar(&c.destination, "destination", ".", destinationUsageText)
 	c.flags.StringVar(&c.destination, "dest", ".", destUsageText)
 	c.flags.StringVar(&c.config, "config", "", configUsageText)
-	c.flags.Var(&CSVFlag{&c.includes}, "includes", includesUsageText)
 
 	// Ensure f.Destination points to some kind of directory by its notation
 	// FIXME(mkcp): trailing slashes should be trimmed in path.Dir... why does a double slash end in a slash?
@@ -285,14 +281,6 @@ func (c *RunCommand) mergeAgentConfig(config agent.Config) agent.Config {
 				"vault", config.Vault,
 			)
 		}
-	}
-
-	// Params for --includes
-	config.Includes = c.includes
-	if len(c.includes) > 0 {
-		hclog.L().Warn(
-			"DEPRECATION NOTICE: The '-includes' option will be removed in an upcoming version of hcdiag. Please use HCL copy blocks instead.",
-		)
 	}
 
 	// Bundle write location

--- a/docs/custom-config.md
+++ b/docs/custom-config.md
@@ -95,7 +95,6 @@ product "consul" {
     format = "string"
   }
 
-  // You could copy files with -includes as well
   command {
     run = "cat /etc/consul.d/example.hcl"
     format = "string"


### PR DESCRIPTION
The -includes flag was deprecated in v0.5.0. This merge removes it. Users who need to copy files should, instead, use configuration files with Copy runners.