### PR TITLE
Remove Debug-Interval and Debug-Duration Flags

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -415,11 +415,13 @@ func (a *Agent) Setup() error {
 
 	// Create the base config that we copy into each product
 	baseCfg := product.Config{
-		TmpDir:     a.tmpDir,
-		Since:      a.Config.Since,
-		Until:      a.Config.Until,
-		OS:         a.Config.OS,
-		Redactions: a.Redactions,
+		TmpDir:        a.tmpDir,
+		Since:         a.Config.Since,
+		Until:         a.Config.Until,
+		OS:            a.Config.OS,
+		DebugDuration: product.DefaultDuration,
+		DebugInterval: product.DefaultInterval,
+		Redactions:    a.Redactions,
 	}
 
 	// Build Consul and assign it to the product map.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -37,10 +37,6 @@ type Config struct {
 	Until       time.Time `json:"until"`
 	Destination string    `json:"destination"`
 
-	// DebugDuration
-	DebugDuration time.Duration `json:"debug_duration"`
-	// DebugInterval
-	DebugInterval time.Duration `json:"debug_interval"`
 	// We omit this from JSON to avoid duplicates in manifest.json; it is copied and serialized in Agent instead.
 	Environment Environment `json:"-"`
 }
@@ -419,13 +415,11 @@ func (a *Agent) Setup() error {
 
 	// Create the base config that we copy into each product
 	baseCfg := product.Config{
-		TmpDir:        a.tmpDir,
-		Since:         a.Config.Since,
-		Until:         a.Config.Until,
-		OS:            a.Config.OS,
-		DebugDuration: a.Config.DebugDuration,
-		DebugInterval: a.Config.DebugInterval,
-		Redactions:    a.Redactions,
+		TmpDir:     a.tmpDir,
+		Since:      a.Config.Since,
+		Until:      a.Config.Until,
+		OS:         a.Config.OS,
+		Redactions: a.Redactions,
 	}
 
 	// Build Consul and assign it to the product map.

--- a/changelog/335.txt
+++ b/changelog/335.txt
@@ -1,0 +1,4 @@
+```release-note:breaking
+cli: The -debug-duration and -debug-interval flags have been removed, after having been deprecated in version 0.5.0. HCL configuration and the product debug runners should be used instead.
+```
+

--- a/command/run.go
+++ b/command/run.go
@@ -55,12 +55,6 @@ type RunCommand struct {
 
 	// HCL file location
 	config string
-
-	// debugDuration param for product debug bundles
-	debugDuration time.Duration
-
-	// debugInterval param for product debug bundles
-	debugInterval time.Duration
 }
 
 func (c *RunCommand) init() {

--- a/command/run.go
+++ b/command/run.go
@@ -80,7 +80,6 @@ func (c *RunCommand) init() {
 		configUsageText       = "Path to HCL configuration file"
 
 		// Deprecated options
-		includesUsageText      = "DEPRECATED: Files or directories to include (comma-separated, file-*-globbing available if 'wrapped-*-in-single-quotes'); e.g. '/var/log/consul-*,/var/log/nomad-*'. NOTE: This option will be removed in an upcoming version of hcdiag. Please use HCL copy blocks instead."
 		debugDurationUsageText = "DEPRECATED: How long to run product debug bundle commands. Provide a duration ex: '00h00m00s'. See: -duration in 'vault debug', 'consul debug', and 'nomad operator debug'. NOTE: This option will be removed in an upcoming version of hcdiag. Please use HCL debug blocks instead."
 		debugIntervalUsageText = "DEPRECATED: How long metrics collection intervals in product debug commands last. Provide a duration ex: '00h00m00s'. See: -interval in 'vault debug', 'consul debug', and 'nomad operator debug'. NOTE: This option will be removed in an upcoming version of hcdiag. Please use HCL debug blocks instead."
 	)

--- a/command/run.go
+++ b/command/run.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/hashicorp/hcdiag/agent"
 	"github.com/hashicorp/hcdiag/hcl"
-	"github.com/hashicorp/hcdiag/product"
 	"github.com/hashicorp/hcdiag/util"
 )
 
@@ -78,10 +77,6 @@ func (c *RunCommand) init() {
 		destinationUsageText  = "Path to the directory the bundle should be written in"
 		destUsageText         = "Shorthand for -destination"
 		configUsageText       = "Path to HCL configuration file"
-
-		// Deprecated options
-		debugDurationUsageText = "DEPRECATED: How long to run product debug bundle commands. Provide a duration ex: '00h00m00s'. See: -duration in 'vault debug', 'consul debug', and 'nomad operator debug'. NOTE: This option will be removed in an upcoming version of hcdiag. Please use HCL debug blocks instead."
-		debugIntervalUsageText = "DEPRECATED: How long metrics collection intervals in product debug commands last. Provide a duration ex: '00h00m00s'. See: -interval in 'vault debug', 'consul debug', and 'nomad operator debug'. NOTE: This option will be removed in an upcoming version of hcdiag. Please use HCL debug blocks instead."
 	)
 
 	// flag.ContinueOnError allows flag.Parse to return an error if one comes up, rather than doing an `os.Exit(2)`
@@ -96,8 +91,6 @@ func (c *RunCommand) init() {
 	c.flags.BoolVar(&c.autoDetectProducts, "autodetect", true, autodetectUsageText)
 	c.flags.DurationVar(&c.includeSince, "include-since", seventyTwoHours, includeSinceUsageText)
 	c.flags.DurationVar(&c.since, "since", seventyTwoHours, sinceUsageText)
-	c.flags.DurationVar(&c.debugDuration, "debug-duration", product.DefaultDuration, debugDurationUsageText)
-	c.flags.DurationVar(&c.debugInterval, "debug-interval", product.DefaultInterval, debugIntervalUsageText)
 	c.flags.StringVar(&c.os, "os", "auto", osUsageText)
 	c.flags.StringVar(&c.destination, "destination", ".", destinationUsageText)
 	c.flags.StringVar(&c.destination, "dest", ".", destUsageText)
@@ -284,10 +277,6 @@ func (c *RunCommand) mergeAgentConfig(config agent.Config) agent.Config {
 
 	// Bundle write location
 	config.Destination = c.destination
-
-	// Apply Debug{Duration,Interval}
-	config.DebugDuration = c.debugDuration
-	config.DebugInterval = c.debugInterval
 
 	return config
 }


### PR DESCRIPTION
The -debug-duration and debug-interval flags were deprecated in v0.5.0. This merge removes them. Users who need to adjust debug timers should, instead, use custom configuration files with product debug runners.