### PR TITLE
Remove Release Candidate Tag from `0.5.3`

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -19,7 +19,7 @@ var (
 	// prerelease is a pre-release marker for the version. If this is "" (empty string) then it means that
 	// it is a final release. Otherwise, this is a pre-release such as "dev" (in development),
 	// "beta", "rc1", etc.
-	prerelease = "rc0"
+	prerelease = ""
 
 	// metadata is any additional (optional) information regarding the build, as described by the semantic
 	// versioning specification.


### PR DESCRIPTION
Walked through process to promote to staging and prod with `0.5.3-rc0` and verified following the steps here: https://hashicorp.atlassian.net/wiki/spaces/ENSV/pages/2370274134/Release+Procedures+for+hcdiag. 

Now to repeat the process, but for the real thing.

Jira Task: https://hashicorp.atlassian.net/jira/software/c/projects/CORI2/boards/548?assignee=5c3e1b1da0376d4fe1e6010f&assignee=712020%3A2169ba7a-45cb-47d5-9cfd-a660b6d01a06&selectedIssue=CORI2-1338