### PR TITLE
Add a proc_count to the results of the host process runner

### DIFF
--- a/changelog/333.txt
+++ b/changelog/333.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+runners: the process runner now also includes a process count, proc_count, in its results.
+```
+

--- a/runner/host/processes.go
+++ b/runner/host/processes.go
@@ -103,7 +103,10 @@ func (p Process) run() op.Op {
 	}
 
 	procs, err = p.procs(psProcs)
-	results := map[string]any{"procs": procs}
+	results := map[string]any{
+		"procs":      procs,
+		"proc_count": len(procs),
+	}
 	if err != nil {
 		hclog.L().Trace("runner/host.Process.Run()", "error", err)
 		return op.New(p.ID(), results, op.Fail, err, runner.Params(p), time.Time{}, time.Now())


### PR DESCRIPTION
This PR adds a proc_count object to the host process runner results, as requested in https://hashicorp.atlassian.net/browse/CORI2-191.


```
root@6f87a0b57dce:/hashistack/hcdiag-2023-07-10T202259Z# jq '."host"."do host"."result"."process"."result"."proc_count"' results.json
10
```

The full process runner results now look like this:
```
root@6f87a0b57dce:/hashistack/hcdiag-2023-07-10T202259Z# jq '."host"."do host"."result"."process"."result"' results.json
{
  "proc_count": 10,
  "procs": [
    {
      "name": "bash",
      "pid": 1,
      "ppid": 0
    },
    {
      "name": "nomad",
      "pid": 3308,
      "ppid": 1
    },
    {
      "name": "consul",
      "pid": 3309,
      "ppid": 1
    },
    {
      "name": "vault",
      "pid": 3310,
      "ppid": 1
    },
    {
      "name": "tail",
      "pid": 3311,
      "ppid": 1
    },
    {
      "name": "bash",
      "pid": 3343,
      "ppid": 0
    },
    {
      "name": "hcdiag",
      "pid": 3373,
      "ppid": 3343
    },
    {
      "name": "vault",
      "pid": 3449,
      "ppid": 3373
    },
    {
      "name": "vault",
      "pid": 3464,
      "ppid": 3373
    },
    {
      "name": "nomad",
      "pid": 3469,
      "ppid": 3373
    }
  ]
}
```
