### PR TITLE
Add `rc0` Tag to Version `0.5.4`

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -19,7 +19,7 @@ var (
 	// prerelease is a pre-release marker for the version. If this is "" (empty string) then it means that
 	// it is a final release. Otherwise, this is a pre-release such as "dev" (in development),
 	// "beta", "rc1", etc.
-	prerelease = ""
+	prerelease = "rc0"
 
 	// metadata is any additional (optional) information regarding the build, as described by the semantic
 	// versioning specification.


### PR DESCRIPTION
This PR adds the `rc0` tag to the `0.5.4` version