### PR TITLE
add a docker development environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:22.04
+COPY docker-init.sh /usr/local/bin/
+
+# Entrypoint will be set by docker-compose:"command"
+ENTRYPOINT []
+

--- a/Makefile
+++ b/Makefile
@@ -55,5 +55,9 @@ version: ## Show the version of the project
 	@echo $(VERSION)
 .PHONY: version
 
+compose-up: # run docker compose in the foreground
+	docker-compose up --force-recreate --build --remove-orphans
+.PHONY: compose-up
+
 # windows:
 # $env:path = "$pwd/bin;$env:path"

--- a/changelog/332.txt
+++ b/changelog/332.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+tooling: create a docker-based development environment.
+```
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  hashistack:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: /bin/bash /usr/local/bin/docker-init.sh
+    volumes:
+      - ./bin:/hcdiag
+

--- a/docker-init.sh
+++ b/docker-init.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install dependencies
+apt-get update && apt-get install -y wget gpg
+
+# Add Hashicorp repo
+wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor > /usr/share/keyrings/hashicorp-archive-keyring.gpg && echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com jammy main" | tee /etc/apt/sources.list.d/hashicorp.list
+
+# Install binaries
+apt-get update && apt-get install -y nomad consul
+
+# Vault post-install script is not smart enough to work inside of containers that don't give access to setcap
+# e.g.:
+# /var/lib/dpkg/info/vault.postinst: line 36: setcap: command not found
+set +e
+apt-get install -y vault
+set -e
+
+# Move
+mkdir -p /hashistack && cd /hashistack
+
+# Start services
+#
+# no ACLs for now
+# echo "acl { enabled = true }" > nomad.hcl
+#
+# nomad agent -dev -config=nomad.hcl  >> nomad.log 2>&1 &
+nomad agent -dev >> nomad.log 2>&1 &
+consul agent -dev >> consul.log 2>&1 &
+vault server -dev  >> vault.log 2>&1 &
+
+# Shell configuration niceties (so you can run the products without errors on the CLI)
+echo "export CONSUL_HTTP_ADDR=http://127.0.0.1:8500" >> hashi.env
+echo "export VAULT_ADDR=http://127.0.0.1:8200" >> hashi.env
+
+# Instructions
+echo "Setup complete. Get started with the following commands:"
+echo
+echo "1. Compile hcdiag:"
+echo "GOOS=linux GOARCH=amd64 go build -o bin/hcdiag"
+echo
+echo "2. Connect to the container in a new shell:"
+echo "'docker exec -it hcdiag-hashistack-1 /bin/bash'"
+echo
+echo "3. Move to the working directory and source the env file:"
+echo "cd /hashistack && source hashi.env"
+echo
+
+# Run forever
+echo "About to run forever..."
+tail -F runforever
+


### PR DESCRIPTION
Virtualbox is no longer an option on Apple Silicon, and that makes our vagrant environment harder to set up for devs new to working on hcdiag. I've created a basic docker development environment that makes it easy to test hcdiag in a docker container.

This container setup uses the same base image and install process that our learn tutorials recommend (I came up with that too, so if you don't like how this is done I'm happy to hear alternatives :-D), so it'll help keep code rot from setting in there as well.

## Developer Experience:
Developers with docker-engine installed can run the following commands to start testing hcdiag in a container:

1. Build and start the container: `make compose-up`
1. Compile hcdiag for linux (automatically shows up in the container via the directory mount): `GOOS=linux GOARCH=amd64 go build -o bin/hcdiag`
1. Connect to the container in a new shell: `docker exec -it hcdiag-hashistack-1 /bin/bash`
1. Move to the working directory and source the env file: `cd /hashistack && source hashi.env`
1. Run your new hcdiag build: `/hcdiag/hcdiag`

The container's init script reminds you of these steps each time so there's nothing to remember:

<img width="940" alt="Screenshot 2023-07-10 at 3 22 13 PM" src="https://github.com/hashicorp/hcdiag/assets/1267040/f25bea84-277f-497b-bb2e-7d8fd4d57b54">

## Implementation

1. There's a setup script (`docker-init.sh`) which configures Ubuntu, installs Nomad, Vault, and Consul, creates an .env file so the product binaries "just work," starts the products in dev mode, and sleeps.
1. There's a `Dockerfile` which copies a setup script to the base image. I've kept this simple so that the script can do all the heavy lifting at runtime, too (running services and then blocking forever so devs can `docker exec` in and work).
1. There's a docker-compose file which builds the container and mounts the hcdiag `bin` directory in the container at /hcdiag.
1. There's an additional target in our Makefile, `docker-compose`.

## Feedback
I'm not married to this idea or to this exact approach, I just started working on hcdiag this morning and wanted something that works. If you have suggestions for improvements, please leave a comment here!